### PR TITLE
Add CI: Rust and Python test workflows

### DIFF
--- a/.github/workflows/ci_python.yml
+++ b/.github/workflows/ci_python.yml
@@ -55,9 +55,8 @@ jobs:
 
       # Dependency-free smokes only: the gated integration smokes
       # (smoke_hermes_sdk, smoke_relay_integration, smoke_harbor_*) need an
-      # NVIDIA_API_KEY / a running Hermes / a sibling harbor checkout, and
-      # smoke_sdk_concurrency is currently flaky (runtime_id collisions), so it
-      # is excluded until that is fixed.
+      # NVIDIA_API_KEY / a running Hermes / a sibling harbor checkout, so they
+      # are excluded.
       - name: Run dependency-free smokes
         run: |
           set -euo pipefail
@@ -65,6 +64,7 @@ jobs:
           smokes=(
             python/tests/smoke_environment_handle.py
             python/tests/smoke_sdk.py
+            python/tests/smoke_sdk_concurrency.py
             python/tests/smoke_native_sdk.py
             tests/smoke_cli.py
             tests/smoke_hermes_cli.py

--- a/.github/workflows/ci_python.yml
+++ b/.github/workflows/ci_python.yml
@@ -46,10 +46,12 @@ jobs:
       - name: Set up uv
         uses: astral-sh/setup-uv@cec208311dfd045dd5311c1add060b2062131d57 # v8
 
+      # PyYAML is not a project dependency, but smoke_hermes_config_mapping
+      # imports it to read Hermes config fixtures, so install it for the smokes.
       - name: Build SDK with native extension
         run: |
           uv venv --python 3.12 .venv
-          uv pip install --python .venv/bin/python -e .
+          uv pip install --python .venv/bin/python -e . "pyyaml>=6"
 
       # Dependency-free smokes only: the gated integration smokes
       # (smoke_hermes_sdk, smoke_relay_integration, smoke_harbor_*) need an

--- a/.github/workflows/ci_python.yml
+++ b/.github/workflows/ci_python.yml
@@ -1,0 +1,77 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+name: Python
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+concurrency:
+  group: ci-python-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+defaults:
+  run:
+    shell: bash
+
+jobs:
+  test:
+    name: Test
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
+
+      # Rust is needed both to build the native extension (maturin backend) and
+      # because the CLI-backed smokes shell out to `cargo run -p fabric-cli`.
+      - name: Set up Rust
+        uses: actions-rust-lang/setup-rust-toolchain@150fca883cd4034361b621bd4e6a9d34e5143606 # v1.15.4
+        with:
+          toolchain: stable
+          cache: false
+
+      - name: Cache cargo build
+        uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
+        with:
+          shared-key: fabric-rust
+
+      - name: Set up uv
+        uses: astral-sh/setup-uv@cec208311dfd045dd5311c1add060b2062131d57 # v8
+
+      - name: Build SDK with native extension
+        run: |
+          uv venv --python 3.12 .venv
+          uv pip install --python .venv/bin/python -e .
+
+      # Dependency-free smokes only: the gated integration smokes
+      # (smoke_hermes_sdk, smoke_relay_integration, smoke_harbor_*) need an
+      # NVIDIA_API_KEY / a running Hermes / a sibling harbor checkout, and
+      # smoke_sdk_concurrency is currently flaky (runtime_id collisions), so it
+      # is excluded until that is fixed.
+      - name: Run dependency-free smokes
+        run: |
+          set -euo pipefail
+          py=.venv/bin/python
+          smokes=(
+            python/tests/smoke_environment_handle.py
+            python/tests/smoke_sdk.py
+            python/tests/smoke_native_sdk.py
+            tests/smoke_cli.py
+            tests/smoke_hermes_cli.py
+            tests/smoke_hermes_config_mapping.py
+            tests/smoke_swebench_style.py
+            tests/smoke_local_env_e2e.py
+          )
+          for s in "${smokes[@]}"; do
+            echo "::group::$s"
+            "$py" "$s"
+            echo "::endgroup::"
+          done

--- a/.github/workflows/ci_rust.yml
+++ b/.github/workflows/ci_rust.yml
@@ -1,0 +1,57 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+name: Rust
+
+# These checks need no secrets, so a plain pull_request trigger shows the result
+# directly on the PR (the docs workflow uses copy-pr-bot mirror branches only
+# because it needs FERN_TOKEN).
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+concurrency:
+  group: ci-rust-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+defaults:
+  run:
+    shell: bash
+
+jobs:
+  test:
+    name: Test
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
+
+      - name: Set up Rust
+        uses: actions-rust-lang/setup-rust-toolchain@150fca883cd4034361b621bd4e6a9d34e5143606 # v1.15.4
+        with:
+          toolchain: stable
+          components: rustfmt
+          cache: false
+
+      - name: Cache cargo build
+        uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
+        with:
+          shared-key: fabric-rust
+
+      - name: Check formatting
+        run: cargo fmt --all -- --check
+
+      - name: Check native extension crate
+        run: cargo check -p fabric-python --locked
+
+      # Includes the schema snapshot tests, which guard the public contract
+      # against drift from the Rust types.
+      - name: Run workspace tests
+        run: cargo test --workspace --locked


### PR DESCRIPTION
## Adds two GitHub Actions workflows so the existing test suite runs on PRs:

- **`ci_rust.yml`** — `cargo fmt --check`, `cargo check -p fabric-python`, and `cargo test --workspace` (which includes the schema-snapshot checks that guard the public contract).
- **`ci_python.yml`** — builds the native extension, then runs the dependency-free smokes (`smoke_cli`, `smoke_sdk`, `smoke_native_sdk`, `smoke_hermes_cli`, `smoke_hermes_config_mapping`, `smoke_swebench_style`, `smoke_local_env_e2e`, `smoke_environment_handle`).

## Why

The repo had a test suite but nothing ran it on PRs, so contract/schema drift could merge unnoticed. Both workflows are single-platform (ubuntu-latest), need no secrets, and mirror nemo-relay's Rust/Python split and pinned action SHAs.

## Triggers

`pull_request` + `push` to `main`. No secrets are required, so the checks report directly on the PR (unlike the docs workflow, which uses copy-pr-bot mirror branches for `FERN_TOKEN`).

## Excluded

- Gated integration smokes (`smoke_hermes_sdk`, `smoke_relay_integration`, `smoke_harbor_*`) — they need `NVIDIA_API_KEY` / a running Hermes / a sibling harbor checkout.
- `smoke_sdk_concurrency` — currently flaky (two concurrent runs can collide on `runtime_id`); excluded until that is fixed.

## Verified locally

All included checks pass (`cargo fmt`/`check`/`test --workspace` green; all 8 smokes pass).

Resolves FABRIC-32

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated continuous integration workflows to enforce automated code quality checks and comprehensive testing across Python and Rust components.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->