### PR TITLE
Expand Relay plugin configuration

### DIFF
--- a/adapters/common/src/nemo_fabric_adapters/common/hermes.py
+++ b/adapters/common/src/nemo_fabric_adapters/common/hermes.py
@@ -7,9 +7,10 @@ from __future__ import annotations
 
 import json
 import os
-import sys
 from pathlib import Path
 from typing import Any
+
+from nemo_fabric_adapters.common.utils import write_relay_plugins_toml
 
 
 def effective_config(payload: dict[str, Any]) -> dict[str, Any]:
@@ -282,24 +283,6 @@ def load_relay_plugin_config(payload: dict[str, Any]) -> dict[str, Any]:
     plugin_config.setdefault("components", [])
     normalize_relay_output_dirs(plugin_config, payload)
     return plugin_config
-
-
-def write_relay_plugins_toml(plugin_config: dict[str, Any]) -> Path | None:
-    try:
-        import tomli_w
-
-        config_path = os.environ.get("FABRIC_RELAY_CONFIG_PATH")
-        if not config_path:
-            raise RuntimeError("FABRIC_RELAY_CONFIG_PATH is required when Relay is enabled")
-
-        path = Path(config_path).with_name("relay-plugins.toml")
-        path.parent.mkdir(parents=True, exist_ok=True)
-        path.write_text(tomli_w.dumps(plugin_config), encoding="utf-8")
-        return path
-    except ImportError:
-        print("tomli_w is not installed, skipping writing relay plugins TOML", file=sys.stderr)
-        return None
-
 
 def normalize_relay_output_dirs(plugin_config: dict[str, Any], payload: dict[str, Any]) -> None:
     base = Path(config_root(payload)).resolve()

--- a/adapters/common/src/nemo_fabric_adapters/common/hermes.py
+++ b/adapters/common/src/nemo_fabric_adapters/common/hermes.py
@@ -115,20 +115,11 @@ def write_hermes_config(
     hermes_home: Path,
     *,
     relay_enabled: bool = False,
-    require_yaml: bool = False,
-    missing_yaml_message: str = "PyYAML is required to write Hermes config",
 ) -> tuple[Path, dict[str, Any]]:
     hermes_home.mkdir(parents=True, exist_ok=True)
     config = build_hermes_config(payload, relay_enabled=relay_enabled)
     config_path = hermes_home / "config.yaml"
-    config_path.write_text(
-        common_utils.dump_yaml(
-            config,
-            require_yaml=require_yaml,
-            missing_yaml_message=missing_yaml_message,
-        ),
-        encoding="utf-8",
-    )
+    config_path.write_text(common_utils.dump_yaml(config), encoding="utf-8")
     return config_path, config
 
 

--- a/adapters/common/src/nemo_fabric_adapters/common/hermes.py
+++ b/adapters/common/src/nemo_fabric_adapters/common/hermes.py
@@ -5,36 +5,15 @@
 
 from __future__ import annotations
 
-import json
 import os
 from pathlib import Path
 from typing import Any
 
-from nemo_fabric_adapters.common.utils import write_relay_plugins_toml
-
-
-def effective_config(payload: dict[str, Any]) -> dict[str, Any]:
-    return payload.get("effective_config") or {}
-
-
-def fabric_config(payload: dict[str, Any]) -> dict[str, Any]:
-    return effective_config(payload).get("config") or {}
-
-
-def config_root(payload: dict[str, Any]) -> str:
-    return effective_config(payload).get("config_root") or payload.get("config_root") or "."
-
-
-def agent_name(payload: dict[str, Any]) -> str:
-    return effective_config(payload).get("agent_name") or payload.get("agent_name") or "fabric-agent"
-
-
-def runtime_context(payload: dict[str, Any]) -> dict[str, Any]:
-    return payload.get("runtime_context") or {}
+import nemo_fabric_adapters.common.utils as common_utils
 
 
 def runtime_session_id(payload: dict[str, Any]) -> str | None:
-    runtime_id = runtime_context(payload).get("runtime_id")
+    runtime_id = common_utils.runtime_context(payload).get("runtime_id")
     if runtime_id:
         return str(runtime_id)
     return None
@@ -42,23 +21,6 @@ def runtime_session_id(payload: dict[str, Any]) -> str | None:
 
 def request_payload(payload: dict[str, Any]) -> dict[str, Any]:
     return payload.get("request") or {}
-
-
-def environment_payload(payload: dict[str, Any]) -> dict[str, Any]:
-    return runtime_context(payload).get("environment") or payload.get("environment") or {}
-
-
-def settings_payload(payload: dict[str, Any]) -> dict[str, Any]:
-    harness = fabric_config(payload).get("harness") or {}
-    return harness.get("settings") or payload.get("settings") or {}
-
-
-def models_payload(payload: dict[str, Any]) -> dict[str, Any]:
-    return fabric_config(payload).get("models") or payload.get("models") or {}
-
-
-def capability_plan(payload: dict[str, Any]) -> dict[str, Any]:
-    return payload.get("capability_plan") or payload.get("capabilities") or {}
 
 
 def default_base_url(provider: str | None) -> str | None:
@@ -76,8 +38,8 @@ def get_base_url(settings: dict[str, Any], model_config: dict[str, Any]) -> str 
 
 
 def selected_model_config(payload: dict[str, Any]) -> dict[str, Any]:
-    settings = settings_payload(payload)
-    models = models_payload(payload)
+    settings = common_utils.settings_payload(payload)
+    models = common_utils.models_payload(payload)
     model_config = models.get(settings.get("model", "default"), {})
     if not isinstance(model_config, dict):
         return {}
@@ -85,10 +47,10 @@ def selected_model_config(payload: dict[str, Any]) -> dict[str, Any]:
 
 
 def build_hermes_config(payload: dict[str, Any], *, relay_enabled: bool = False) -> dict[str, Any]:
-    settings = settings_payload(payload)
+    settings = common_utils.settings_payload(payload)
     model_config = selected_model_config(payload)
-    native = capability_plan(payload).get("native") or {}
-    environment = environment_payload(payload)
+    native = common_utils.capability_plan(payload).get("native") or {}
+    environment = common_utils.environment_payload(payload)
 
     model_name = settings.get("model_name") or model_config.get("model", "")
     provider = settings.get("provider") or model_config.get("provider")
@@ -130,10 +92,10 @@ def build_hermes_config(payload: dict[str, Any], *, relay_enabled: bool = False)
 
     if "enabled_toolsets" in settings:
         config["platform_toolsets"] = {
-            settings.get("toolset_platform", "cli"): normalize_list(settings.get("enabled_toolsets"))
+            settings.get("toolset_platform", "cli"): common_utils.normalize_list(settings.get("enabled_toolsets"))
         }
 
-    plugins = normalize_list(settings.get("plugins_enabled"))
+    plugins = common_utils.normalize_list(settings.get("plugins_enabled"))
     if relay_enabled and "observability/nemo_relay" not in plugins:
         plugins.append("observability/nemo_relay")
     if plugins:
@@ -147,36 +109,12 @@ def write_hermes_config(
     hermes_home: Path,
     *,
     relay_enabled: bool = False,
-    require_yaml: bool = False,
-    missing_yaml_message: str = "PyYAML is required to write Hermes config",
 ) -> tuple[Path, dict[str, Any]]:
     hermes_home.mkdir(parents=True, exist_ok=True)
     config = build_hermes_config(payload, relay_enabled=relay_enabled)
     config_path = hermes_home / "config.yaml"
-    config_path.write_text(
-        dump_yaml(
-            config,
-            require_yaml=require_yaml,
-            missing_yaml_message=missing_yaml_message,
-        ),
-        encoding="utf-8",
-    )
+    config_path.write_text(common_utils.dump_yaml(config), encoding="utf-8")
     return config_path, config
-
-
-def dump_yaml(
-    value: dict[str, Any],
-    *,
-    require_yaml: bool = False,
-    missing_yaml_message: str = "PyYAML is required to write Hermes config",
-) -> str:
-    try:
-        import yaml
-    except ImportError as exc:
-        if require_yaml:
-            raise RuntimeError(missing_yaml_message) from exc
-        return json.dumps(value, indent=2, sort_keys=False) + "\n"
-    return yaml.safe_dump(value, sort_keys=False)
 
 
 def hermes_mcp_server_config(server: dict[str, Any]) -> dict[str, Any]:
@@ -190,16 +128,6 @@ def hermes_mcp_server_config(server: dict[str, Any]) -> dict[str, Any]:
         if transport:
             config["transport"] = transport
     return config
-
-
-def normalize_list(value: Any) -> list[str]:
-    if value is None:
-        return []
-    if isinstance(value, str):
-        value = [value]
-    if not isinstance(value, list):
-        value = [value]
-    return [str(item) for item in value if str(item)]
 
 
 def without_none(mapping: dict[str, Any]) -> dict[str, Any]:
@@ -221,8 +149,8 @@ def configure_hermes_relay(payload: dict[str, Any]) -> dict[str, Any] | None:
     if os.environ.get("FABRIC_RELAY_ENABLED") != "true":
         return None
 
-    relay_plugin_config = load_relay_plugin_config(payload)
-    relay_plugins_toml_path = write_relay_plugins_toml(relay_plugin_config)
+    relay_plugin_config = common_utils.load_relay_plugin_config(payload)
+    relay_plugins_toml_path = common_utils.write_relay_plugins_toml(relay_plugin_config)
     if relay_plugins_toml_path is not None:
         os.environ["HERMES_NEMO_RELAY_PLUGINS_TOML"] = str(relay_plugins_toml_path)
 
@@ -250,7 +178,7 @@ def configure_hermes_relay(payload: dict[str, Any]) -> dict[str, Any] | None:
             atif.get("filename_template", "trajectory-{session_id}.atif.json")
         )
         os.environ["HERMES_NEMO_RELAY_ATIF_AGENT_NAME"] = str(
-            atif.get("agent_name") or agent_name(payload)
+            atif.get("agent_name") or common_utils.agent_name(payload)
         )
         os.environ["HERMES_NEMO_RELAY_ATIF_AGENT_VERSION"] = str(atif.get("agent_version", "fabric-poc"))
         os.environ["HERMES_NEMO_RELAY_ATIF_MODEL_NAME"] = str(atif.get("model_name") or relay_model_name(payload))
@@ -258,85 +186,12 @@ def configure_hermes_relay(payload: dict[str, Any]) -> dict[str, Any] | None:
     return relay_plugin_config
 
 
-def load_relay_plugin_config(payload: dict[str, Any]) -> dict[str, Any]:
-    config_path = os.environ.get("FABRIC_RELAY_CONFIG_PATH")
-    if not config_path:
-        raise RuntimeError("FABRIC_RELAY_CONFIG_PATH is required when Relay is enabled")
-
-    with Path(config_path).open(encoding="utf-8") as stream:
-        wrapper = json.load(stream)
-
-    relay = wrapper.get("relay", {})
-    plugin_config = relay.get("config") or {}
-    if "components" not in plugin_config:
-        plugin_config = {
-            "version": 1,
-            "components": [
-                {
-                    "kind": "observability",
-                    "enabled": True,
-                    "config": plugin_config or {"version": 1},
-                }
-            ],
-        }
-    plugin_config.setdefault("version", 1)
-    plugin_config.setdefault("components", [])
-    normalize_relay_output_dirs(plugin_config, payload)
-    return plugin_config
-
-def normalize_relay_output_dirs(plugin_config: dict[str, Any], payload: dict[str, Any]) -> None:
-    base = Path(config_root(payload)).resolve()
-    for component in plugin_config.get("components", []):
-        if component.get("kind") != "observability":
-            continue
-        config = component.setdefault("config", {})
-        config.setdefault("version", 1)
-        for section_name in ("atof", "atif"):
-            section = config.get(section_name)
-            if not isinstance(section, dict) or not section.get("enabled"):
-                continue
-            output_directory = section.get("output_directory")
-            if output_directory:
-                path = Path(output_directory)
-                if not path.is_absolute():
-                    section["output_directory"] = str(base / path)
-            else:
-                section["output_directory"] = str(base / "artifacts" / "relay")
-            if section_name == "atof":
-                section.setdefault("filename", "events.atof.jsonl")
-                section.setdefault("mode", "overwrite")
-            if section_name == "atif":
-                section.setdefault("filename_template", "trajectory-{session_id}.atif.json")
-                section.setdefault("agent_name", agent_name(payload))
-                section.setdefault("model_name", relay_model_name(payload))
-
-
 def relay_model_name(payload: dict[str, Any]) -> str:
