### PR TITLE
feat: improvements for fabric validate CLI command

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,4 @@ tests/fixtures/*/artifacts/
 # UV Lock
 # TBD if we want to track this in git
 uv.lock
+

--- a/crates/fabric-cli/src/main.rs
+++ b/crates/fabric-cli/src/main.rs
@@ -9,8 +9,8 @@ use std::process::ExitCode;
 use clap::{Parser, Subcommand};
 use fabric_core::{
     RunRequest, SchemaName, doctor_plan, generate_all_schemas, generate_schema_json,
-    load_fabric_document, resolve_effective_config_with_profiles, resolve_run_plan_with_profiles,
-    run_plan, write_schema_snapshots,
+    resolve_effective_config_with_profiles, resolve_run_plan_with_profiles, run_plan,
+    validate_agent_directory, write_schema_snapshots,
 };
 
 #[derive(Debug, Parser)]
@@ -24,7 +24,7 @@ struct Cli {
 
 #[derive(Debug, Subcommand)]
 enum Command {
-    /// Validate an agent directory, manifest, or profile config.
+    /// Validate an agent directory or YAML config.
     Validate {
         /// Path to an agent directory or YAML config.
         path: PathBuf,
@@ -100,7 +100,7 @@ fn run() -> Result<(), Box<dyn std::error::Error>> {
     let cli = Cli::parse();
     match cli.command {
         Some(Command::Validate { path }) => {
-            load_fabric_document(&path)?;
+            validate_agent_directory(&path)?;
             println!("validated {}", path.display());
         }
         Some(Command::Inspect { path, profile }) => {
@@ -151,9 +151,7 @@ fn run() -> Result<(), Box<dyn std::error::Error>> {
                     .error
                     .as_ref()
                     .map(|error| error.message.clone())
-                    .unwrap_or_else(|| {
-                        format!("harness exited with an exit code of {_exit_code}")
-                    });
+                    .unwrap_or_else(|| format!("harness exited with an exit code of {_exit_code}"));
                 return Err(message.into());
             }
         }

--- a/crates/fabric-core/src/config.rs
+++ b/crates/fabric-core/src/config.rs
@@ -579,6 +579,17 @@ pub fn load_fabric_document(path: impl AsRef<Path>) -> Result<FabricDocument> {
     load_file(path)
 }
 
+/// Validate an agent directory or config, including discoverable profile YAMLs.
+pub fn validate_agent_directory(path: impl AsRef<Path>) -> Result<()> {
+    match load_fabric_document(path)? {
+        FabricDocument::FabricConfig { root, config, .. } => {
+            discover_profiles(&config, &root)?;
+        }
+    }
+
+    Ok(())
+}
+
 /// Load an adapter descriptor from JSON package metadata.
 pub fn load_adapter_descriptor(path: impl AsRef<Path>) -> Result<AdapterDescriptor> {
     let path = path.as_ref();
@@ -848,7 +859,10 @@ fn discover_profiles(
     for directory in &config.profiles.directories {
         let directory = resolve_path(config_root, directory);
         if !directory.exists() {
-            println!("warning: profile directory does not exist: {}", directory.display());
+            println!(
+                "warning: profile directory does not exist: {}",
+                directory.display()
+            );
             continue;
         }
         let entries = std::fs::read_dir(&directory).map_err(|source| FabricError::Read {

--- a/crates/fabric-core/src/config.rs
+++ b/crates/fabric-core/src/config.rs
@@ -848,6 +848,7 @@ fn discover_profiles(
     for directory in &config.profiles.directories {
         let directory = resolve_path(config_root, directory);
         if !directory.exists() {
+            println!("warning: profile directory does not exist: {}", directory.display());
             continue;
         }
         let entries = std::fs::read_dir(&directory).map_err(|source| FabricError::Read {

--- a/crates/fabric-core/src/config.rs
+++ b/crates/fabric-core/src/config.rs
@@ -855,7 +855,7 @@ fn discover_profiles(
     config: &FabricConfig,
     config_root: &Path,
 ) -> Result<BTreeMap<String, PathBuf>> {
-    let mut profiles = BTreeMap::new();
+    let mut profiles: BTreeMap<String, PathBuf> = BTreeMap::new();
     for directory in &config.profiles.directories {
         let directory = resolve_path(config_root, directory);
         if !directory.exists() {
@@ -887,7 +887,14 @@ fn discover_profiles(
             }) else {
                 continue;
             };
-            profiles.insert(name, normalize_path(path));
+            let profile_path = normalize_path(path);
+            if profiles.contains_key(&name) {
+                return Err(FabricError::ProfileError {
+                    path: profile_path,
+                    message: format!("duplicate profile `{name}`"),
+                });
+            }
+            profiles.insert(name, profile_path);
         }
     }
     Ok(profiles)

--- a/crates/fabric-core/src/error.rs
+++ b/crates/fabric-core/src/error.rs
@@ -32,6 +32,14 @@ pub enum FabricError {
         /// Available profile names.
         available: Vec<String>,
     },
+    /// A profile config failed validation.
+    #[error("profile error in {path}: {message}")]
+    ProfileError {
+        /// Profile path.
+        path: PathBuf,
+        /// Validation message.
+        message: String,
+    },
     /// A requested adapter id is not present in the agent config.
     #[error("unknown adapter `{adapter_id}`; available adapters: {available:?}")]
     UnknownAdapter {

--- a/crates/fabric-core/src/lib.rs
+++ b/crates/fabric-core/src/lib.rs
@@ -19,7 +19,7 @@ pub use config::{
     load_adapter_descriptor, load_fabric_document, resolve_effective_config,
     resolve_effective_config_from_config, resolve_effective_config_with_profiles, resolve_run_plan,
     resolve_run_plan_from_config, resolve_run_plan_from_effective_config,
-    resolve_run_plan_with_profiles,
+    resolve_run_plan_with_profiles, validate_agent_directory,
 };
 pub use doctor::{DoctorCheck, DoctorReport, DoctorStatus, doctor_plan};
 pub use error::{FabricError, Result};


### PR DESCRIPTION
* Expand the validate sub command to ensure that the profile YAML files are valid YAML, fix the help strings for the validate command.
  * This just runs `discover_profiles` and catches anything that would be caught by `fabric run` when a profile appears in the profiles dir, but isn't currently selected.
* Catch duplicate profile names rather than silently allowing the second profile to win
* Log a warning for any missing profile directories
* Ensure the `.tmp` directory is created on initial clone