### PR TITLE
Harden Hermes config mapping coverage

### DIFF
--- a/POC-TO-MVP-PLAN.md
+++ b/POC-TO-MVP-PLAN.md
@@ -171,6 +171,9 @@ Status:
   `FABRIC_INVOCATION` file. The launcher reads that invocation file, maps Fabric
   config into Hermes-native config, and then invokes the real `hermes` CLI.
 - Both paths return the normalized Fabric `RunResult` shape.
+- Fabric model, workspace, skills, MCP, tools, telemetry, and artifact config
+  remains visible in generated Hermes-native config or launch settings.
+- Unsupported Hermes MCP mappings with no target fail before invocation.
 
 Next steps:
 
@@ -179,11 +182,8 @@ Next steps:
 - Test Hermes SDK and CLI paths with more representative inputs.
 - Add parity checks for normalized result fields shared by the inline SDK and
   process-backed CLI paths.
-- Fabric model, workspace, skills, MCP, tools, telemetry, and artifact config
-  should remain visible in generated Hermes-native config or launch settings.
 - Add testing for Relay artifacts such as ATOF/ATIF references.
 - Add testing for harness-native events, artifacts, and logs.
-- Ensure unsupported mappings fail before invocation with actionable errors.
 
 ### 3. Config Variation Matrix
 
@@ -195,6 +195,9 @@ Status:
 - CLI and SDK smoke tests cover profile resolution and multi-profile planning.
 - Hermes capability mapping exists for model, workspace, skills, MCP, tools,
   telemetry, and artifacts.
+- Generated Hermes config checks confirm enabled skills, tools, MCP, telemetry,
+  workspace, and artifact settings.
+- Negative tests cover unsupported mappings failing before invocation.
 
 Next steps:
 
@@ -202,13 +205,9 @@ Next steps:
 - Add missing profile variations where useful, including alternate model,
   toolset, workspace, artifact, and telemetry combinations.
 - Test both Hermes SDK and Hermes CLI against the applicable matrix.
-- Add tests to confirm generated Hermes config or launch settings contain
-  enabled skills, tools, MCP, telemetry, workspace, and artifact settings.
 - Add ATIF/ATOF checks that confirm enabled skills, tools, MCP, or telemetry
   appear in the emitted trajectory where the harness and adapter support it.
 - Add checks for harness-native events, artifacts, and logs.
-- Add negative tests where unsupported mappings fail before invocation with
-  actionable errors.
 
 Config mapping and actual runtime behavior are related but not identical.
 Fabric should prove that capability config is mapped into the harness-native

