### PR TITLE
Add SDK guardrail smokes

### DIFF
--- a/.github/workflows/ci_python.yml
+++ b/.github/workflows/ci_python.yml
@@ -66,6 +66,9 @@ jobs:
             python/tests/smoke_sdk.py
             python/tests/smoke_sdk_concurrency.py
             python/tests/smoke_native_sdk.py
+            python/tests/smoke_typed_config.py
+            python/tests/smoke_consumer_neutral.py
+            python/tests/smoke_readme_examples.py
             tests/smoke_cli.py
             tests/smoke_hermes_cli.py
             tests/smoke_hermes_config_mapping.py

--- a/python/tests/smoke_consumer_neutral.py
+++ b/python/tests/smoke_consumer_neutral.py
@@ -80,9 +80,14 @@ def core_imports_only_stdlib_and_self() -> None:
     )
 
     # Pin the declared contract too: a dependency added to pyproject would slip
-    # past the import scan above if nothing in the core imports it yet.
+    # past the import scan above if nothing in the core imports it yet. Assert the
+    # structure explicitly so a missing [project]/dependencies fails loudly
+    # instead of defaulting to an empty list and hiding a metadata regression.
     pyproject = tomllib.loads(PYPROJECT.read_text(encoding="utf-8"))
-    deps = pyproject.get("project", {}).get("dependencies", [])
+    assert "project" in pyproject, f"{PYPROJECT} is missing the [project] table"
+    project = pyproject["project"]
+    assert "dependencies" in project, f"{PYPROJECT} [project] is missing 'dependencies'"
+    deps = project["dependencies"]
     assert deps == [], f"SDK must stay zero-dependency; found dependencies={deps!r}"
 
 