-    settings = settings_payload(payload)
-    models = models_payload(payload)
+    settings = common_utils.settings_payload(payload)
+    models = common_utils.models_payload(payload)
     model_config = models.get(settings.get("model", "default"), {})
     return settings.get("model_name") or model_config.get("model") or "unknown"
 
-
-def collect_relay_artifacts(plugin_config: dict[str, Any]) -> list[dict[str, str]]:
-    artifacts: list[dict[str, str]] = []
-    for component in plugin_config.get("components", []):
-        if component.get("kind") != "observability":
-            continue
-        config = component.get("config") or {}
-        for section_name, pattern in (
-            ("atof", "*.jsonl"),
-            ("atif", "*.json"),
-        ):
-            section = config.get(section_name)
-            if not isinstance(section, dict) or not section.get("enabled"):
-                continue
-            directory = Path(section.get("output_directory") or ".")
-            if not directory.exists():
-                continue
-            for path in sorted(directory.glob(pattern)):
-                artifacts.append({"kind": section_name, "path": str(path)})
-    return artifacts
 
 def ensure_hermes_session(fabric_runtime_id: str, model_name: str, model_config: dict[str, Any], hermes_home: Path) -> dict[str, Any]:
     """

--- a/adapters/common/src/nemo_fabric_adapters/common/hermes.py
+++ b/adapters/common/src/nemo_fabric_adapters/common/hermes.py
@@ -7,6 +7,7 @@ from __future__ import annotations
 
 import json
 import os
+import sys
 from pathlib import Path
 from typing import Any
 
@@ -220,6 +221,10 @@ def configure_hermes_relay(payload: dict[str, Any]) -> dict[str, Any] | None:
         return None
 
     relay_plugin_config = load_relay_plugin_config(payload)
+    relay_plugins_toml_path = write_relay_plugins_toml(relay_plugin_config)
+    if relay_plugins_toml_path is not None:
+        os.environ["HERMES_NEMO_RELAY_PLUGINS_TOML"] = str(relay_plugins_toml_path)
+
     observability = next(
         (
             component.get("config") or {}
@@ -277,6 +282,23 @@ def load_relay_plugin_config(payload: dict[str, Any]) -> dict[str, Any]:
     plugin_config.setdefault("components", [])
     normalize_relay_output_dirs(plugin_config, payload)
     return plugin_config
+
+
+def write_relay_plugins_toml(plugin_config: dict[str, Any]) -> Path | None:
+    try:
+        import tomli_w
+
+        config_path = os.environ.get("FABRIC_RELAY_CONFIG_PATH")
+        if not config_path:
+            raise RuntimeError("FABRIC_RELAY_CONFIG_PATH is required when Relay is enabled")
+
+        path = Path(config_path).with_name("relay-plugins.toml")
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(tomli_w.dumps(plugin_config), encoding="utf-8")
+        return path
+    except ImportError:
+        print("tomli_w is not installed, skipping writing relay plugins TOML", file=sys.stderr)
+        return None
 
 
 def normalize_relay_output_dirs(plugin_config: dict[str, Any], payload: dict[str, Any]) -> None:

--- a/adapters/common/src/nemo_fabric_adapters/common/utils.py
+++ b/adapters/common/src/nemo_fabric_adapters/common/utils.py
@@ -1,0 +1,28 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Shared adapter utility helpers."""
+
+from __future__ import annotations
+
+import os
+import sys
+from pathlib import Path
+from typing import Any
+
+
+def write_relay_plugins_toml(plugin_config: dict[str, Any]) -> Path | None:
+    try:
+        import tomli_w
+
+        config_path = os.environ.get("FABRIC_RELAY_CONFIG_PATH")
+        if not config_path:
+            raise RuntimeError("FABRIC_RELAY_CONFIG_PATH is required when Relay is enabled")
+
+        path = Path(config_path).with_name("relay-plugins.toml")
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(tomli_w.dumps(plugin_config), encoding="utf-8")
+        return path
+    except ImportError:
+        print("tomli_w is not installed, skipping writing relay plugins TOML", file=sys.stderr)
+        return None

--- a/adapters/common/src/nemo_fabric_adapters/common/utils.py
+++ b/adapters/common/src/nemo_fabric_adapters/common/utils.py
@@ -59,19 +59,12 @@ def normalize_list(value: Any) -> list[str]:
     return [str(item) for item in value if str(item)]
 
 
-def dump_yaml(
-    value: dict[str, Any],
-    *,
-    require_yaml: bool = False,
-    missing_yaml_message: str = "PyYAML is required to write Hermes config",
-) -> str:
+def dump_yaml(value: dict[str, Any]) -> str:
     try:
         import yaml
-    except ImportError as exc:
-        if require_yaml:
-            raise RuntimeError(missing_yaml_message) from exc
+        return yaml.safe_dump(value, sort_keys=False)
+    except ImportError:
         return json.dumps(value, indent=2, sort_keys=False) + "\n"
-    return yaml.safe_dump(value, sort_keys=False)
 
 
 def load_relay_plugin_config(payload: dict[str, Any]) -> dict[str, Any]:

--- a/adapters/common/src/nemo_fabric_adapters/common/utils.py
+++ b/adapters/common/src/nemo_fabric_adapters/common/utils.py
@@ -9,7 +9,17 @@ import json
 import os
 import sys
 from pathlib import Path
-from typing import Any
+from typing import Any, TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from nemo_relay import plugin
+    from nemo_relay.observability import (
+        AtifConfig,
+        AtofConfig,
+        HttpStorageConfig,
+        OtlpConfig,
+        S3StorageConfig,
+    )
 
 
 def effective_config(payload: dict[str, Any]) -> dict[str, Any]:
