### PR TITLE
Make generated ids unique across processes

### DIFF
--- a/crates/fabric-core/src/runtime.rs
+++ b/crates/fabric-core/src/runtime.rs
@@ -1547,8 +1547,12 @@ fn event_with_metadata(
 }
 
 fn new_id(prefix: &str) -> String {
+    // The atomic counter only differentiates ids within a single process; a
+    // process-backed runner spawns a fresh `fabric-cli` per call, resetting it
+    // to 1. Include the process id (distinct across concurrently running
+    // processes) so ids stay unique when two runs land in the same millisecond.
     let counter = NEXT_ID.fetch_add(1, Ordering::Relaxed);
-    format!("{prefix}-{}-{counter}", now_millis())
+    format!("{prefix}-{}-{}-{counter}", now_millis(), std::process::id())
 }
 
 fn now_millis() -> u128 {


### PR DESCRIPTION
## Problem

`runtime_id` (and `invocation_id`, plus the artifact roots derived from them) can collide between two concurrent runs on the **process-backed path**. `smoke_sdk_concurrency` fails intermittently — **~3/12 runs** in a local baseline.

## Root cause

`new_id` builds ids from a millisecond timestamp + a process-global `AtomicU64` counter:

```rust
let counter = NEXT_ID.fetch_add(1, Ordering::Relaxed);
format!("{prefix}-{}-{counter}", now_millis())
```

The counter only differentiates ids **within one process**. A process-backed runner (`FabricClient(command=("cargo","run",…))`) spawns a fresh `fabric-cli` per call, so the counter resets to `1` every time. Two concurrent runs in the same millisecond both produce `…-<millis>-1` → collision.

## Fix

Include `std::process::id()`, which the OS keeps distinct across concurrently running processes, so ids stay unique across processes too. `new_id` is the single source for request/environment/runtime/invocation/event ids, so one change covers all. No new dependency.

## Verification

- `smoke_sdk_concurrency`: **3/12 fail** before → **0/20** after.
- `cargo test --workspace` green; `smoke_cli` / `smoke_sdk` / `smoke_native_sdk` pass (ids feed artifact dir names).
- ids are opaque (nothing in the tree parses them by `-`).

## Follow-up

Once this and the CI PR (#8) both land, `smoke_sdk_concurrency` can be re-added to `ci_python.yml` (it's excluded there only because of this flake).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced ID generation to ensure uniqueness across concurrent processes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->