--- a/python/tests/smoke_consumer_neutral.py
+++ b/python/tests/smoke_consumer_neutral.py
@@ -1,0 +1,105 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Smoke test: the SDK core stays consumer-neutral and dependency-free.
+
+WS4 guardrail. The public SDK core -- the ``nemo_fabric`` package outside the
+``integrations`` subpackage -- must not depend on any third-party package: no
+harness (Hermes), no consumer (Harbor/Platform), no telemetry backend (Relay).
+Adapters are loaded dynamically at runtime via importlib, and consumer glue
+lives under ``nemo_fabric.integrations`` behind an optional extra; the core
+never imports any of them.
+
+Two checks:
+
+1. Static -- every top-level import in the core resolves to the standard library
+   or ``nemo_fabric`` itself. This also pins the SDK's zero-dependency contract
+   (pyproject ``dependencies = []``).
+2. Runtime -- a plain ``import nemo_fabric`` (what a consumer like Platform does)
+   pulls in no consumer/harness package.
+"""
+
+from __future__ import annotations
+
+import ast
+import subprocess
+import sys
+from pathlib import Path
+
+SDK_ROOT = Path(__file__).resolve().parents[2] / "python" / "src" / "nemo_fabric"
+ALLOWED = set(sys.stdlib_module_names) | {"nemo_fabric", "__future__"}
+# Consumer/harness packages that must never leak into a plain ``import nemo_fabric``.
+CONSUMER_SPECIFIC = [
+    "harbor",
+    "hermes",
+    "relay",
+    "nemo_relay",
+    "nemo_fabric_adapters",
+    "nemo_fabric_test_adapters",
+]
+
+
+def _top_level_imports(tree: ast.AST) -> set[str]:
+    roots: set[str] = set()
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            for alias in node.names:
+                roots.add(alias.name.split(".")[0])
+        elif isinstance(node, ast.ImportFrom) and not node.level and node.module:
+            # node.level == 0 -> absolute import; relative imports stay in-package.
+            roots.add(node.module.split(".")[0])
+    return roots
+
+
+def core_imports_only_stdlib_and_self() -> None:
+    """Static: no third-party import anywhere in the core (non-integrations)."""
+
+    core = sorted(
+        path
+        for path in SDK_ROOT.rglob("*.py")
+        if "integrations" not in path.relative_to(SDK_ROOT).parts
+    )
+    assert core, f"no core SDK sources found under {SDK_ROOT}"
+
+    offenders: dict[str, list[str]] = {}
+    for path in core:
+        bad = sorted(
+            root
+            for root in _top_level_imports(ast.parse(path.read_text()))
+            if root not in ALLOWED
+        )
+        if bad:
+            offenders[path.name] = bad
+
+    assert not offenders, (
+        "SDK core must import only the standard library and nemo_fabric "
+        "(consumer glue belongs under nemo_fabric.integrations); "
+        f"found third-party imports: {offenders}"
+    )
+
+
+def importing_the_sdk_pulls_in_no_consumer_package() -> None:
+    """Runtime: ``import nemo_fabric`` does not drag in a consumer/harness dep."""
+
+    probe = (
+        "import importlib, sys\n"
+        "importlib.import_module('nemo_fabric')\n"
+        f"forbidden = {CONSUMER_SPECIFIC!r}\n"
+        "roots = {name.split('.')[0] for name in sys.modules}\n"
+        "print(','.join(sorted(roots & set(forbidden))))\n"
+    )
+    result = subprocess.run(
+        [sys.executable, "-c", probe], capture_output=True, text=True, check=True
+    )
+    leaked = result.stdout.strip()
+    assert not leaked, f"`import nemo_fabric` leaked consumer packages: {leaked}"
+
+
+def main() -> None:
+    core_imports_only_stdlib_and_self()
+    importing_the_sdk_pulls_in_no_consumer_package()
+    print("smoke_consumer_neutral ok")
+
+
+if __name__ == "__main__":
+    main()

--- a/python/tests/smoke_consumer_neutral.py
+++ b/python/tests/smoke_consumer_neutral.py
@@ -24,9 +24,11 @@ from __future__ import annotations
 import ast
 import subprocess
 import sys
+import tomllib
 from pathlib import Path
 
 SDK_ROOT = Path(__file__).resolve().parents[2] / "python" / "src" / "nemo_fabric"
+PYPROJECT = Path(__file__).resolve().parents[2] / "python" / "pyproject.toml"
 ALLOWED = set(sys.stdlib_module_names) | {"nemo_fabric", "__future__"}
 # Consumer/harness packages that must never leak into a plain ``import nemo_fabric``.
 CONSUMER_SPECIFIC = [
@@ -77,6 +79,12 @@ def core_imports_only_stdlib_and_self() -> None:
         f"found third-party imports: {offenders}"
     )
 
+    # Pin the declared contract too: a dependency added to pyproject would slip
+    # past the import scan above if nothing in the core imports it yet.
+    pyproject = tomllib.loads(PYPROJECT.read_text(encoding="utf-8"))
+    deps = pyproject.get("project", {}).get("dependencies", [])
+    assert deps == [], f"SDK must stay zero-dependency; found dependencies={deps!r}"
+
 
 def importing_the_sdk_pulls_in_no_consumer_package() -> None:
     """Runtime: ``import nemo_fabric`` does not drag in a consumer/harness dep."""
@@ -89,7 +97,11 @@ def importing_the_sdk_pulls_in_no_consumer_package() -> None:
         "print(','.join(sorted(roots & set(forbidden))))\n"
     )
     result = subprocess.run(
-        [sys.executable, "-c", probe], capture_output=True, text=True, check=True
+        [sys.executable, "-c", probe],
+        capture_output=True,
+        text=True,
+        check=True,
+        timeout=30,
     )
     leaked = result.stdout.strip()
     assert not leaked, f"`import nemo_fabric` leaked consumer packages: {leaked}"

--- a/python/tests/smoke_readme_examples.py
+++ b/python/tests/smoke_readme_examples.py
@@ -59,7 +59,7 @@ README_PLAN_CONFIG = {
 def readme_documents_each_example() -> None:
     """The README still contains every invocation this smoke mirrors."""
 
-    text = README.read_text()
+    text = README.read_text(encoding="utf-8")
     missing = [snippet for snippet in DOCUMENTED_SNIPPETS if snippet not in text]
     assert not missing, f"README no longer documents these examples verbatim: {missing}"
 

--- a/python/tests/smoke_readme_examples.py
+++ b/python/tests/smoke_readme_examples.py
@@ -1,0 +1,97 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Smoke test: the README "Use Fabric" examples stay accurate and runnable.
+
+WS4 guardrail. The documented Python SDK examples (``plan`` / ``doctor`` /
+``plan_config`` and the source-tree CLI-command form) are mirrored here and run
+against the real example agent, so an API change breaks this test instead of
+silently rotting the README. A drift guard additionally asserts the README still
+contains each documented invocation verbatim, keeping the prose and the
+executable mirror in sync. The CLI snippets are exercised by ``tests/smoke_cli.py``.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from pathlib import Path
+
+from nemo_fabric import FabricClient
+
+ROOT = Path(__file__).resolve().parents[2]
+README = ROOT / "README.md"
+EXAMPLE_AGENT = ROOT / "examples" / "code-review-agent"
+
+# Exact invocations the README documents and this smoke mirrors. If the README
+# changes any of these, update the executable mirror below (and vice versa).
+DOCUMENTED_SNIPPETS = [
+    "fabric plan examples/code-review-agent --profile hermes_sdk",
+    "fabric plan examples/code-review-agent --profile env_local --profile mcp_github",
+    "fabric doctor examples/code-review-agent --profile hermes_sdk",
+    'plan = client.plan(agent, profile="hermes_sdk")',
+    'report = await client.doctor(agent, profile="hermes_sdk")',
+    "plan = client.plan_config(",
+    '"harness": {"adapter_id": "nvidia.fabric.hermes.sdk"},',
+    'base_dir="examples/code-review-agent",',
+    'client = FabricClient(command=("cargo", "run", "-q", "-p", "fabric-cli", "--"))',
+]
+
+# The exact typed-config dict shown in the README "plan_config" example.
+README_PLAN_CONFIG = {
+    "schema_version": "fabric.agent/v1alpha1",
+    "metadata": {"name": "code-review-agent"},
+    "harness": {"adapter_id": "nvidia.fabric.hermes.sdk"},
+    "models": {
+        "default": {
+            "provider": "nvidia",
+            "model": "nvidia/nemotron-3-nano-30b-a3b",
+        }
+    },
+    "runtime": {
+        "mode": "session",
+        "transport": "library",
+        "input_schema": "chat",
+        "output_schema": "message",
+    },
+}
+
+
+def readme_documents_each_example() -> None:
+    """The README still contains every invocation this smoke mirrors."""
+
+    text = README.read_text()
+    missing = [snippet for snippet in DOCUMENTED_SNIPPETS if snippet not in text]
+    assert not missing, f"README no longer documents these examples verbatim: {missing}"
+
+
+async def readme_python_examples_run() -> None:
+    """The documented Python SDK examples execute and return documented shapes."""
+
+    agent = EXAMPLE_AGENT
+    async with FabricClient() as client:
+        plan = client.plan(agent, profile="hermes_sdk")
+        report = await client.doctor(agent, profile="hermes_sdk")
+        typed_plan = client.plan_config(README_PLAN_CONFIG, base_dir=agent)
+
+    # README prints plan["agent_name"] and report["checks"].
+    assert plan["agent_name"] == "code-review-agent", plan["agent_name"]
+    assert report["checks"], "doctor returned no checks"
+    assert typed_plan["agent_name"] == "code-review-agent"
+    assert (
+        typed_plan["adapter_descriptor"]["descriptor"]["adapter_id"]
+        == "nvidia.fabric.hermes.sdk"
+    )
+
+    # The documented source-tree form selects the CLI command path.
+    cli_client = FabricClient(command=("cargo", "run", "-q", "-p", "fabric-cli", "--"))
+    assert cli_client.command == ("cargo", "run", "-q", "-p", "fabric-cli", "--")
+
+
+def main() -> None:
+    readme_documents_each_example()
+    asyncio.run(readme_python_examples_run())
+    print("smoke_readme_examples ok")
+
+
+if __name__ == "__main__":
+    main()

--- a/python/tests/smoke_typed_config.py
+++ b/python/tests/smoke_typed_config.py
@@ -1,0 +1,143 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Smoke test: typed (in-memory) config is first-class, with no agent directory.
+
+WS4 guardrail. The SDK's ``*_config`` methods accept a typed config object and
+resolve, diagnose, and run it without an on-disk agent package:
+
+* ``plan_config`` / ``doctor_config`` resolve a maintained (repository) adapter
+  with ``base_dir=None`` -- zero filesystem layout, no ``agent.yaml``.
+* ``run_config`` drives a real inline run using only a local adapter directory
+  (still no agent package).
+* the ``*_config`` methods are native-only; the CLI fallback raises a clear,
+  documented error rather than silently degrading.
+
+This complements ``smoke_native_sdk.py``, which exercises ``plan_config`` with a
+``base_dir`` pointed at an agent package.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import tempfile
+from pathlib import Path
+from shutil import copytree
+
+from nemo_fabric import FabricClient, FabricNativeUnavailableError
+
+ROOT = Path(__file__).resolve().parents[2]
+# The inline test adapter (needs only python3, no secrets), shipped as a fixture.
+SHIM_ADAPTERS = ROOT / "tests" / "fixtures" / "hermes-shim-agent" / "adapters"
+
+
+def _repository_adapter_config() -> dict:
+    """Config referencing a maintained adapter resolvable without any package."""
+
+    return {
+        "schema_version": "fabric.agent/v1alpha1",
+        "metadata": {"name": "typed-only-agent"},
+        "harness": {
+            "adapter_id": "nvidia.fabric.hermes.sdk",
+            "resolution": "preinstalled",
+        },
+        "models": {
+            "default": {"provider": "nvidia", "model": "test-model", "temperature": 0.0}
+        },
+        "runtime": {
+            "mode": "oneshot",
+            "transport": "library",
+            "input_schema": "chat",
+            "output_schema": "message",
+            "artifacts": "./artifacts",
+        },
+        "environment": {
+            "provider": "local",
+            "workspace": "./ws",
+            "artifacts": "./artifacts/local",
+        },
+        "telemetry": {"enabled": False},
+    }
+
+
+def _shim_adapter_config() -> dict:
+    """Config referencing the inline test adapter (runs without secrets)."""
+
+    config = _repository_adapter_config()
+    config["metadata"] = {"name": "typed-only-run"}
+    config["harness"] = {
+        "adapter_id": "test.fabric.hermes_shim",
+        "resolution": "preinstalled",
+        "settings": {"workspace": "./ws"},
+    }
+    config["models"] = {
+        "default": {"provider": "test", "model": "test-model", "temperature": 0.0}
+    }
+    return config
+
+
+async def resolves_and_diagnoses_without_a_directory(client: FabricClient) -> None:
+    """plan_config / doctor_config resolve a maintained adapter with no package."""
+
+    config = _repository_adapter_config()
+
+    # base_dir=None: the literal "no path at all" call must still resolve.
+    plan_no_path = client.plan_config(config)
+    assert plan_no_path["agent_name"] == "typed-only-agent"
+
+    # Point base_dir at an EMPTY directory (not an agent package): resolution can
+    # then only succeed via the baked-in repository adapter dir, so the source is
+    # deterministic regardless of the process CWD.
+    with tempfile.TemporaryDirectory(prefix="typed-no-dir-") as empty:
+        plan = client.plan_config(config, base_dir=empty)
+        report = await client.doctor_config(config, base_dir=empty)
+
+    descriptor = plan["adapter_descriptor"]
+    assert descriptor["descriptor"]["adapter_id"] == "nvidia.fabric.hermes.sdk"
+    # "repository" (not "local") proves it resolved without any on-disk package.
+    assert descriptor["source"] == "repository", descriptor["source"]
+
+    assert report["agent_name"] == "typed-only-agent"
+    assert report["checks"], "doctor_config produced no checks"
+    assert report["status"] in {"pass", "warn", "fail"}, report["status"]
+
+
+async def runs_without_an_agent_package(client: FabricClient) -> None:
+    """run_config drives an inline run with only an adapter dir (no agent.yaml)."""
+
+    config = _shim_adapter_config()
+    with tempfile.TemporaryDirectory(prefix="typed-run-") as tmpdir:
+        base = Path(tmpdir) / "scratch"
+        # Only the adapter lives here -- this is deliberately NOT an agent
+        # package (no agent.yaml / profiles / repos / skills).
+        copytree(SHIM_ADAPTERS, base / "adapters")
+        assert not (base / "agent.yaml").exists()
+        result = await client.run_config(config, base_dir=base, input_text="hello typed")
+
+    assert result["status"] == "succeeded", result.get("status")
+    assert result["adapter_kind"] == "python"
+    assert result["metadata"]["adapter_runner"] == "python_inline"
+    assert result["output"]["received"] == "hello typed"
+
+
+def typed_config_requires_native() -> None:
+    """The CLI fallback surfaces a clear error for typed-config methods."""
+
+    cli_client = FabricClient(command=("fabric",))
+    try:
+        cli_client.plan_config(_repository_adapter_config())
+    except FabricNativeUnavailableError:
+        return
+    raise AssertionError("plan_config should require the native extension over the CLI path")
+
+
+async def main() -> None:
+    typed_config_requires_native()
+    async with FabricClient() as client:
+        await resolves_and_diagnoses_without_a_directory(client)
+        await runs_without_an_agent_package(client)
+    print("smoke_typed_config ok")
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/python/tests/smoke_typed_config.py
+++ b/python/tests/smoke_typed_config.py
@@ -120,19 +120,35 @@ async def runs_without_an_agent_package(client: FabricClient) -> None:
     assert result["output"]["received"] == "hello typed"
 
 
-def typed_config_requires_native() -> None:
-    """The CLI fallback surfaces a clear error for typed-config methods."""
+async def typed_config_requires_native() -> None:
+    """The CLI fallback surfaces a clear error for every typed-config method."""
 
     cli_client = FabricClient(command=("fabric",))
+    config = _repository_adapter_config()
+
+    # plan_config is sync; doctor_config / run_config are async. All three are
+    # native-only, so each must raise rather than silently degrade over the CLI.
     try:
-        cli_client.plan_config(_repository_adapter_config())
+        cli_client.plan_config(config)
     except FabricNativeUnavailableError:
-        return
-    raise AssertionError("plan_config should require the native extension over the CLI path")
+        pass
+    else:
+        raise AssertionError("plan_config should require the native extension over the CLI path")
+
+    for name, coro in (
+        ("doctor_config", cli_client.doctor_config(config)),
+        ("run_config", cli_client.run_config(config)),
+    ):
+        try:
+            await coro
+        except FabricNativeUnavailableError:
+            pass
+        else:
+            raise AssertionError(f"{name} should require the native extension over the CLI path")
 
 
 async def main() -> None:
-    typed_config_requires_native()
+    await typed_config_requires_native()
     async with FabricClient() as client:
         await resolves_and_diagnoses_without_a_directory(client)
         await runs_without_an_agent_package(client)


### PR DESCRIPTION
## What

Adds three dependency-light SDK smoke tests that pin WS4 contract guarantees (test-only; no runtime code changes):

| Smoke | Guarantees |
|-------|-----------|
| `python/tests/smoke_typed_config.py` | Typed (in-memory) config is first-class: `plan_config`/`doctor_config` resolve a maintained adapter with **no agent directory**, `run_config` drives an inline run from an adapter-only dir (no agent package), and the `*_config` methods raise a clear `FabricNativeUnavailableError` on the CLI fallback (native-only). |
| `python/tests/smoke_consumer_neutral.py` | The SDK core imports only the standard library and `nemo_fabric` (consumer glue stays under `nemo_fabric.integrations`); a plain `import nemo_fabric` pulls in no consumer/harness package. Also pins the zero-dependency contract (`dependencies = []`). |
| `python/tests/smoke_readme_examples.py` | The README "Use Fabric" Python examples (`plan`/`doctor`/`plan_config`, the source-tree CLI-command form) execute against the example agent, with a drift guard asserting the README documents each invocation verbatim. |

## Why

These are the WS4 "keep ..." guardrails: typed config first-class, a consumer-neutral SDK API, and accurate README examples. They harden the contract a consumer (e.g. Platform) depends on, with near-zero risk.

## Tests

No external setup or secrets required (native extension only):

```
python3 -m pip install -e .
python3 python/tests/smoke_typed_config.py
python3 python/tests/smoke_consumer_neutral.py
python3 python/tests/smoke_readme_examples.py
```

All three print `smoke_<name> ok`. The CLI README snippets remain covered by `tests/smoke_cli.py`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **Tests**
  * Added a consumer-neutral smoke test ensuring the SDK core stays isolated from unwanted external packages.
  * Added a README “Use Fabric” smoke test that verifies documented snippets and executes the mirrored examples against the code-review agent.
  * Added a typed-config smoke test validating in-memory config resolution, diagnostics, and execution, including expected native-extension behavior for CLI-path usage.
* **Chores**
  * Updated the CI Python smoke test suite to run the new scripts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->