@@ -119,6 +129,158 @@ def normalize_relay_output_dirs(plugin_config: dict[str, Any], payload: dict[str
                 section.setdefault("filename_template", "trajectory-{session_id}.atif.json")
                 section.setdefault("agent_name", agent_name(payload))
                 section.setdefault("model_name", _relay_model_name(payload))
+
+
+def _relay_api_plugin_config(plugin_config: dict[str, Any]) -> plugin.PluginConfig:
+    from nemo_relay import plugin
+    from nemo_relay.observability import (
+        ComponentSpec,
+        ConfigPolicy,
+        ObservabilityConfig,
+    )
+
+    components: list[Any] = []
+    for component in plugin_config.get("components", []):
+        if not isinstance(component, dict):
+            continue
+        enabled = bool(component.get("enabled", True))
+        config = component.get("config") or {}
+        if component.get("kind") == "observability" and isinstance(config, dict):
+            policy = config.get("policy") if isinstance(config.get("policy"), dict) else {}
+            components.append(
+                ComponentSpec(
+                    ObservabilityConfig(
+                        version=int(config.get("version", 1)),
+                        atof=_relay_api_atof_config(config.get("atof")),
+                        atif=_relay_api_atif_config(
+                            config.get("atif"),
+                        ),
+                        opentelemetry=_relay_api_otlp_config(config.get("opentelemetry")),
+                        openinference=_relay_api_otlp_config(config.get("openinference")),
+                        policy=ConfigPolicy(
+                            unknown_component=policy.get("unknown_component", "warn"),
+                            unknown_field=policy.get("unknown_field", "warn"),
+                            unsupported_value=policy.get("unsupported_value", "error"),
+                        ),
+                    ),
+                    enabled=enabled,
+                )
+            )
+            continue
+        components.append(
+            plugin.ComponentSpec(
+                kind=str(component.get("kind") or ""),
+                enabled=enabled,
+                config=config if isinstance(config, dict) else {},
+            )
+        )
+
+    policy = plugin_config.get("policy") if isinstance(plugin_config.get("policy"), dict) else {}
+    return plugin.PluginConfig(
+        version=int(plugin_config.get("version", 1)),
+        components=components,
+        policy=plugin.ConfigPolicy(
+            unknown_component=policy.get("unknown_component", "warn"),
+            unknown_field=policy.get("unknown_field", "warn"),
+            unsupported_value=policy.get("unsupported_value", "error"),
+        ),
+    )
+
+
+def _relay_api_atof_config(value: Any) -> AtofConfig | None:
+    if not isinstance(value, dict):
+        return None
+    from nemo_relay.observability import AtofConfig, AtofEndpointConfig
+
+    endpoint_configs = value.get("endpoints")
+    endpoints = None
+    if isinstance(endpoint_configs, list):
+        endpoints = [
+            AtofEndpointConfig(
+                url=str(endpoint.get("url", "")),
+                transport=endpoint.get("transport", "http_post"),
+                headers=endpoint.get("headers", {}),
+                timeout_millis=int(endpoint.get("timeout_millis", 3000)),
+            )
+            for endpoint in endpoint_configs
+            if isinstance(endpoint, dict)
+        ]
+    return AtofConfig(
+        enabled=bool(value.get("enabled", False)),
+        output_directory=value.get("output_directory"),
+        filename=value.get("filename"),
+        mode=value.get("mode", "append"),
+        endpoints=endpoints,
+    )
+
+
+def _relay_api_atif_config(value: Any) -> AtifConfig | None:
+    if not isinstance(value, dict):
+        return None
+    from nemo_relay.observability import AtifConfig
+
+    storage_configs = value.get("storage")
+    storage = None
+    if isinstance(storage_configs, list):
+        storage = [
+            _relay_api_storage_config(item)
+            for item in storage_configs
+            if isinstance(item, dict)
+        ]
+    return AtifConfig(
+        enabled=bool(value.get("enabled", False)),
+        agent_name=value.get("agent_name", "NeMo Relay"),
+        agent_version=value.get("agent_version"),
+        model_name=value.get("model_name", "unknown"),
+        tool_definitions=value.get("tool_definitions"),
+        extra=value.get("extra"),
+        output_directory=value.get("output_directory"),
+        filename_template=value.get("filename_template", "nemo-relay-atif-{session_id}.json"),
+        storage=storage,
+    )
+
+
+def _relay_api_storage_config(value: dict[str, Any]) -> HttpStorageConfig | S3StorageConfig:
+    if value.get("type") == "s3":
+        from nemo_relay.observability import S3StorageConfig
+
+        return S3StorageConfig(
+            bucket=value.get("bucket", ""),
+            key_prefix=value.get("key_prefix"),
+            access_key_id=value.get("access_key_id"),
+            secret_access_key_var=value.get("secret_access_key_var"),
+            session_token_var=value.get("session_token_var"),
+            region=value.get("region"),
+            endpoint_url=value.get("endpoint_url"),
+            allow_http=value.get("allow_http"),
+        )
+    from nemo_relay.observability import HttpStorageConfig
+
+    return HttpStorageConfig(
+        endpoint=value.get("endpoint", ""),
+        headers=value.get("headers", {}),
+        header_env=value.get("header_env", {}),
+        timeout_millis=int(value.get("timeout_millis", 3000)),
+    )
+
+
+def _relay_api_otlp_config(value: Any) -> OtlpConfig | None:
+    if not isinstance(value, dict):
+        return None
+    from nemo_relay.observability import OtlpConfig
+
+    return OtlpConfig(
+        enabled=bool(value.get("enabled", False)),
+        transport=value.get("transport", "http_binary"),
+        endpoint=value.get("endpoint"),
+        headers=value.get("headers", {}),
+        resource_attributes=value.get("resource_attributes", {}),
+        service_name=value.get("service_name", "nemo-relay"),
+        service_namespace=value.get("service_namespace"),
+        service_version=value.get("service_version"),
+        instrumentation_scope=value.get("instrumentation_scope"),
+        timeout_millis=int(value.get("timeout_millis", 3000)),
+    )
 
 
 def collect_relay_artifacts(plugin_config: dict[str, Any]) -> list[dict[str, str]]:

--- a/adapters/common/src/nemo_fabric_adapters/common/utils.py
+++ b/adapters/common/src/nemo_fabric_adapters/common/utils.py
@@ -5,10 +5,142 @@
 
 from __future__ import annotations
 
+import json
 import os
 import sys
 from pathlib import Path
 from typing import Any
+
+
+def effective_config(payload: dict[str, Any]) -> dict[str, Any]:
+    return payload.get("effective_config") or {}
+
+
+def fabric_config(payload: dict[str, Any]) -> dict[str, Any]:
+    return effective_config(payload).get("config") or {}
+
+
+def config_root(payload: dict[str, Any]) -> str:
+    return effective_config(payload).get("config_root") or payload.get("config_root") or "."
+
+
+def agent_name(payload: dict[str, Any]) -> str:
+    return effective_config(payload).get("agent_name") or payload.get("agent_name") or "fabric-agent"
+
+
+def runtime_context(payload: dict[str, Any]) -> dict[str, Any]:
+    return payload.get("runtime_context") or {}
+
+
+def environment_payload(payload: dict[str, Any]) -> dict[str, Any]:
+    return runtime_context(payload).get("environment") or payload.get("environment") or {}
+
+
+def settings_payload(payload: dict[str, Any]) -> dict[str, Any]:
+    harness = fabric_config(payload).get("harness") or {}
+    return harness.get("settings") or payload.get("settings") or {}
+
+
+def models_payload(payload: dict[str, Any]) -> dict[str, Any]:
+    return fabric_config(payload).get("models") or payload.get("models") or {}
+
+
+def capability_plan(payload: dict[str, Any]) -> dict[str, Any]:
+    return payload.get("capability_plan") or payload.get("capabilities") or {}
+
+
+def normalize_list(value: Any) -> list[str]:
+    if value is None:
+        return []
+    if isinstance(value, str):
+        value = [value]
+    if not isinstance(value, list):
+        value = [value]
+    return [str(item) for item in value if str(item)]
+
+
+def dump_yaml(value: dict[str, Any]) -> str:
+    try:
+        import yaml
+        return yaml.safe_dump(value, sort_keys=False)
+    except ImportError:
+        # Since yaml is a super-set of json, we can always dump to json to a yaml file
+        return json.dumps(value, indent=2, sort_keys=False) + "\n"
+
+
+def load_relay_plugin_config(payload: dict[str, Any]) -> dict[str, Any]:
+    config_path = os.environ.get("FABRIC_RELAY_CONFIG_PATH")
+    if not config_path:
+        raise RuntimeError("FABRIC_RELAY_CONFIG_PATH is required when Relay is enabled")
+
+    with Path(config_path).open(encoding="utf-8") as stream:
+        wrapper = json.load(stream)
+
+    relay = wrapper.get("relay", {})
+    plugin_config = relay.get("config") or {}
+    if "components" not in plugin_config:
+        plugin_config = {
+            "version": 1,
+            "components": [
+                {
+                    "kind": "observability",
+                    "enabled": True,
+                    "config": plugin_config or {"version": 1},
+                }
+            ],
+        }
+    plugin_config.setdefault("version", 1)
+    plugin_config.setdefault("components", [])
+    normalize_relay_output_dirs(plugin_config, payload)
+    return plugin_config
+
+
+def normalize_relay_output_dirs(plugin_config: dict[str, Any], payload: dict[str, Any]) -> None:
+    base = Path(config_root(payload)).resolve()
+    for component in plugin_config.get("components", []):
+        if component.get("kind") != "observability":
+            continue
+        config = component.setdefault("config", {})
+        config.setdefault("version", 1)
+        for section_name in ("atof", "atif"):
+            section = config.get(section_name)
+            if not isinstance(section, dict) or not section.get("enabled"):
+                continue
+            output_directory = section.get("output_directory")
+            if output_directory:
+                path = Path(output_directory)
+                if not path.is_absolute():
+                    section["output_directory"] = str(base / path)
+            else:
+                section["output_directory"] = str(base / "artifacts" / "relay")
+            if section_name == "atof":
+                section.setdefault("filename", "events.atof.jsonl")
+                section.setdefault("mode", "overwrite")
+            if section_name == "atif":
+                section.setdefault("filename_template", "trajectory-{session_id}.atif.json")
+                section.setdefault("agent_name", agent_name(payload))
+                section.setdefault("model_name", _relay_model_name(payload))
+
+
+def collect_relay_artifacts(plugin_config: dict[str, Any]) -> list[dict[str, str]]:
+    artifacts: list[dict[str, str]] = []
+    for component in plugin_config.get("components", []):
+        if component.get("kind") != "observability":
+            continue
+        config = component.get("config") or {}
+        for section_name, pattern in (
+            ("atof", "*.jsonl"),
+            ("atif", "*.json"),
+        ):
+            section = config.get(section_name)
+            if not isinstance(section, dict) or not section.get("enabled"):
+                continue
+            directory = Path(section.get("output_directory") or ".")
+            if not directory.exists():
+                continue
+            for path in sorted(directory.glob(pattern)):
+                artifacts.append({"kind": section_name, "path": str(path)})
+    return artifacts
 
 
 def write_relay_plugins_toml(plugin_config: dict[str, Any]) -> Path | None:
@@ -26,3 +158,10 @@ def write_relay_plugins_toml(plugin_config: dict[str, Any]) -> Path | None:
     except ImportError:
         print("tomli_w is not installed, skipping writing relay plugins TOML", file=sys.stderr)
         return None
+
+
+def _relay_model_name(payload: dict[str, Any]) -> str:
+    settings = settings_payload(payload)
+    models = models_payload(payload)
+    model_config = models.get(settings.get("model", "default"), {})
+    return settings.get("model_name") or model_config.get("model") or "unknown"

--- a/adapters/common/src/nemo_fabric_adapters/common/utils.py
+++ b/adapters/common/src/nemo_fabric_adapters/common/utils.py
@@ -176,7 +176,7 @@ def _relay_api_plugin_config(plugin_config: dict[str, Any]) -> plugin.PluginConf
         )
 
     policy = plugin_config.get("policy") if isinstance(plugin_config.get("policy"), dict) else {}
-    return plugin.PluginConfig(
+    plugin_config = plugin.PluginConfig(
         version=int(plugin_config.get("version", 1)),
         components=components,
         policy=plugin.ConfigPolicy(
@@ -185,6 +185,12 @@ def _relay_api_plugin_config(plugin_config: dict[str, Any]) -> plugin.PluginConf
             unsupported_value=policy.get("unsupported_value", "error"),
         ),
     )
+
+    report = plugin.validate(plugin_config)
+    if any(diagnostic["level"] == "error" for diagnostic in report["diagnostics"]):
+        raise RuntimeError(report["diagnostics"])
+
+    return plugin_config
 
 
 def _relay_api_atof_config(value: Any) -> AtofConfig | None:

--- a/adapters/hermes-cli/src/nemo_fabric_adapters/hermes_cli/adapter.py
+++ b/adapters/hermes-cli/src/nemo_fabric_adapters/hermes_cli/adapter.py
@@ -184,13 +184,11 @@ def build_command(
     command_args = common_utils.normalize_list(settings.get("hermes_args") or settings.get("command_args"))
     provider = settings.get("provider") or model_config.get("provider")
 
-    args = [command, *command_args]
+    args = [command, *command_args, "chat", "--quiet", "--query", prompt]
     if use_session:
         # On the first invocation, we create the session up-front, and use the `--continue` flag to resume it even
         # though technically it's an empty session.
-        args.extend(["chat", "--quiet", "--continue", fabric_runtime_id, "--query", prompt])
-    else:
-        args.extend(["-z", prompt])
+        args.extend([ "--continue", fabric_runtime_id, ])
 
     if model_name:
         args.extend(["--model", str(model_name)])

--- a/adapters/hermes-cli/src/nemo_fabric_adapters/hermes_cli/adapter.py
+++ b/adapters/hermes-cli/src/nemo_fabric_adapters/hermes_cli/adapter.py
@@ -24,6 +24,7 @@ if COMMON_DIR not in sys.path:
     sys.path.append(COMMON_DIR)
 
 import nemo_fabric_adapters.common.hermes as hermes_common  # noqa: E402
+import nemo_fabric_adapters.common.utils as common_utils  # noqa: E402
 
 
 def main() -> None:
@@ -56,15 +57,15 @@ def _api_key_preflight_check(settings: dict[str, Any], model_config: dict[str, A
 
 
 def get_runtime_mode(payload: dict[str, Any]) -> str:
-    runtime = hermes_common.fabric_config(payload).get("runtime") or {}
+    runtime = common_utils.fabric_config(payload).get("runtime") or {}
     return runtime.get("mode", "oneshot")
 
 
 def run_hermes_cli(payload: dict[str, Any]) -> dict[str, Any]:
-    settings = hermes_common.settings_payload(payload)
+    settings = common_utils.settings_payload(payload)
     request = hermes_common.request_payload(payload)
-    config_root = Path(hermes_common.config_root(payload)).resolve()
-    environment = hermes_common.environment_payload(payload)
+    config_root = Path(common_utils.config_root(payload)).resolve()
+    environment = common_utils.environment_payload(payload)
     model_config = hermes_common.selected_model_config(payload)
     model_name = settings.get("model_name") or model_config.get("model")
     runtime_mode = get_runtime_mode(payload)
@@ -95,7 +96,7 @@ def run_hermes_cli(payload: dict[str, Any]) -> dict[str, Any]:
         hermes_common.ensure_hermes_session(fabric_runtime_id, model_name, model_config, hermes_home)
 
     prompt = request_to_prompt(request)
-    toolsets = hermes_common.normalize_list(settings.get("enabled_toolsets"))
+    toolsets = common_utils.normalize_list(settings.get("enabled_toolsets"))
 
     command = build_command(
         settings,
@@ -155,7 +156,7 @@ def run_hermes_cli(payload: dict[str, Any]) -> dict[str, Any]:
     }
 
     if relay_plugin_config is not None:
-        relay_artifacts = hermes_common.collect_relay_artifacts(relay_plugin_config)
+        relay_artifacts = common_utils.collect_relay_artifacts(relay_plugin_config)
         output["relay_runtime"] = {
             "enabled": True,
             "mode": os.environ.get("FABRIC_RELAY_MODE"),
@@ -180,7 +181,7 @@ def build_command(
         config_root,
         settings.get("hermes_command") or settings.get("command", "hermes"),
     )
-    command_args = hermes_common.normalize_list(settings.get("hermes_args") or settings.get("command_args"))
+    command_args = common_utils.normalize_list(settings.get("hermes_args") or settings.get("command_args"))
     provider = settings.get("provider") or model_config.get("provider")
 
     args = [command, *command_args]

--- a/adapters/hermes-sdk/src/nemo_fabric_adapters/hermes_sdk/adapter.py
+++ b/adapters/hermes-sdk/src/nemo_fabric_adapters/hermes_sdk/adapter.py
@@ -102,14 +102,66 @@ async def run_hermes_sdk(payload: dict[str, Any]) -> dict[str, Any]:
     if not isinstance(user_message, str):
         user_message = json.dumps(user_message, sort_keys=True)
 
-    hermes_stdout = StringIO()
-    relay_artifacts: list[dict[str, str]] = []
-    with redirect_stdout(hermes_stdout):
-        from hermes_cli.config import load_config
-        from hermes_cli.plugins import discover_plugins, invoke_hook
-        from hermes_state import SessionDB
-        from run_agent import AIAgent
+    hermes_kwargs = {
+        "payload": payload,
+        "settings": settings,
+        "model_config": model_config,
+        "base_url": base_url,
+        "api_key": api_key,
+        "user_message": user_message,
+        "relay_plugin_config": relay_plugin_config,
+    }
+    (result, enabled_toolsets, relay_artifacts, adapter_stdout) = _invoke_hermes(**hermes_kwargs)
+    response = result.get("response") or result.get("final_response")
+    messages = result.get("messages") or []
+    output = {
+        "harness": "hermes",
+        "adapter": "python",
+        "mode": "hermes_sdk",
+        "model": model_config.get("model"),
+        "base_url": base_url,
+        "response": response,
+        "completed": bool(result.get("completed")),
+        "failed": bool(result.get("failed")),
+        "api_calls": result.get("api_calls"),
+        "messages": messages,
+        "message_count": len(messages),
+        "error": result.get("error"),
+        "adapter_stdout": adapter_stdout,
+        "hermes_home": str(hermes_home),
+        "hermes_config_path": str(hermes_config_path),
+        "hermes_native_config": hermes_common.summarize_hermes_config(hermes_config),
+        "enabled_toolsets": enabled_toolsets,
+    }
+    if relay_plugin_config is not None:
+        output["relay_runtime"] = {
+            "enabled": True,
+            "mode": os.environ.get("FABRIC_RELAY_MODE"),
+            "config_path": os.environ.get("FABRIC_RELAY_CONFIG_PATH"),
+            "emitter": "hermes.observability/nemo_relay",
+        }
+        output["relay_artifacts"] = relay_artifacts
+    return output
 
+
+def _invoke_hermes(
+    *,
+    payload: dict[str, Any],
+    settings: dict[str, Any],
+    model_config: dict[str, Any],
+    base_url: str | None,
+    api_key: str,
+    user_message: str,
+    relay_plugin_config: dict[str, Any] | None,
+) -> tuple[dict[str, Any], list[str] | None, list[dict[str, str]], str]:
+    from hermes_cli.config import load_config
+    from hermes_cli.plugins import discover_plugins, invoke_hook
+    from hermes_state import SessionDB
+    from run_agent import AIAgent
+
+    relay_artifacts: list[dict[str, str]] = []
+    hermes_stdout = StringIO()
+    with redirect_stdout(hermes_stdout):
         discover_plugins(force=True)
         loaded_hermes_config = load_config()
         enabled_toolsets = resolve_hermes_toolsets(settings, loaded_hermes_config)
@@ -117,27 +169,29 @@ async def run_hermes_sdk(payload: dict[str, Any]) -> dict[str, Any]:
         session_db = SessionDB()
         conversation_history = load_runtime_history(session_db, session_id)
         agent = None
-        agent = AIAgent(**filter_supported_kwargs(
-            AIAgent,
-            base_url=base_url,
-            api_key=api_key,
-            provider=settings.get("provider") or model_config.get("provider"),
-            model=settings.get("model_name") or model_config.get("model", ""),
-            max_iterations=int(settings.get("max_iterations", 1)),
-            enabled_toolsets=enabled_toolsets,
-            disabled_toolsets=settings.get("disabled_toolsets"),
-            quiet_mode=True,
-            skip_context_files=True,
-            skip_memory=True,
-            save_trajectories=bool(settings.get("save_trajectories", False)),
-            max_tokens=settings.get("max_tokens", 512),
-            temperature=settings.get("temperature", model_config.get("temperature", 0.0)),
-            reasoning_config=settings.get("reasoning_config", {"effort": "none"}),
-            insert_reasoning=bool(settings.get("insert_reasoning", False)),
-            platform="fabric",
-            session_id=session_id,
-            session_db=session_db,
-        ))
+        agent = AIAgent(
+            **filter_supported_kwargs(
+                AIAgent,
+                base_url=base_url,
+                api_key=api_key,
+                provider=settings.get("provider") or model_config.get("provider"),
+                model=settings.get("model_name") or model_config.get("model", ""),
+                max_iterations=int(settings.get("max_iterations", 1)),
+                enabled_toolsets=enabled_toolsets,
+                disabled_toolsets=settings.get("disabled_toolsets"),
+                quiet_mode=True,
+                skip_context_files=True,
+                skip_memory=True,
+                save_trajectories=bool(settings.get("save_trajectories", False)),
+                max_tokens=settings.get("max_tokens", 512),
+                temperature=settings.get("temperature", model_config.get("temperature", 0.0)),
+                reasoning_config=settings.get("reasoning_config", {"effort": "none"}),
+                insert_reasoning=bool(settings.get("insert_reasoning", False)),
+                platform="fabric",
+                session_id=session_id,
+                session_db=session_db,
+            )
+        )
         try:
             conversation_kwargs = filter_supported_call_kwargs(
                 agent.run_conversation,
@@ -159,36 +213,7 @@ async def run_hermes_sdk(payload: dict[str, Any]) -> dict[str, Any]:
                     platform=getattr(agent, "platform", None) or "fabric",
                 )
                 relay_artifacts = common_utils.collect_relay_artifacts(relay_plugin_config)
-    response = result.get("response") or result.get("final_response")
-    messages = result.get("messages") or []
-    output = {
-        "harness": "hermes",
-        "adapter": "python",
-        "mode": "hermes_sdk",
-        "model": model_config.get("model"),
-        "base_url": base_url,
-        "response": response,
-        "completed": bool(result.get("completed")),
-        "failed": bool(result.get("failed")),
-        "api_calls": result.get("api_calls"),
-        "messages": messages,
-        "message_count": len(messages),
-        "error": result.get("error"),
-        "adapter_stdout": hermes_stdout.getvalue(),
-        "hermes_home": str(hermes_home),
-        "hermes_config_path": str(hermes_config_path),
-        "hermes_native_config": hermes_common.summarize_hermes_config(hermes_config),
-        "enabled_toolsets": enabled_toolsets,
-    }
-    if relay_plugin_config is not None:
-        output["relay_runtime"] = {
-            "enabled": True,
-            "mode": os.environ.get("FABRIC_RELAY_MODE"),
-            "config_path": os.environ.get("FABRIC_RELAY_CONFIG_PATH"),
-            "emitter": "hermes.observability/nemo_relay",
-        }
-        output["relay_artifacts"] = relay_artifacts
-    return output
+    return result, enabled_toolsets, relay_artifacts, hermes_stdout.getvalue()
 
 
 def filter_supported_kwargs(callable_obj: Any, **kwargs: Any) -> dict[str, Any]:

--- a/adapters/hermes-sdk/src/nemo_fabric_adapters/hermes_sdk/adapter.py
+++ b/adapters/hermes-sdk/src/nemo_fabric_adapters/hermes_sdk/adapter.py
@@ -18,7 +18,17 @@ import sys
 from contextlib import redirect_stdout
 from io import StringIO
 from pathlib import Path
-from typing import Any
+from typing import Any, TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from nemo_relay import plugin
+    from nemo_relay.observability import (
+        AtifConfig,
+        AtofConfig,
+        HttpStorageConfig,
+        OtlpConfig,
+        S3StorageConfig,
+    )
 
 CUR_DIR = Path(__file__).parent
 ADAPTERS_DIR = CUR_DIR.parent.parent.parent.parent
@@ -85,11 +95,16 @@ async def run_hermes_sdk(payload: dict[str, Any]) -> dict[str, Any]:
     os.environ["HERMES_SESSION_SOURCE"] = "fabric"
     os.environ.setdefault("TERMINAL_ENV", settings.get("terminal_backend", "local"))
     os.environ.setdefault("TERMINAL_TIMEOUT", str(settings.get("terminal_timeout", 60)))
-    relay_plugin_config = hermes_common.configure_hermes_relay(payload)
+    relay_enabled = os.environ.get("FABRIC_RELAY_ENABLED", "").strip().lower() == "true"
+
+    relay_plugin_config = None
+    if relay_enabled:
+        relay_plugin_config = common_utils.load_relay_plugin_config(payload)
+
     hermes_config_path, hermes_config = hermes_common.write_hermes_config(
         payload,
         hermes_home,
-        relay_enabled=relay_plugin_config is not None,
+        relay_enabled=relay_enabled,
     )
 
     api_key_env = settings.get("api_key_env") or model_config.get("api_key_env") or "NVIDIA_API_KEY"
@@ -111,7 +126,16 @@ async def run_hermes_sdk(payload: dict[str, Any]) -> dict[str, Any]:
         "user_message": user_message,
         "relay_plugin_config": relay_plugin_config,
     }
-    (result, enabled_toolsets, relay_artifacts, adapter_stdout) = _invoke_hermes(**hermes_kwargs)
+    if relay_enabled:
+        relay_api_config = _relay_api_plugin_config(relay_plugin_config or {})
+        from nemo_relay import plugin
+
+        async with plugin.plugin(relay_api_config):
+            (result, enabled_toolsets, relay_artifacts, adapter_stdout) = _invoke_hermes(
+                **hermes_kwargs
+            )
+    else:
+        (result, enabled_toolsets, relay_artifacts, adapter_stdout) = _invoke_hermes(**hermes_kwargs)
     response = result.get("response") or result.get("final_response")
     messages = result.get("messages") or []
     output = {
@@ -142,6 +166,158 @@ async def run_hermes_sdk(payload: dict[str, Any]) -> dict[str, Any]:
         }
         output["relay_artifacts"] = relay_artifacts
     return output
+
+
+def _relay_api_plugin_config(plugin_config: dict[str, Any]) -> plugin.PluginConfig:
+    from nemo_relay import plugin
+    from nemo_relay.observability import (
+        ComponentSpec,
+        ConfigPolicy,
+        ObservabilityConfig,
+    )
+
+    components: list[Any] = []
+    for component in plugin_config.get("components", []):
+        if not isinstance(component, dict):
+            continue
+        enabled = bool(component.get("enabled", True))
+        config = component.get("config") or {}
+        if component.get("kind") == "observability" and isinstance(config, dict):
+            policy = config.get("policy") if isinstance(config.get("policy"), dict) else {}
+            components.append(
+                ComponentSpec(
+                    ObservabilityConfig(
+                        version=int(config.get("version", 1)),
+                        atof=_relay_api_atof_config(config.get("atof")),
+                        atif=_relay_api_atif_config(
+                            config.get("atif"),
+                        ),
+                        opentelemetry=_relay_api_otlp_config(config.get("opentelemetry")),
+                        openinference=_relay_api_otlp_config(config.get("openinference")),
+                        policy=ConfigPolicy(
+                            unknown_component=policy.get("unknown_component", "warn"),
+                            unknown_field=policy.get("unknown_field", "warn"),
+                            unsupported_value=policy.get("unsupported_value", "error"),
+                        ),
+                    ),
+                    enabled=enabled,
+                )
+            )
+            continue
+        components.append(
+            plugin.ComponentSpec(
+                kind=str(component.get("kind") or ""),
+                enabled=enabled,
+                config=config if isinstance(config, dict) else {},
+            )
+        )
+
+    policy = plugin_config.get("policy") if isinstance(plugin_config.get("policy"), dict) else {}
+    return plugin.PluginConfig(
+        version=int(plugin_config.get("version", 1)),
+        components=components,
+        policy=plugin.ConfigPolicy(
+            unknown_component=policy.get("unknown_component", "warn"),
+            unknown_field=policy.get("unknown_field", "warn"),
+            unsupported_value=policy.get("unsupported_value", "error"),
+        ),
+    )
+
+
+def _relay_api_atof_config(value: Any) -> AtofConfig | None:
+    if not isinstance(value, dict):
+        return None
+    from nemo_relay.observability import AtofConfig, AtofEndpointConfig
+
+    endpoint_configs = value.get("endpoints")
+    endpoints = None
+    if isinstance(endpoint_configs, list):
+        endpoints = [
+            AtofEndpointConfig(
+                url=str(endpoint.get("url", "")),
+                transport=endpoint.get("transport", "http_post"),
+                headers=endpoint.get("headers", {}),
+                timeout_millis=int(endpoint.get("timeout_millis", 3000)),
+            )
+            for endpoint in endpoint_configs
+            if isinstance(endpoint, dict)
+        ]
+    return AtofConfig(
+        enabled=bool(value.get("enabled", False)),
+        output_directory=value.get("output_directory"),
+        filename=value.get("filename"),
+        mode=value.get("mode", "append"),
+        endpoints=endpoints,
+    )
+
+
+def _relay_api_atif_config(value: Any) -> AtifConfig | None:
+    if not isinstance(value, dict):
+        return None
+    from nemo_relay.observability import AtifConfig
+
+    storage_configs = value.get("storage")
+    storage = None
+    if isinstance(storage_configs, list):
+        storage = [
+            _relay_api_storage_config(item)
+            for item in storage_configs
+            if isinstance(item, dict)
+        ]
+    return AtifConfig(
+        enabled=bool(value.get("enabled", False)),
+        agent_name=value.get("agent_name", "NeMo Relay"),
+        agent_version=value.get("agent_version"),
+        model_name=value.get("model_name", "unknown"),
+        tool_definitions=value.get("tool_definitions"),
+        extra=value.get("extra"),
+        output_directory=value.get("output_directory"),
+        filename_template=value.get("filename_template", "nemo-relay-atif-{session_id}.json"),
+        storage=storage,
+    )
+
+
+def _relay_api_storage_config(value: dict[str, Any]) -> HttpStorageConfig | S3StorageConfig:
+    if value.get("type") == "s3":
+        from nemo_relay.observability import S3StorageConfig
+
+        return S3StorageConfig(
+            bucket=value.get("bucket", ""),
+            key_prefix=value.get("key_prefix"),
+            access_key_id=value.get("access_key_id"),
+            secret_access_key_var=value.get("secret_access_key_var"),
+            session_token_var=value.get("session_token_var"),
+            region=value.get("region"),
+            endpoint_url=value.get("endpoint_url"),
+            allow_http=value.get("allow_http"),
+        )
+    from nemo_relay.observability import HttpStorageConfig
+
+    return HttpStorageConfig(
+        endpoint=value.get("endpoint", ""),
+        headers=value.get("headers", {}),
+        header_env=value.get("header_env", {}),
+        timeout_millis=int(value.get("timeout_millis", 3000)),
+    )
+
+
+def _relay_api_otlp_config(value: Any) -> OtlpConfig | None:
+    if not isinstance(value, dict):
+        return None
+    from nemo_relay.observability import OtlpConfig
+
+    return OtlpConfig(
+        enabled=bool(value.get("enabled", False)),
+        transport=value.get("transport", "http_binary"),
+        endpoint=value.get("endpoint"),
+        headers=value.get("headers", {}),
+        resource_attributes=value.get("resource_attributes", {}),
+        service_name=value.get("service_name", "nemo-relay"),
+        service_namespace=value.get("service_namespace"),
+        service_version=value.get("service_version"),
+        instrumentation_scope=value.get("instrumentation_scope"),
+        timeout_millis=int(value.get("timeout_millis", 3000)),
+    )
 
 
 def _invoke_hermes(

--- a/adapters/hermes-sdk/src/nemo_fabric_adapters/hermes_sdk/adapter.py
+++ b/adapters/hermes-sdk/src/nemo_fabric_adapters/hermes_sdk/adapter.py
@@ -26,6 +26,7 @@ if COMMON_DIR not in sys.path:
     sys.path.append(COMMON_DIR)
 
 import nemo_fabric_adapters.common.hermes as hermes_common  # noqa: E402
+import nemo_fabric_adapters.common.utils as common_utils  # noqa: E402
 
 
 def main() -> None:
@@ -44,7 +45,7 @@ def run(payload: dict[str, Any]) -> dict[str, Any]:
 
 def resolve_hermes_toolsets(settings: dict[str, Any], config: dict[str, Any]) -> list[str] | None:
     if "enabled_toolsets" in settings:
-        return hermes_common.normalize_list(settings.get("enabled_toolsets"))
+        return common_utils.normalize_list(settings.get("enabled_toolsets"))
 
     from hermes_cli.tools_config import _get_platform_tools
 
@@ -69,10 +70,10 @@ def load_runtime_history(session_db: Any, session_id: str | None) -> list[dict[s
 
 
 def run_hermes_sdk(payload: dict[str, Any]) -> dict[str, Any]:
-    settings = hermes_common.settings_payload(payload)
+    settings = common_utils.settings_payload(payload)
     request = hermes_common.request_payload(payload)
     model_config = hermes_common.selected_model_config(payload)
-    hermes_home = Path(hermes_common.config_root(payload)).joinpath(
+    hermes_home = Path(common_utils.config_root(payload)).joinpath(
         settings.get("hermes_home", "./artifacts/hermes-home")
     )
     hermes_home.mkdir(parents=True, exist_ok=True)
@@ -88,8 +89,6 @@ def run_hermes_sdk(payload: dict[str, Any]) -> dict[str, Any]:
         payload,
         hermes_home,
         relay_enabled=relay_plugin_config is not None,
-        require_yaml=True,
-        missing_yaml_message="Hermes SDK mode requires PyYAML to write Hermes config",
     )
 
     api_key_env = settings.get("api_key_env") or model_config.get("api_key_env") or "NVIDIA_API_KEY"
@@ -158,7 +157,7 @@ def run_hermes_sdk(payload: dict[str, Any]) -> dict[str, Any]:
                     model=getattr(agent, "model", None) or hermes_common.relay_model_name(payload),
                     platform=getattr(agent, "platform", None) or "fabric",
                 )
-                relay_artifacts = hermes_common.collect_relay_artifacts(relay_plugin_config)
+                relay_artifacts = common_utils.collect_relay_artifacts(relay_plugin_config)
     response = result.get("response") or result.get("final_response")
     messages = result.get("messages") or []
     output = {

--- a/adapters/hermes-sdk/src/nemo_fabric_adapters/hermes_sdk/adapter.py
+++ b/adapters/hermes-sdk/src/nemo_fabric_adapters/hermes_sdk/adapter.py
@@ -10,6 +10,7 @@ surface and invokes the installed Hermes runtime.
 
 from __future__ import annotations
 
+import asyncio
 import inspect
 import json
 import os
@@ -40,7 +41,7 @@ def main() -> None:
 def run(payload: dict[str, Any]) -> dict[str, Any]:
     """Fabric adapter entrypoint used by script and native SDK runtime calls."""
 
-    return run_hermes_sdk(payload)
+    return asyncio.run(run_hermes_sdk(payload))
 
 
 def resolve_hermes_toolsets(settings: dict[str, Any], config: dict[str, Any]) -> list[str] | None:
@@ -69,7 +70,7 @@ def load_runtime_history(session_db: Any, session_id: str | None) -> list[dict[s
     return messages or None
 
 
-def run_hermes_sdk(payload: dict[str, Any]) -> dict[str, Any]:
+async def run_hermes_sdk(payload: dict[str, Any]) -> dict[str, Any]:
     settings = common_utils.settings_payload(payload)
     request = hermes_common.request_payload(payload)
     model_config = hermes_common.selected_model_config(payload)

--- a/adapters/hermes-sdk/src/nemo_fabric_adapters/hermes_sdk/adapter.py
+++ b/adapters/hermes-sdk/src/nemo_fabric_adapters/hermes_sdk/adapter.py
@@ -18,17 +18,7 @@ import sys
 from contextlib import redirect_stdout
 from io import StringIO
 from pathlib import Path
-from typing import Any, TYPE_CHECKING
-
-if TYPE_CHECKING:
-    from nemo_relay import plugin
-    from nemo_relay.observability import (
-        AtifConfig,
-        AtofConfig,
-        HttpStorageConfig,
-        OtlpConfig,
-        S3StorageConfig,
-    )
+from typing import Any
 
 CUR_DIR = Path(__file__).parent
 ADAPTERS_DIR = CUR_DIR.parent.parent.parent.parent
@@ -127,7 +117,7 @@ async def run_hermes_sdk(payload: dict[str, Any]) -> dict[str, Any]:
         "relay_plugin_config": relay_plugin_config,
     }
     if relay_enabled:
-        relay_api_config = _relay_api_plugin_config(relay_plugin_config or {})
+        relay_api_config = common_utils._relay_api_plugin_config(relay_plugin_config or {})
         from nemo_relay import plugin
 
         async with plugin.plugin(relay_api_config):
@@ -166,158 +156,6 @@ async def run_hermes_sdk(payload: dict[str, Any]) -> dict[str, Any]:
         }
         output["relay_artifacts"] = relay_artifacts
     return output
-
-
-def _relay_api_plugin_config(plugin_config: dict[str, Any]) -> plugin.PluginConfig:
-    from nemo_relay import plugin
-    from nemo_relay.observability import (
-        ComponentSpec,
-        ConfigPolicy,
-        ObservabilityConfig,
-    )
-
-    components: list[Any] = []
-    for component in plugin_config.get("components", []):
-        if not isinstance(component, dict):
-            continue
-        enabled = bool(component.get("enabled", True))
-        config = component.get("config") or {}
-        if component.get("kind") == "observability" and isinstance(config, dict):
-            policy = config.get("policy") if isinstance(config.get("policy"), dict) else {}
-            components.append(
-                ComponentSpec(
-                    ObservabilityConfig(
-                        version=int(config.get("version", 1)),
-                        atof=_relay_api_atof_config(config.get("atof")),
-                        atif=_relay_api_atif_config(
-                            config.get("atif"),
-                        ),
-                        opentelemetry=_relay_api_otlp_config(config.get("opentelemetry")),
-                        openinference=_relay_api_otlp_config(config.get("openinference")),
-                        policy=ConfigPolicy(
-                            unknown_component=policy.get("unknown_component", "warn"),
-                            unknown_field=policy.get("unknown_field", "warn"),
-                            unsupported_value=policy.get("unsupported_value", "error"),
-                        ),
-                    ),
-                    enabled=enabled,
-                )
-            )
-            continue
-        components.append(
-            plugin.ComponentSpec(
-                kind=str(component.get("kind") or ""),
-                enabled=enabled,
-                config=config if isinstance(config, dict) else {},
-            )
-        )
-
-    policy = plugin_config.get("policy") if isinstance(plugin_config.get("policy"), dict) else {}
-    return plugin.PluginConfig(
-        version=int(plugin_config.get("version", 1)),
-        components=components,
-        policy=plugin.ConfigPolicy(
-            unknown_component=policy.get("unknown_component", "warn"),
-            unknown_field=policy.get("unknown_field", "warn"),
-            unsupported_value=policy.get("unsupported_value", "error"),
-        ),
-    )
-
-
-def _relay_api_atof_config(value: Any) -> AtofConfig | None:
-    if not isinstance(value, dict):
-        return None
-    from nemo_relay.observability import AtofConfig, AtofEndpointConfig
-
-    endpoint_configs = value.get("endpoints")
-    endpoints = None
-    if isinstance(endpoint_configs, list):
-        endpoints = [
-            AtofEndpointConfig(
-                url=str(endpoint.get("url", "")),
-                transport=endpoint.get("transport", "http_post"),
-                headers=endpoint.get("headers", {}),
-                timeout_millis=int(endpoint.get("timeout_millis", 3000)),
-            )
-            for endpoint in endpoint_configs
-            if isinstance(endpoint, dict)
-        ]
-    return AtofConfig(
-        enabled=bool(value.get("enabled", False)),
-        output_directory=value.get("output_directory"),
-        filename=value.get("filename"),
-        mode=value.get("mode", "append"),
-        endpoints=endpoints,
-    )
-
-
-def _relay_api_atif_config(value: Any) -> AtifConfig | None:
-    if not isinstance(value, dict):
-        return None
-    from nemo_relay.observability import AtifConfig
-
-    storage_configs = value.get("storage")
-    storage = None
-    if isinstance(storage_configs, list):
-        storage = [
-            _relay_api_storage_config(item)
-            for item in storage_configs
-            if isinstance(item, dict)
-        ]
-    return AtifConfig(
-        enabled=bool(value.get("enabled", False)),
-        agent_name=value.get("agent_name", "NeMo Relay"),
-        agent_version=value.get("agent_version"),
-        model_name=value.get("model_name", "unknown"),
-        tool_definitions=value.get("tool_definitions"),
-        extra=value.get("extra"),
-        output_directory=value.get("output_directory"),
-        filename_template=value.get("filename_template", "nemo-relay-atif-{session_id}.json"),
-        storage=storage,
-    )
-
-
-def _relay_api_storage_config(value: dict[str, Any]) -> HttpStorageConfig | S3StorageConfig:
-    if value.get("type") == "s3":
-        from nemo_relay.observability import S3StorageConfig
-
-        return S3StorageConfig(
-            bucket=value.get("bucket", ""),
-            key_prefix=value.get("key_prefix"),
-            access_key_id=value.get("access_key_id"),
-            secret_access_key_var=value.get("secret_access_key_var"),
-            session_token_var=value.get("session_token_var"),
-            region=value.get("region"),
-            endpoint_url=value.get("endpoint_url"),
-            allow_http=value.get("allow_http"),
-        )
-    from nemo_relay.observability import HttpStorageConfig
-
-    return HttpStorageConfig(
-        endpoint=value.get("endpoint", ""),
-        headers=value.get("headers", {}),
-        header_env=value.get("header_env", {}),
-        timeout_millis=int(value.get("timeout_millis", 3000)),
-    )
-
-
-def _relay_api_otlp_config(value: Any) -> OtlpConfig | None:
-    if not isinstance(value, dict):
-        return None
-    from nemo_relay.observability import OtlpConfig
-
-    return OtlpConfig(
-        enabled=bool(value.get("enabled", False)),
-        transport=value.get("transport", "http_binary"),
-        endpoint=value.get("endpoint"),
-        headers=value.get("headers", {}),
-        resource_attributes=value.get("resource_attributes", {}),
-        service_name=value.get("service_name", "nemo-relay"),
-        service_namespace=value.get("service_namespace"),
-        service_version=value.get("service_version"),
-        instrumentation_scope=value.get("instrumentation_scope"),
-        timeout_millis=int(value.get("timeout_millis", 3000)),
-    )
 
 
 def _invoke_hermes(

--- a/examples/code-review-agent/profiles/hermes-cli-relay-otel.yaml
+++ b/examples/code-review-agent/profiles/hermes-cli-relay-otel.yaml
@@ -1,0 +1,68 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+schema_version: fabric.profile/v1alpha1
+name: hermes_cli_relay_otel
+description: Run Hermes CLI with native NeMo Relay OpenTelemetry tracing enabled.
+
+harness:
+  adapter_id: nvidia.fabric.hermes.cli
+  resolution: preinstalled
+  settings:
+    python_env: HERMES_PYTHON
+    workspace: ./repos/my-service
+    hermes_home: ./artifacts/hermes-cli-relay-otel/home
+    base_url: https://integrate.api.nvidia.com/v1
+    max_iterations: 1
+    max_tokens: 512
+    temperature: 0.0
+    reasoning_config:
+      effort: none
+    enabled_toolsets: []
+    system_prompt: You are a concise smoke test assistant.
+
+runtime:
+  mode: oneshot
+  transport: cli
+  input_schema: chat
+  output_schema: message
+  artifacts: ./artifacts/hermes-cli-relay-otel
+
+environment:
+  provider: local
+  workspace: ./repos/my-service
+  artifacts: ./artifacts/hermes-cli-relay-otel
+
+telemetry:
+  enabled: true
+  mode: sdk
+  output_dir: ./artifacts/hermes-cli-relay-otel/relay
+  config:
+    version: 1
+    components:
+      - kind: observability
+        enabled: true
+        config:
+          version: 1
+          atif:
+            enabled: true
+            output_directory: ./artifacts/hermes-cli-relay-otel/relay
+            filename_template: "trajectory-{session_id}.atif.json"
+            agent_name: code-review-agent
+            agent_version: fabric-poc
+          atof:
+            enabled: true
+            output_directory: ./artifacts/hermes-cli-relay-otel/relay
+            filename: events.atof.jsonl
+            mode: overwrite
+          opentelemetry:
+            enabled: true
+            transport: http_binary
+            endpoint: http://localhost:4318/v1/traces
+            service_name: code-review-agent
+            service_namespace: fabric
+            service_version: fabric-poc
+            instrumentation_scope: nemo-relay-otel
+            timeout_millis: 3000
+            resource_attributes:
+              deployment.environment: dev

--- a/examples/code-review-agent/profiles/hermes-relay-cli-openinference.yaml
+++ b/examples/code-review-agent/profiles/hermes-relay-cli-openinference.yaml
@@ -1,0 +1,61 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+schema_version: fabric.profile/v1alpha1
+name: hermes_relay_cli_openinference
+description: Run Hermes CLI with native NeMo Relay OpenInference tracing enabled.
+
+harness:
+  adapter_id: nvidia.fabric.hermes.cli
+  resolution: preinstalled
+  settings:
+    python_env: HERMES_PYTHON
+    workspace: ./repos/my-service
+    hermes_home: ./artifacts/hermes-relay-cli-openinference/home
+    base_url: https://integrate.api.nvidia.com/v1
+    max_iterations: 1
+    max_tokens: 512
+    temperature: 0.0
+    reasoning_config:
+      effort: none
+    enabled_toolsets: []
+    system_prompt: You are a concise smoke test assistant.
+
+runtime:
+  mode: oneshot
+  transport: cli
+  input_schema: chat
+  output_schema: message
+  artifacts: ./artifacts/hermes-relay-cli-openinference
+
+environment:
+  provider: local
+  workspace: ./repos/my-service
+  artifacts: ./artifacts/hermes-relay-cli-openinference
+
+telemetry:
+  enabled: true
+  mode: sdk
+  output_dir: ./artifacts/hermes-relay-cli-openinference/relay
+  config:
+    version: 1
+    components:
+      - kind: observability
+        enabled: true
+        config:
+          version: 1
+          atif:
+            enabled: true
+            output_directory: ./artifacts/hermes-relay-cli-openinference/relay
+            filename_template: "trajectory-{session_id}.atif.json"
+            agent_name: code-review-agent
+            agent_version: fabric-poc
+          atof:
+            enabled: true
+            output_directory: ./artifacts/hermes-relay-cli-openinference/relay
+            filename: events.atof.jsonl
+            mode: overwrite
+          openinference:
+            enabled: true
+            transport: http_binary
+            endpoint: http://localhost:6006/v1/traces

--- a/examples/code-review-agent/profiles/hermes-relay-openinference.yaml
+++ b/examples/code-review-agent/profiles/hermes-relay-openinference.yaml
@@ -1,0 +1,61 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+schema_version: fabric.profile/v1alpha1
+name: hermes_relay_openinference
+description: Run Hermes SDK with native NeMo Relay OpenInference tracing enabled.
+
+harness:
+  adapter_id: nvidia.fabric.hermes.sdk
+  resolution: preinstalled
+  settings:
+    python_env: HERMES_PYTHON
+    workspace: ./repos/my-service
+    hermes_home: ./artifacts/hermes-relay-openinference/home
+    base_url: https://integrate.api.nvidia.com/v1
+    max_iterations: 1
+    max_tokens: 512
+    temperature: 0.0
+    reasoning_config:
+      effort: none
+    enabled_toolsets: []
+    system_prompt: You are a concise smoke test assistant.
+
+runtime:
+  mode: oneshot
+  transport: library
+  input_schema: chat
+  output_schema: message
+  artifacts: ./artifacts/hermes-relay-openinference
+
+environment:
+  provider: local
+  workspace: ./repos/my-service
+  artifacts: ./artifacts/hermes-relay-openinference
+
+telemetry:
+  enabled: true
+  mode: sdk
+  output_dir: ./artifacts/hermes-relay-openinference/relay
+  config:
+    version: 1
+    components:
+      - kind: observability
+        enabled: true
+        config:
+          version: 1
+          atif:
+            enabled: true
+            output_directory: ./artifacts/hermes-relay-openinference/relay
+            filename_template: "trajectory-{session_id}.atif.json"
+            agent_name: code-review-agent
+            agent_version: fabric-poc
+          atof:
+            enabled: true
+            output_directory: ./artifacts/hermes-relay-openinference/relay
+            filename: events.atof.jsonl
+            mode: overwrite
+          openinference:
+            enabled: true
+            transport: http_binary
+            endpoint: http://localhost:6006/v1/traces

--- a/examples/code-review-agent/profiles/hermes-relay-otel.yaml
+++ b/examples/code-review-agent/profiles/hermes-relay-otel.yaml
@@ -1,0 +1,68 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+schema_version: fabric.profile/v1alpha1
+name: hermes_relay_otel
+description: Run Hermes SDK with native NeMo Relay OpenTelemetry tracing enabled.
+
+harness:
+  adapter_id: nvidia.fabric.hermes.sdk
+  resolution: preinstalled
+  settings:
+    python_env: HERMES_PYTHON
+    workspace: ./repos/my-service
+    hermes_home: ./artifacts/hermes-relay-otel/home
+    base_url: https://integrate.api.nvidia.com/v1
+    max_iterations: 1
+    max_tokens: 512
+    temperature: 0.0
+    reasoning_config:
+      effort: none
+    enabled_toolsets: []
+    system_prompt: You are a concise smoke test assistant.
+
+runtime:
+  mode: oneshot
+  transport: library
+  input_schema: chat
+  output_schema: message
+  artifacts: ./artifacts/hermes-relay-otel
+
+environment:
+  provider: local
+  workspace: ./repos/my-service
+  artifacts: ./artifacts/hermes-relay-otel
+
+telemetry:
+  enabled: true
+  mode: sdk
+  output_dir: ./artifacts/hermes-relay-otel/relay
+  config:
+    version: 1
+    components:
+      - kind: observability
+        enabled: true
+        config:
+          version: 1
+          atif:
+            enabled: true
+            output_directory: ./artifacts/hermes-relay-otel/relay
+            filename_template: "trajectory-{session_id}.atif.json"
+            agent_name: code-review-agent
+            agent_version: fabric-poc
+          atof:
+            enabled: true
+            output_directory: ./artifacts/hermes-relay-otel/relay
+            filename: events.atof.jsonl
+            mode: overwrite
+          opentelemetry:
+            enabled: true
+            transport: http_binary
+            endpoint: http://localhost:4318/v1/traces
+            service_name: code-review-agent
+            service_namespace: fabric
+            service_version: fabric-poc
+            instrumentation_scope: nemo-relay-otel
+            timeout_millis: 3000
+            resource_attributes:
+              deployment.environment: dev

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,8 +14,16 @@ dependencies = []
 
 [project.optional-dependencies]
 harbor = ["harbor>=0.13.2; python_version >= '3.12'"]
-hermes = ["hermes-agent>=0.17.0; python_version >= '3.11' and python_version < '3.14'"]
-relay = ["nemo-relay~=0.4; python_version >= '3.11'"]
+
+hermes = [
+  "hermes-agent>=0.17.0; python_version >= '3.11' and python_version < '3.14'",
+  "pyyaml>=6.0", # needed by adapters to write hermes config files
+]
+
+relay = [
+  "nemo-relay~=0.4; python_version >= '3.11'",
+  "tomli-w~=1.2", # Needed by adapters to write relay config files
+]
 
 [dependency-groups]
 dev = [

--- a/tests/fixtures/hermes-cli-agent/bin/fake-hermes.py
+++ b/tests/fixtures/hermes-cli-agent/bin/fake-hermes.py
@@ -14,10 +14,10 @@ from pathlib import Path
 
 def main() -> int:
     args = sys.argv[1:]
-    if "-z" not in args:
-        print("fake hermes expected -z", file=sys.stderr)
+    if "--query" not in args:
+        print("fake hermes expected --query", file=sys.stderr)
         return 2
-    prompt = args[args.index("-z") + 1]
+    prompt = args[args.index("--query") + 1]
     hermes_home = os.environ.get("HERMES_HOME", "")
     config_path = Path(hermes_home) / "config.yaml"
     if not config_path.is_file():

--- a/tests/smoke_hermes_cli.py
+++ b/tests/smoke_hermes_cli.py
@@ -40,7 +40,9 @@ def main() -> None:
         response = json.loads(result["output"]["response"])
         assert response["fake_hermes"] is True
         assert response["prompt"] == "hello cli"
-        assert "-z" in response["argv"]
+        assert "chat" in response["argv"]
+        assert "--quiet" in response["argv"]
+        assert "--query" in response["argv"]
         assert "--model" in response["argv"]
         assert "test-model" in response["argv"]
 

--- a/tests/smoke_hermes_config_mapping.py
+++ b/tests/smoke_hermes_config_mapping.py
@@ -5,20 +5,20 @@
 
 from __future__ import annotations
 
-import importlib.util
+import sys
 import tempfile
 from pathlib import Path
 
 import yaml
 
 ROOT = Path(__file__).resolve().parents[1]
-ADAPTERS_COMMON = ROOT / "adapters" / "common" / "src" / "nemo_fabric_adapters" / "common" / "hermes.py"
+ADAPTERS_COMMON_SRC = ROOT / "adapters" / "common" / "src"
 
 def main() -> None:
-    common = load_common()
+    hermes_common, _common_utils = load_common()
     with tempfile.TemporaryDirectory(prefix="fabric-hermes-config-") as tmpdir:
         hermes_home = Path(tmpdir) / "home"
-        config_path, config = common.write_hermes_config(
+        config_path, config = hermes_common.write_hermes_config(
             payload(tmpdir),
             hermes_home,
             relay_enabled=True,
@@ -46,15 +46,15 @@ def main() -> None:
     assert config["platform_toolsets"]["cli"] == []
     assert config["plugins"]["enabled"] == ["observability/nemo_relay"]
 
-def _load_module_from_path(name:str, path: Path):
-    spec = importlib.util.spec_from_file_location(name, path)
-    assert spec and spec.loader
-    module = importlib.util.module_from_spec(spec)
-    spec.loader.exec_module(module)
-    return module
-
 def load_common():
-    return _load_module_from_path("fabric_hermes_common", ADAPTERS_COMMON)
+    common_src = ADAPTERS_COMMON_SRC.as_posix()
+    if common_src not in sys.path:
+        sys.path.insert(0, common_src)
+
+    import nemo_fabric_adapters.common.hermes as hermes_common
+    import nemo_fabric_adapters.common.utils as common_utils
+
+    return hermes_common, common_utils
 
 
 def payload(tmpdir: str) -> dict:

--- a/tests/test_adapaters_common_hermes.py
+++ b/tests/test_adapaters_common_hermes.py
@@ -1,7 +1,6 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-import builtins
 import json
 import os
 import types
@@ -10,49 +9,9 @@ from pathlib import Path
 import pytest
 
 
-@pytest.fixture(name="common_utils", scope="session")
-def common_utils_fixture(adapters_common: str) -> types.ModuleType:
-    import nemo_fabric_adapters.common.utils as common_utils  # noqa: E402
-
-    return common_utils
-
-
-def test_payload_accessors_prefer_effective_config(
-    common_utils: types.ModuleType,
-    hermes_common: types.ModuleType,
-) -> None:
-    payload = {
-        "agent_name": "outer-agent",
-        "config_root": "/outer",
-        "request": {"input": "hello"},
-        "environment": {"workspace": "/outer-workspace"},
-        "settings": {"outer": True},
-        "models": {"outer": {"model": "outer-model"}},
-        "capabilities": {"outer": True},
-        "runtime_context": {
-            "environment": {"workspace": "/runtime-workspace"},
-        },
-        "effective_config": {
-            "agent_name": "effective-agent",
-            "config_root": "/effective",
-            "config": {
-                "harness": {"settings": {"inner": True}},
-                "models": {"inner": {"model": "inner-model"}},
-            },
-        },
-        "capability_plan": {"native": {"skill_paths": ["skills"]}},
-    }
-
-    assert common_utils.effective_config(payload) == payload["effective_config"]
-    assert common_utils.fabric_config(payload) == payload["effective_config"]["config"]
-    assert common_utils.agent_name(payload) == "effective-agent"
-    assert common_utils.config_root(payload) == "/effective"
-    assert common_utils.runtime_context(payload) == payload["runtime_context"]
-    assert hermes_common.request_payload(payload) == {"input": "hello"}
-    assert common_utils.environment_payload(payload) == {"workspace": "/runtime-workspace"}
-    assert common_utils.settings_payload(payload) == {"inner": True}
-    assert common_utils.models_payload(payload) == {"inner": {"model": "inner-model"}}
-    assert common_utils.capability_plan(payload) == {"native": {"skill_paths": ["skills"]}}
+def test_request_payload(hermes_common: types.ModuleType):
+    assert hermes_common.request_payload({"request": {"input": "hello"}}) == {"input": "hello"}
+    assert hermes_common.request_payload({}) == {}
 
 
 @pytest.mark.parametrize(
@@ -227,26 +186,6 @@ def test_write_hermes_config_writes_file(hermes_common: types.ModuleType, tmp_pa
     assert "nvidia/test-model" in config_path.read_text(encoding="utf-8")
 
 
-def test_dump_yaml_falls_back_to_json_when_yaml_is_unavailable(
-    common_utils: types.ModuleType,
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    real_import = builtins.__import__
-
-    def fake_import(name: str, *args: object, **kwargs: object) -> object:
-        if name == "yaml":
-            raise ImportError("No module named yaml")
-        return real_import(name, *args, **kwargs)
-
-    monkeypatch.setattr(builtins, "__import__", fake_import)
-
-    assert common_utils.dump_yaml({"model": {"default": "demo"}}) == json.dumps(
-        {"model": {"default": "demo"}},
-        indent=2,
-        sort_keys=False,
-    ) + "\n"
-
-
 @pytest.mark.parametrize(
     ("server", "expected"),
     [
@@ -276,19 +215,6 @@ def test_hermes_mcp_server_config(
     assert hermes_common.hermes_mcp_server_config(server) == expected
 
 
-@pytest.mark.parametrize(
-    ("value", "expected"),
-    [
-        (None, []),
-        ("git", ["git"]),
-        (["git", 7, ""], ["git", "7"]),
-        (42, ["42"]),
-    ],
-)
-def test_normalize_list(common_utils: types.ModuleType, value: object, expected: list[str]) -> None:
-    assert common_utils.normalize_list(value) == expected
-
-
 def test_without_none(hermes_common: types.ModuleType) -> None:
     assert hermes_common.without_none({"a": 1, "b": None, "c": False}) == {"a": 1, "c": False}
 
@@ -311,54 +237,6 @@ def test_summarize_hermes_config(hermes_common: types.ModuleType) -> None:
         "plugins": ["observability/nemo_relay"],
         "platform_toolsets": {"cli": ["git"]},
     }
-
-
-def test_load_relay_plugin_config_wraps_and_normalizes_bare_observability_config(
-    common_utils: types.ModuleType,
-    monkeypatch: pytest.MonkeyPatch,
-    tmp_path: Path,
-) -> None:
-    config_path = tmp_path / "relay.json"
-    config_path.write_text(
-        json.dumps(
-            {
-                "relay": {
-                    "config": {
-                        "atof": {
-                            "enabled": True,
-                            "output_directory": "custom-relay",
-                        },
-                        "atif": {"enabled": True},
-                    }
-                }
-            }
-        ),
-        encoding="utf-8",
-    )
-    monkeypatch.setenv("FABRIC_RELAY_CONFIG_PATH", str(config_path))
-    payload = {
-        "effective_config": {
-            "agent_name": "review-agent",
-            "config_root": str(tmp_path),
-            "config": {
-                "harness": {"settings": {"model": "review"}},
-                "models": {"review": {"model": "nvidia/review-model"}},
-            },
-        }
-    }
-
-    plugin_config = common_utils.load_relay_plugin_config(payload)
-    observability = plugin_config["components"][0]["config"]
-
-    assert plugin_config["version"] == 1
-    assert plugin_config["components"][0]["kind"] == "observability"
-    assert observability["atof"]["output_directory"] == str(tmp_path / "custom-relay")
-    assert observability["atof"]["filename"] == "events.atof.jsonl"
-    assert observability["atof"]["mode"] == "overwrite"
-    assert observability["atif"]["output_directory"] == str(tmp_path / "artifacts" / "relay")
-    assert observability["atif"]["filename_template"] == "trajectory-{session_id}.atif.json"
-    assert observability["atif"]["agent_name"] == "review-agent"
-    assert observability["atif"]["model_name"] == "nvidia/review-model"
 
 
 def test_configure_hermes_relay_sets_hermes_plugin_environment(
@@ -434,32 +312,3 @@ def test_configure_hermes_relay_returns_none_when_disabled(
     monkeypatch.delenv("FABRIC_RELAY_ENABLED", raising=False)
 
     assert hermes_common.configure_hermes_relay({}) is None
-
-
-def test_collect_relay_artifacts(common_utils: types.ModuleType, tmp_path: Path) -> None:
-    atof_dir = tmp_path / "atof"
-    atif_dir = tmp_path / "atif"
-    atof_dir.mkdir()
-    atif_dir.mkdir()
-    atof_file = atof_dir / "events.atof.jsonl"
-    atif_file = atif_dir / "trajectory-1.atif.json"
-    ignored_file = atif_dir / "ignored.txt"
-    atof_file.write_text("{}", encoding="utf-8")
-    atif_file.write_text("{}", encoding="utf-8")
-    ignored_file.write_text("ignored", encoding="utf-8")
-    plugin_config = {
-        "components": [
-            {
-                "kind": "observability",
-                "config": {
-                    "atof": {"enabled": True, "output_directory": str(atof_dir)},
-                    "atif": {"enabled": True, "output_directory": str(atif_dir)},
-                },
-            }
-        ]
-    }
-
-    assert common_utils.collect_relay_artifacts(plugin_config) == [
-        {"kind": "atof", "path": str(atof_file)},
-        {"kind": "atif", "path": str(atif_file)},
-    ]

--- a/tests/test_adapaters_common_utils.py
+++ b/tests/test_adapaters_common_utils.py
@@ -1,0 +1,160 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+import builtins
+import json
+import types
+from pathlib import Path
+
+import pytest
+
+
+@pytest.fixture(name="common_utils", scope="session")
+def common_utils_fixture(adapters_common: str) -> types.ModuleType:
+    import nemo_fabric_adapters.common.utils as common_utils  # noqa: E402
+
+    return common_utils
+
+
+def test_payload_accessors_prefer_effective_config(common_utils: types.ModuleType):
+    payload = {
+        "agent_name": "outer-agent",
+        "config_root": "/outer",
+        "request": {"input": "hello"},
+        "environment": {"workspace": "/outer-workspace"},
+        "settings": {"outer": True},
+        "models": {"outer": {"model": "outer-model"}},
+        "capabilities": {"outer": True},
+        "runtime_context": {
+            "environment": {"workspace": "/runtime-workspace"},
+        },
+        "effective_config": {
+            "agent_name": "effective-agent",
+            "config_root": "/effective",
+            "config": {
+                "harness": {"settings": {"inner": True}},
+                "models": {"inner": {"model": "inner-model"}},
+            },
+        },
+        "capability_plan": {"native": {"skill_paths": ["skills"]}},
+    }
+
+    assert common_utils.effective_config(payload) == payload["effective_config"]
+    assert common_utils.fabric_config(payload) == payload["effective_config"]["config"]
+    assert common_utils.agent_name(payload) == "effective-agent"
+    assert common_utils.config_root(payload) == "/effective"
+    assert common_utils.runtime_context(payload) == payload["runtime_context"]
+    assert common_utils.environment_payload(payload) == {"workspace": "/runtime-workspace"}
+    assert common_utils.settings_payload(payload) == {"inner": True}
+    assert common_utils.models_payload(payload) == {"inner": {"model": "inner-model"}}
+    assert common_utils.capability_plan(payload) == {"native": {"skill_paths": ["skills"]}}
+
+
+def test_dump_yaml_falls_back_to_json_when_yaml_is_unavailable(
+    common_utils: types.ModuleType,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    real_import = builtins.__import__
+
+    def fake_import(name: str, *args: object, **kwargs: object) -> object:
+        if name == "yaml":
+            raise ImportError("No module named yaml")
+        return real_import(name, *args, **kwargs)
+
+    monkeypatch.setattr(builtins, "__import__", fake_import)
+
+    assert common_utils.dump_yaml({"model": {"default": "demo"}}) == json.dumps(
+        {"model": {"default": "demo"}},
+        indent=2,
+        sort_keys=False,
+    ) + "\n"
+
+
+@pytest.mark.parametrize(
+    ("value", "expected"),
+    [
+        (None, []),
+        ("git", ["git"]),
+        (["git", 7, ""], ["git", "7"]),
+        (42, ["42"]),
+    ],
+)
+def test_normalize_list(common_utils: types.ModuleType, value: object, expected: list[str]):
+    assert common_utils.normalize_list(value) == expected
+
+
+def test_load_relay_plugin_config_wraps_and_normalizes_bare_observability_config(
+    common_utils: types.ModuleType,
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+):
+    config_path = tmp_path / "relay.json"
+    config_path.write_text(
+        json.dumps(
+            {
+                "relay": {
+                    "config": {
+                        "atof": {
+                            "enabled": True,
+                            "output_directory": "custom-relay",
+                        },
+                        "atif": {"enabled": True},
+                    }
+                }
+            }
+        ),
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("FABRIC_RELAY_CONFIG_PATH", str(config_path))
+    payload = {
+        "effective_config": {
+            "agent_name": "review-agent",
+            "config_root": str(tmp_path),
+            "config": {
+                "harness": {"settings": {"model": "review"}},
+                "models": {"review": {"model": "nvidia/review-model"}},
+            },
+        }
+    }
+
+    plugin_config = common_utils.load_relay_plugin_config(payload)
+    observability = plugin_config["components"][0]["config"]
+
+    assert plugin_config["version"] == 1
+    assert plugin_config["components"][0]["kind"] == "observability"
+    assert observability["atof"]["output_directory"] == str(tmp_path / "custom-relay")
+    assert observability["atof"]["filename"] == "events.atof.jsonl"
+    assert observability["atof"]["mode"] == "overwrite"
+    assert observability["atif"]["output_directory"] == str(tmp_path / "artifacts" / "relay")
+    assert observability["atif"]["filename_template"] == "trajectory-{session_id}.atif.json"
+    assert observability["atif"]["agent_name"] == "review-agent"
+    assert observability["atif"]["model_name"] == "nvidia/review-model"
+
+
+def test_collect_relay_artifacts(common_utils: types.ModuleType, tmp_path: Path):
+    atof_dir = tmp_path / "atof"
+    atif_dir = tmp_path / "atif"
+    atof_dir.mkdir()
+    atif_dir.mkdir()
+    atof_file = atof_dir / "events.atof.jsonl"
+    atif_file = atif_dir / "trajectory-1.atif.json"
+    ignored_file = atif_dir / "ignored.txt"
+    atof_file.write_text("{}", encoding="utf-8")
+    atif_file.write_text("{}", encoding="utf-8")
+    ignored_file.write_text("ignored", encoding="utf-8")
+    plugin_config = {
+        "components": [
+            {
+                "kind": "observability",
+                "config": {
+                    "atof": {"enabled": True, "output_directory": str(atof_dir)},
+                    "atif": {"enabled": True, "output_directory": str(atif_dir)},
+                },
+            }
+        ]
+    }
+
+    assert common_utils.collect_relay_artifacts(plugin_config) == [
+        {"kind": "atof", "path": str(atof_file)},
+        {"kind": "atif", "path": str(atif_file)},
+    ]

--- a/tests/test_adapaters_common_utils.py
+++ b/tests/test_adapaters_common_utils.py
@@ -68,12 +68,6 @@ def test_dump_yaml_falls_back_to_json_when_yaml_is_unavailable(
         indent=2,
         sort_keys=False,
     ) + "\n"
-    with pytest.raises(RuntimeError, match="Need PyYAML"):
-        common_utils.dump_yaml(
-            {"model": {"default": "demo"}},
-            require_yaml=True,
-            missing_yaml_message="Need PyYAML",
-        )
 
 
 @pytest.mark.parametrize(

--- a/tests/test_adapaters_hermes_common.py
+++ b/tests/test_adapaters_hermes_common.py
@@ -235,12 +235,6 @@ def test_dump_yaml_falls_back_to_json_when_yaml_is_unavailable(
         indent=2,
         sort_keys=False,
     ) + "\n"
-    with pytest.raises(RuntimeError, match="Need PyYAML"):
-        hermes_common.dump_yaml(
-            {"model": {"default": "demo"}},
-            require_yaml=True,
-            missing_yaml_message="Need PyYAML",
-        )
 
 
 @pytest.mark.parametrize(

--- a/tests/test_adapaters_hermes_common.py
+++ b/tests/test_adapaters_hermes_common.py
@@ -10,7 +10,17 @@ from pathlib import Path
 import pytest
 
 
-def test_payload_accessors_prefer_effective_config(hermes_common: types.ModuleType) -> None:
+@pytest.fixture(name="common_utils", scope="session")
+def common_utils_fixture(adapters_common: str) -> types.ModuleType:
+    import nemo_fabric_adapters.common.utils as common_utils  # noqa: E402
+
+    return common_utils
+
+
+def test_payload_accessors_prefer_effective_config(
+    common_utils: types.ModuleType,
+    hermes_common: types.ModuleType,
+) -> None:
     payload = {
         "agent_name": "outer-agent",
         "config_root": "/outer",
@@ -33,16 +43,16 @@ def test_payload_accessors_prefer_effective_config(hermes_common: types.ModuleTy
         "capability_plan": {"native": {"skill_paths": ["skills"]}},
     }
 
-    assert hermes_common.effective_config(payload) == payload["effective_config"]
-    assert hermes_common.fabric_config(payload) == payload["effective_config"]["config"]
-    assert hermes_common.agent_name(payload) == "effective-agent"
-    assert hermes_common.config_root(payload) == "/effective"
-    assert hermes_common.runtime_context(payload) == payload["runtime_context"]
+    assert common_utils.effective_config(payload) == payload["effective_config"]
+    assert common_utils.fabric_config(payload) == payload["effective_config"]["config"]
+    assert common_utils.agent_name(payload) == "effective-agent"
+    assert common_utils.config_root(payload) == "/effective"
+    assert common_utils.runtime_context(payload) == payload["runtime_context"]
     assert hermes_common.request_payload(payload) == {"input": "hello"}
-    assert hermes_common.environment_payload(payload) == {"workspace": "/runtime-workspace"}
-    assert hermes_common.settings_payload(payload) == {"inner": True}
-    assert hermes_common.models_payload(payload) == {"inner": {"model": "inner-model"}}
-    assert hermes_common.capability_plan(payload) == {"native": {"skill_paths": ["skills"]}}
+    assert common_utils.environment_payload(payload) == {"workspace": "/runtime-workspace"}
+    assert common_utils.settings_payload(payload) == {"inner": True}
+    assert common_utils.models_payload(payload) == {"inner": {"model": "inner-model"}}
+    assert common_utils.capability_plan(payload) == {"native": {"skill_paths": ["skills"]}}
 
 
 @pytest.mark.parametrize(
@@ -218,7 +228,7 @@ def test_write_hermes_config_writes_file(hermes_common: types.ModuleType, tmp_pa
 
 
 def test_dump_yaml_falls_back_to_json_when_yaml_is_unavailable(
-    hermes_common: types.ModuleType,
+    common_utils: types.ModuleType,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     real_import = builtins.__import__
@@ -230,7 +240,7 @@ def test_dump_yaml_falls_back_to_json_when_yaml_is_unavailable(
 
     monkeypatch.setattr(builtins, "__import__", fake_import)
 
-    assert hermes_common.dump_yaml({"model": {"default": "demo"}}) == json.dumps(
+    assert common_utils.dump_yaml({"model": {"default": "demo"}}) == json.dumps(
         {"model": {"default": "demo"}},
         indent=2,
         sort_keys=False,
@@ -275,8 +285,8 @@ def test_hermes_mcp_server_config(
         (42, ["42"]),
     ],
 )
-def test_normalize_list(hermes_common: types.ModuleType, value: object, expected: list[str]) -> None:
-    assert hermes_common.normalize_list(value) == expected
+def test_normalize_list(common_utils: types.ModuleType, value: object, expected: list[str]) -> None:
+    assert common_utils.normalize_list(value) == expected
 
 
 def test_without_none(hermes_common: types.ModuleType) -> None:
@@ -304,7 +314,7 @@ def test_summarize_hermes_config(hermes_common: types.ModuleType) -> None:
 
 
 def test_load_relay_plugin_config_wraps_and_normalizes_bare_observability_config(
-    hermes_common: types.ModuleType,
+    common_utils: types.ModuleType,
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,
 ) -> None:
@@ -337,7 +347,7 @@ def test_load_relay_plugin_config_wraps_and_normalizes_bare_observability_config
         }
     }
 
-    plugin_config = hermes_common.load_relay_plugin_config(payload)
+    plugin_config = common_utils.load_relay_plugin_config(payload)
     observability = plugin_config["components"][0]["config"]
 
     assert plugin_config["version"] == 1
@@ -426,7 +436,7 @@ def test_configure_hermes_relay_returns_none_when_disabled(
     assert hermes_common.configure_hermes_relay({}) is None
 
 
-def test_collect_relay_artifacts(hermes_common: types.ModuleType, tmp_path: Path) -> None:
+def test_collect_relay_artifacts(common_utils: types.ModuleType, tmp_path: Path) -> None:
     atof_dir = tmp_path / "atof"
     atif_dir = tmp_path / "atif"
     atof_dir.mkdir()
@@ -449,7 +459,7 @@ def test_collect_relay_artifacts(hermes_common: types.ModuleType, tmp_path: Path
         ]
     }
 
-    assert hermes_common.collect_relay_artifacts(plugin_config) == [
+    assert common_utils.collect_relay_artifacts(plugin_config) == [
         {"kind": "atof", "path": str(atof_file)},
         {"kind": "atif", "path": str(atif_file)},
     ]

--- a/tests/test_hermes_cli.py
+++ b/tests/test_hermes_cli.py
@@ -186,7 +186,7 @@ class TestHermesE2E:
             "uuid",
         }
         actual_atof_fields = set().union(*(record.keys() for record in atof_records))
-        assert len(atof_records) == 6
+        assert len(atof_records) == 7
         assert actual_atof_fields.issuperset(expected_atof_fields)
         assert all(
             record["metadata"]["model"] == "nvidia/nemotron-3-nano-30b-a3b"
@@ -197,7 +197,10 @@ class TestHermesE2E:
             atof_records[0]["name"]
             == f"hermes-session-{atof_records[0]['metadata']['session_id']}"
         )
-        assert atof_records[-1]["name"] == "hermes.session.end"
+
+        assert atof_records[-2]["name"] == "hermes.session.end"
+        assert atof_records[-1]["scope_category"] == "end"
+        assert atof_records[-1]["data"]["reason"] == "shutdown"
 
     async def test_atif_artifacts(self):
         kinds = {artifact["kind"] for artifact in self.relay_artifacts}

--- a/tests/test_hermes_cli.py
+++ b/tests/test_hermes_cli.py
@@ -122,7 +122,7 @@ class TestHermesE2E:
         assert hermes_config_path.is_file()
         assert hermes_config_path.is_relative_to(self.code_review_agent_dir)
 
-        hermes_config = yaml.safe_load(hermes_config_path.read_text())
+        hermes_config = yaml.safe_load(hermes_config_path.read_text(encoding="utf-8"))
         assert hermes_config["model"]["provider"] == "nvidia"
         assert hermes_config["model"]["default"] == "nvidia/nemotron-3-nano-30b-a3b"
         assert hermes_config["model"]["base_url"] == f"{self.api_server}/v1"
@@ -145,7 +145,7 @@ class TestHermesE2E:
         relay_config_path = Path(artifact_by_name["relay_config"]["path"]).resolve()
         assert relay_config_path.is_file()
         assert relay_config_path.is_relative_to(self.artifact_root)
-        relay_config = json.loads(relay_config_path.read_text())
+        relay_config = json.loads(relay_config_path.read_text(encoding="utf-8"))
         assert relay_config["schema_version"] == "fabric.relay/v1alpha1"
         assert relay_config["relay"]["enabled"] is True
         assert relay_config["fabric"]["profile"] == "hermes_cli_relay"

--- a/tests/test_hermes_cli.py
+++ b/tests/test_hermes_cli.py
@@ -226,6 +226,5 @@ class TestHermesE2E:
 
         last_step = steps[-1]
         assert last_step["message"] == "hermes.session.end"
-        assert last_step["extra"]["event_payload"]["completed"] is True
         assert last_step["extra"]["invocation"]["framework"] == "nemo_relay"
         assert last_step["extra"]["invocation"]["status"] == "completed"

--- a/tests/test_hermes_sdk_adapter.py
+++ b/tests/test_hermes_sdk_adapter.py
@@ -18,7 +18,7 @@ if str(HERMES_SDK_SRC) not in sys.path:
 from nemo_fabric_adapters.hermes_sdk import adapter  # noqa: E402
 
 
-def test_runtime_id_drives_hermes_session_id_and_hermes_db_history(
+async def test_runtime_id_drives_hermes_session_id_and_hermes_db_history(
     monkeypatch,
     tmp_path: Path,
 ) -> None:
@@ -146,7 +146,7 @@ def test_runtime_id_drives_hermes_session_id_and_hermes_db_history(
         "capability_plan": {"native": {}},
     }
 
-    output = adapter.run_hermes_sdk(payload)
+    output = await adapter.run_hermes_sdk(payload)
 
     assert captured["db_resolve_session"] == "runtime-fabric-123"
     assert captured["db_get_session"] == ["runtime-resolved-456"]


### PR DESCRIPTION
* The Hermes Relay plugin supports configuring both ATOF and ATIF Relay plugins from environment variables.
* While other Relay plugins, notably OTel and OpenInference, require a Relay TOML configuration file or a `PluginConfig`
* Add a new `write_relay_plugins_toml` helper method for hermes_cli
* Add new `_relay_api_plugin_config` helper method for hermes_sdk
* Add a new `adapters/common/src/nemo_fabric_adapters/common/utils.py` module for methods like `write_relay_plugins_toml` which are not Hermes specific and could be of use to other adapters.
* Split `tests/test_adapaters_hermes_common.py` tests into those for the common/hermes and common/utils tests
* Always use the `hermes chat --query <prompt>` command in the `hermes_cli` adapter rather that the `-z` flag, the reason is that with `-z` the session is not finalized on completion the way it is with `hermes chat`, this conforms with behavior of the `hermes_sdk` adapter.
* Remove require_yaml parameter, since JSON is a subset of YAML, writing JSON to a YAML file is always valid we should not raise exceptions on a missing PyYaml library.
* Move the `pyyaml` dependency to be a dependency of the `hermes` extra (currently only need to write Hermes config files)
* Add a dependency for `tomli-w` to the `relay` extra


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary

- **New Features**
  - Added Hermes Relay/OpenInference and Relay/OpenTelemetry example profiles for oneshot tracing and artifact generation.
  - When relay is enabled, Hermes config generation is standardized and may emit a Relay plugins TOML for plugin setup.

- **Bug Fixes**
  - Updated Hermes CLI argument handling to consistently use `chat --quiet --query <prompt>` (including session continuation).

- **Refactor**
  - Unified shared Hermes/relay config and payload normalization across the Hermes CLI and SDK adapters.

- **Tests**
  - Updated and expanded unit, smoke, and end-to-end tests to match the new shared relay/config behavior and CLI argument expectations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->