--- a/adapters/common/src/nemo_fabric_adapters/common/hermes.py
+++ b/adapters/common/src/nemo_fabric_adapters/common/hermes.py
@@ -179,7 +179,10 @@ def dump_yaml(
 
 def hermes_mcp_server_config(server: dict[str, Any]) -> dict[str, Any]:
     transport = str(server.get("transport") or "").strip().lower()
-    target = os.path.expandvars(str(server.get("url") or "")).strip()
+    raw_target = server.get("url")
+    if not raw_target and transport in {"stdio", "command", "process"}:
+        raw_target = server.get("command")
+    target = os.path.expandvars(str(raw_target or "")).strip()
     if not target:
         raise ValueError("MCP server mapping requires url or command")
 

--- a/adapters/common/src/nemo_fabric_adapters/common/hermes.py
+++ b/adapters/common/src/nemo_fabric_adapters/common/hermes.py
@@ -179,7 +179,10 @@ def dump_yaml(
 
 def hermes_mcp_server_config(server: dict[str, Any]) -> dict[str, Any]:
     transport = str(server.get("transport") or "").strip().lower()
-    target = os.path.expandvars(str(server.get("url") or ""))
+    target = os.path.expandvars(str(server.get("url") or "")).strip()
+    if not target:
+        raise ValueError("MCP server mapping requires url or command")
+
     config: dict[str, Any] = {"enabled": True}
     if transport in {"stdio", "command", "process"}:
         config["command"] = target

--- a/tests/test_adapaters_hermes_common.py
+++ b/tests/test_adapaters_hermes_common.py
@@ -199,6 +199,100 @@ def test_build_hermes_config_maps_fabric_config_to_hermes_config(
     }
 
 
+def test_hermes_config_variation_matrix_surfaces_supported_capabilities(
+    hermes_common: types.ModuleType,
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    relay_config = tmp_path / "relay.json"
+    relay_config.write_text(
+        json.dumps(
+            {
+                "relay": {
+                    "config": {
+                        "atof": {"enabled": True, "output_directory": "relay/atof"},
+                        "atif": {"enabled": True, "output_directory": "relay/atif"},
+                    }
+                }
+            }
+        ),
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("FABRIC_RELAY_CONFIG_PATH", str(relay_config))
+    payload = {
+        "runtime_context": {
+            "environment": {
+                "workspace": str(tmp_path / "workspace"),
+                "artifacts": str(tmp_path / "artifacts"),
+            },
+            "telemetry": {"relay_enabled": True},
+        },
+        "capability_plan": {
+            "native": {
+                "skill_paths": [tmp_path / "skills" / "review"],
+                "mcp_servers": {
+                    "github": {
+                        "transport": "stdio",
+                        "url": "github-mcp --stdio",
+                        "exposure": "harness_native",
+                    },
+                    "memory": {
+                        "transport": "streamable-http",
+                        "url": "https://mcp.example/memory",
+                        "exposure": "harness_native",
+                    },
+                },
+            }
+        },
+        "effective_config": {
+            "agent_name": "matrix-agent",
+            "config_root": str(tmp_path),
+            "config": {
+                "harness": {
+                    "settings": {
+                        "model": "review",
+                        "enabled_toolsets": ["git", "shell"],
+                        "toolset_platform": "cli",
+                        "terminal_backend": "local",
+                    }
+                },
+                "models": {
+                    "review": {
+                        "provider": "nvidia",
+                        "model": "nvidia/review-model",
+                    }
+                },
+            },
+        },
+    }
+
+    config = hermes_common.build_hermes_config(payload, relay_enabled=True)
+    plugin_config = hermes_common.load_relay_plugin_config(payload)
+    observability = plugin_config["components"][0]["config"]
+
+    assert config["model"] == {
+        "provider": "nvidia",
+        "default": "nvidia/review-model",
+        "base_url": "https://integrate.api.nvidia.com/v1",
+    }
+    assert config["terminal"]["cwd"] == str(tmp_path / "workspace")
+    assert config["skills"]["external_dirs"] == [str(tmp_path / "skills" / "review")]
+    assert config["mcp_servers"] == {
+        "github": {"enabled": True, "command": "github-mcp --stdio"},
+        "memory": {
+            "enabled": True,
+            "url": "https://mcp.example/memory",
+            "transport": "streamable-http",
+        },
+    }
+    assert config["platform_toolsets"] == {"cli": ["git", "shell"]}
+    assert config["plugins"]["enabled"] == ["observability/nemo_relay"]
+    assert observability["atof"]["output_directory"] == str(tmp_path / "relay" / "atof")
+    assert observability["atif"]["output_directory"] == str(tmp_path / "relay" / "atif")
+    assert observability["atif"]["agent_name"] == "matrix-agent"
+    assert observability["atif"]["model_name"] == "nvidia/review-model"
+
+
 def test_write_hermes_config_writes_file(hermes_common: types.ModuleType, tmp_path: Path) -> None:
     payload = {
         "effective_config": {
@@ -262,6 +356,10 @@ def test_dump_yaml_falls_back_to_json_when_yaml_is_unavailable(
             {"url": "http://localhost:9000/default"},
             {"enabled": True, "url": "http://localhost:9000/default"},
         ),
+        (
+            {"transport": "websocket", "url": "ws://localhost:9000"},
+            {"enabled": True, "url": "ws://localhost:9000", "transport": "websocket"},
+        ),
     ],
 )
 def test_hermes_mcp_server_config(
@@ -270,6 +368,21 @@ def test_hermes_mcp_server_config(
     expected: dict[str, object],
 ) -> None:
     assert hermes_common.hermes_mcp_server_config(server) == expected
+
+
+@pytest.mark.parametrize(
+    "server",
+    [
+        {"transport": "stdio"},
+        {"transport": "stdio", "url": "   "},
+    ],
+)
+def test_hermes_mcp_server_config_rejects_unsupported_mappings(
+    hermes_common: types.ModuleType,
+    server: dict[str, str],
+) -> None:
+    with pytest.raises(ValueError, match="requires url or command"):
+        hermes_common.hermes_mcp_server_config(server)
 
 
 @pytest.mark.parametrize(

--- a/tests/test_adapaters_hermes_common.py
+++ b/tests/test_adapaters_hermes_common.py
@@ -345,8 +345,16 @@ def test_dump_yaml_falls_back_to_json_when_yaml_is_unavailable(
             {"enabled": True, "command": "server --stdio"},
         ),
         (
+            {"transport": "stdio", "command": "server --stdio"},
+            {"enabled": True, "command": "server --stdio"},
+        ),
+        (
             {"transport": "command", "url": "server --command"},
             {"enabled": True, "command": "server --command"},
+        ),
+        (
+            {"transport": "process", "command": "server --process"},
+            {"enabled": True, "command": "server --process"},
         ),
         (
             {"transport": "sse", "url": "http://localhost:9000/sse"},


### PR DESCRIPTION
## Summary
- Add Hermes config variation coverage for FABRIC-7 mapped surfaces: model, workspace, skills, MCP, toolsets, Relay plugin, and Relay artifact output settings
- Reject MCP mappings with no target before invoking Hermes
- Preserve MCP transport as pass-through URL config; runtime dispatch remains adapter_kind-driven
- Update the MVP plan by moving the now-covered Hermes config mapping checks from next steps into status

## Validation
- python3 -m pytest tests/test_adapaters_hermes_common.py -q
- python3 tests/smoke_hermes_config_mapping.py
- cargo test -p fabric-core resolves_
- git diff --check

Closes FABRIC-7

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Tightened validation for Hermes MCP server targets by deriving the connection target from the provided URL/command, expanding environment variables, and rejecting empty or whitespace-only results.
  * Refined Hermes session flow to keep returning the finalized session after the setup steps.

* **Tests**
  * Expanded Hermes config variation matrix coverage, including capability exposure and Relay output directory assertions.
  * Added/updated MCP server test cases for websocket transport and corrected input fields.
  * Added negative tests to reject unsupported MCP mappings when no valid connection target is provided.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->