### PR TITLE
fix: harden workspace path

### DIFF
--- a/crates/fabric-core/src/runtime.rs
+++ b/crates/fabric-core/src/runtime.rs
@@ -370,6 +370,10 @@ pub fn prepare_environment(plan: &RunPlan) -> Result<EnvironmentHandle> {
             serde_json::Map::new(),
         )
     };
+    let workspace = match workspace {
+        Some(path) => Some(absolute_path(path)?),
+        None => None,
+    };
     for (key, value) in connection_settings {
         connection.insert(key, value);
     }
@@ -1608,6 +1612,62 @@ runtime:
   "adapter_id": "acme.fabric.process",
   "adapter_kind": "process"
 }"#
+    }
+
+    #[test]
+    fn prepare_environment_absolutizes_workspace() {
+        let root =
+            std::env::temp_dir().join(format!("fabric-workspace-abs-{}", std::process::id()));
+        let _ = fs::remove_dir_all(&root);
+        fs::create_dir_all(root.join("adapters/process")).expect("create agent dir");
+        fs::write(
+            root.join("agent.yaml"),
+            r#"schema_version: fabric.agent/v1alpha1
+metadata:
+  name: workspace-abs-agent
+harness:
+  adapter_id: acme.fabric.process
+  settings:
+    command: cat
+models:
+  default:
+    provider: test
+    model: test-model
+runtime:
+  mode: oneshot
+  transport: cli
+  input_schema: text
+  output_schema: text
+  artifacts: ./artifacts
+environment:
+  provider: local
+  workspace: ./repos/my-service
+"#,
+        )
+        .expect("write config");
+        fs::write(
+            root.join("adapters/process/fabric-adapter.json"),
+            process_adapter_descriptor(),
+        )
+        .expect("write adapter descriptor");
+
+        let mut plan = resolve_run_plan(&root, None).expect("run plan");
+        // Force a relative workspace to reproduce the pre-fix condition where an
+        // adapter would re-join it onto the absolute config_root and double the path.
+        plan.environment_plan
+            .as_mut()
+            .expect("environment plan")
+            .workspace = Some(PathBuf::from("repos/my-service"));
+
+        let environment = prepare_environment(&plan).expect("prepare environment");
+        let workspace = environment.workspace.expect("workspace");
+        assert!(
+            workspace.is_absolute(),
+            "prepared workspace must be absolute so adapters do not re-resolve it: {workspace:?}"
+        );
+        assert!(workspace.ends_with("repos/my-service"), "{workspace:?}");
+
+        let _ = fs::remove_dir_all(&root);
     }
 
     fn artifact_content(result: &RunResult, name: &str) -> String {

--- a/python/src/nemo_fabric/client.py
+++ b/python/src/nemo_fabric/client.py
@@ -595,7 +595,7 @@ def _environment_handle(plan: dict[str, Any]) -> dict[str, Any]:
         "environment_id": _new_id("environment"),
         "provider": environment_plan.get("provider", "local"),
         "control_location": environment_plan.get("control_location", "external_control"),
-        "workspace": environment_plan.get("workspace") or plan.get("agent_root"),
+        "workspace": _absolute_plan_path(environment_plan.get("workspace") or plan.get("agent_root")),
         "artifacts": environment_plan.get("artifacts") or _runtime_artifact_path(plan, runtime),
         "ownership": environment_plan.get("ownership", "caller_owned"),
         "connection": environment_plan.get("connection", {}),

--- a/python/tests/smoke_environment_handle.py
+++ b/python/tests/smoke_environment_handle.py
@@ -1,0 +1,38 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Regression: the inline-path environment handle absolutizes the workspace.
+
+A relative workspace (config-root-relative) must be resolved to an absolute path
+so an adapter does not re-join it onto the absolute config_root and double it
+(e.g. examples/agent/examples/agent/...). Dependency-free; no native extension.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "src"))
+
+from nemo_fabric.client import _environment_handle
+
+
+def main() -> None:
+    plan = {
+        "environment_plan": {"workspace": "examples/code-review-agent/repos/my-service"},
+        "config": {"runtime": {}},
+        "agent_root": "examples/code-review-agent",
+    }
+    workspace = _environment_handle(plan)["workspace"]
+    assert os.path.isabs(workspace), f"workspace not absolute: {workspace}"
+    assert (
+        "code-review-agent/examples/code-review-agent" not in workspace
+    ), f"workspace path is doubled: {workspace}"
+    assert workspace.endswith("repos/my-service"), workspace
+    print("smoke_environment_handle ok")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

The Hermes adapters received a config-root–relative `workspace` and re-joined it onto the already-absolute `config_root`, doubling the path (e.g. `.../examples/code-review-agent/examples/code-review-agent/repos/my-service`) and breaking the Hermes subprocess working directory with `FileNotFoundError`.

This absolutizes the prepared-environment `workspace` in both adapter backends so adapters receive a directly-usable path:

- **`prepare_environment`** (Rust, process/CLI path — FABRIC-21): absolutize via the existing `absolute_path()` helper, consistent with `effective_config`'s absolute paths.
- **`_environment_handle`** (Python, inline SDK path — FABRIC-20): mirror via `_absolute_plan_path()`, for SDK↔CLI parity.

## Verification

- `cargo test` — 24/24, including the new `prepare_environment_absolutizes_workspace`.
- New dependency-free `python/tests/smoke_environment_handle.py` guards the inline path.
- Existing dependency-free smokes pass (`smoke_hermes_cli`, `smoke_hermes_config_mapping`, `smoke_sdk`).
- Live: `fabric run examples/code-review-agent --profile hermes_cli` now launches the real `hermes` binary with a correct absolute working directory (previously failed on the doubled path); only a missing `NVIDIA_API_KEY` remains.

## Notes

The existing smokes missed this because their shim adapters don't use the workspace as a real subprocess cwd; the new tests assert an absolute, non-doubled workspace for both paths.

Refs FABRIC-20, FABRIC-21.
