### PR TITLE
Rename Hermes adapter setting max_turns -> max_iterations

### DIFF
--- a/adapters/hermes-cli/src/nemo_fabric_adapters/hermes_cli/adapter.py
+++ b/adapters/hermes-cli/src/nemo_fabric_adapters/hermes_cli/adapter.py
@@ -205,7 +205,7 @@ def build_hermes_config(payload: dict[str, Any]) -> dict[str, Any]:
         ),
         "agent": without_none(
             {
-                "max_turns": settings.get("max_turns"),
+                "max_turns": settings.get("max_iterations"),
                 "disabled_toolsets": settings.get("disabled_toolsets"),
             }
         ),

--- a/adapters/hermes-sdk/src/nemo_fabric_adapters/hermes_sdk/adapter.py
+++ b/adapters/hermes-sdk/src/nemo_fabric_adapters/hermes_sdk/adapter.py
@@ -254,7 +254,7 @@ def build_hermes_config(payload: dict[str, Any], *, relay_enabled: bool = False)
         ),
         "agent": without_none(
             {
-                "max_turns": settings.get("max_turns"),
+                "max_turns": settings.get("max_iterations"),
                 "disabled_toolsets": settings.get("disabled_toolsets"),
             }
         ),
@@ -393,7 +393,7 @@ def run_hermes_sdk(payload: dict[str, Any]) -> dict[str, Any]:
             api_key=api_key,
             provider=settings.get("provider") or model_config.get("provider"),
             model=settings.get("model_name") or model_config.get("model", ""),
-            max_iterations=int(settings.get("max_turns", 1)),
+            max_iterations=int(settings.get("max_iterations", 1)),
             enabled_toolsets=enabled_toolsets,
             disabled_toolsets=settings.get("disabled_toolsets"),
             quiet_mode=True,

--- a/examples/code-review-agent/profiles/hermes-cli.yaml
+++ b/examples/code-review-agent/profiles/hermes-cli.yaml
@@ -12,7 +12,7 @@ harness:
     workspace: ./repos/my-service
     hermes_home: ./artifacts/hermes-cli/home
     base_url: https://integrate.api.nvidia.com/v1
-    max_turns: 1
+    max_iterations: 1
     terminal_timeout: 60
     enabled_toolsets: []
 

--- a/examples/code-review-agent/profiles/hermes-relay.yaml
+++ b/examples/code-review-agent/profiles/hermes-relay.yaml
@@ -13,7 +13,7 @@ harness:
     workspace: ./repos/my-service
     hermes_home: ./artifacts/hermes-relay/home
     base_url: https://integrate.api.nvidia.com/v1
-    max_turns: 1
+    max_iterations: 1
     max_tokens: 512
     temperature: 0.0
     reasoning_config:

--- a/examples/code-review-agent/profiles/hermes-sdk.yaml
+++ b/examples/code-review-agent/profiles/hermes-sdk.yaml
@@ -13,7 +13,7 @@ harness:
     workspace: ./repos/my-service
     hermes_home: ./artifacts/hermes-home
     base_url: https://integrate.api.nvidia.com/v1
-    max_turns: 1
+    max_iterations: 1
     max_tokens: 512
     temperature: 0.0
     reasoning_config:

--- a/examples/code-review-agent/profiles/hermes-session.yaml
+++ b/examples/code-review-agent/profiles/hermes-session.yaml
@@ -13,7 +13,7 @@ harness:
     workspace: ./repos/my-service
     hermes_home: ./artifacts/hermes-home
     base_url: https://integrate.api.nvidia.com/v1
-    max_turns: 1
+    max_iterations: 1
     max_tokens: 512
     temperature: 0.0
     reasoning_config:


### PR DESCRIPTION
Follow-up to #12. Renames the Hermes adapter setting `max_turns` → `max_iterations`.

## Why
`max_turns` maps to Hermes' `AIAgent(max_iterations=…)` — the cap on agent-loop iterations within a single invocation. The name reads as a conversational-turn count, which is misleading (a session "turn" is one `invoke()`). `max_iterations` matches Hermes' own parameter.

## What
- Rename the setting in the `hermes-sdk`, `hermes-session`, `hermes-cli`, and `hermes-relay` profiles.
- Both adapters read `settings.get("max_iterations")`.
- Hermes' config-file key (`agent.max_turns`) and the SDK parameter (`max_iterations`) are unchanged; runtime behavior is identical.

## Tests
- All four profiles resolve with `max_iterations: 1`; adapter syntax + profile YAML verified. The setting only reaches Hermes on gated real-Hermes runs.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Configuration Updates**
  * Standardized configuration parameter naming across Hermes adapters for consistency and clarity. The iteration limit setting is now referred to as `max_iterations` instead of `max_turns` in all Hermes implementations. Users with existing Hermes configurations should update their settings to use the new parameter name.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->