### PR TITLE
bug: Ensure the CLI exits with a non-zero exit code if the underlying harness exited non-zero

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,7 @@ examples/*/artifacts/
 tests/fixtures/*/artifacts/
 
 .DS_Store
+
+# UV Lock
+# TBD if we want to track this in git
+uv.lock

--- a/crates/fabric-cli/src/main.rs
+++ b/crates/fabric-cli/src/main.rs
@@ -141,6 +141,21 @@ fn run() -> Result<(), Box<dyn std::error::Error>> {
             };
             let result = run_plan(&plan, request)?;
             println!("{}", serde_json::to_string_pretty(&result)?);
+            let _exit_code = result
+                .metadata
+                .get("exit_code")
+                .and_then(serde_json::Value::as_i64)
+                .unwrap_or(0);
+            if _exit_code != 0 {
+                let message = result
+                    .error
+                    .as_ref()
+                    .map(|error| error.message.clone())
+                    .unwrap_or_else(|| {
+                        format!("harness exited with an exit code of {_exit_code}")
+                    });
+                return Err(message.into());
+            }
         }
         Some(Command::Schema { name, output_dir }) => {
             if let Some(output_dir) = output_dir {


### PR DESCRIPTION
* The easiest way to test this is to run `fabric run examples/code-review-agent --profile hermes_cli --input "Reply with exactly: hermes cli ok"` without having set the `NVIDIA_API_KEY` environment variable.
* Add `uv.lock` to the `.gitignore` file for now, until we decide if we want to track it in the repo or not.