### PR TITLE
feat(adapters): add Codex CLI one-shot and session support

### DIFF
--- a/README.md
+++ b/README.md
@@ -320,6 +320,7 @@ Run the real one-shot and session smoke after installing Fabric with its native
 extension:
 
 ```bash
+python3 -m pip install -e ".[codex]"
 RUN_FABRIC_CODEX_INTEGRATION=1 python3 tests/smoke_codex_cli.py
 ```
 

--- a/README.md
+++ b/README.md
@@ -32,8 +32,8 @@ flowchart TB
   Consumer["Consumer\nCLI | Python SDK | integrations"]
   Config["Agent package\nagent.yaml + profiles"]
   Core["Fabric Rust core\nvalidate | resolve | plan | run"]
-  Adapter["Selected Hermes adapter\nSDK | CLI"]
-  Harness["Agent harness runtime\nHermes"]
+  Adapter["Selected harness adapter\nHermes SDK | Hermes CLI | Codex CLI"]
+  Harness["Agent harness runtime\nHermes | Codex"]
   Artifacts["Artifact manifest\noutput | logs | patches | telemetry refs"]
   Relay["NeMo Relay\nATOF / ATIF when enabled"]
 
@@ -111,7 +111,8 @@ under `examples/code-review-agent/artifacts/hermes-sdk/`.
   editing `agent.yaml`.
 - **Adapters:** harness-specific integrations selected by `harness.adapter_id`.
   The Hermes SDK and CLI adapters live under `adapters/hermes-sdk/` and
-  `adapters/hermes-cli/`.
+  `adapters/hermes-cli/`; the Codex CLI adapter lives under
+  `adapters/codex-cli/`.
 - **Artifacts:** normalized output, logs, patches, and telemetry references
   returned through an `ArtifactManifest`.
 
@@ -270,6 +271,14 @@ fabric chat examples/code-review-agent \
   --verbose
 ```
 
+The same session flow works with an existing Codex CLI login:
+
+```bash
+fabric chat examples/code-review-agent \
+  --profile codex_cli_session \
+  --session-id review-session-123
+```
+
 `--session-id` is optional. Each `fabric chat` start creates a new `runtime_id`;
 the session id is the stable resume key. If `--session-id` is omitted, Fabric
 uses the generated `runtime_id` as the session id. If you want a later chat run
@@ -284,7 +293,8 @@ requires `runtime.mode: session`; use `fabric run` for oneshot profiles and
 machine-readable stdout. Because `chat` is an interactive terminal UI, the
 transcript and metadata are written together on stderr.
 
-The real-Hermes integration check is `tests/smoke_hermes_session.py`.
+The opt-in real integration checks are `tests/smoke_hermes_session.py` and
+`tests/smoke_codex_cli.py`.
 
 `FabricClient()` uses the native Rust binding. SDK `run(...)` and
 `start_session(...)` drive the core Fabric runtime lifecycle (`start_runtime` /
@@ -294,6 +304,24 @@ core. For source-tree development, install the package with
 `python3 -m pip install -e .` before using the SDK.
 
 ## Other Runs
+
+Run one isolated Codex CLI turn using Codex's existing authentication and
+configuration:
+
+```bash
+codex login status
+fabric doctor examples/code-review-agent --profile codex_cli
+fabric run examples/code-review-agent \
+  --profile codex_cli \
+  --input "Review the workspace and summarize the highest-risk issue."
+```
+
+Run the real one-shot and session smoke after installing Fabric with its native
+extension:
+
+```bash
+RUN_FABRIC_CODEX_INTEGRATION=1 python3 tests/smoke_codex_cli.py
+```
 
 Run the Hermes CLI adapter:
 

--- a/adapters/codex-cli/README.md
+++ b/adapters/codex-cli/README.md
@@ -3,6 +3,12 @@
 Runs an installed Codex CLI through Fabric's process-adapter lifecycle. The
 same adapter supports one-shot and session runtime modes.
 
+Install Fabric with the adapter dependency before running it:
+
+```bash
+python3 -m pip install -e ".[codex]"
+```
+
 ## Authentication and Codex Config
 
 The adapter does not read, copy, or rewrite Codex credentials. The child Codex
@@ -21,7 +27,8 @@ Fabric adds only explicitly configured invocation overrides:
   `danger-full-access`.
 - `harness.settings.codex_profile` selects a Codex profile.
 - `harness.settings.config_overrides` emits repeated `--config key=value`
-  arguments.
+  arguments. Values may be TOML scalars or arrays; use dotted keys for nested
+  Codex settings.
 - `harness.settings.codex_args` is an escape hatch for additional CLI flags.
 - `harness.settings.timeout_seconds` bounds each invocation and defaults to 1800.
 

--- a/adapters/codex-cli/README.md
+++ b/adapters/codex-cli/README.md
@@ -6,9 +6,10 @@ same adapter supports one-shot and session runtime modes.
 ## Authentication and Codex Config
 
 The adapter does not read, copy, or rewrite Codex credentials. The child Codex
-process inherits `HOME`, `CODEX_HOME`, and its environment, so an existing
-`codex login` session remains authoritative. Automation may provide
-`CODEX_API_KEY` directly to the Codex process.
+process inherits `HOME`, `CODEX_HOME`, platform runtime variables, and proxy or
+certificate settings, so an existing `codex login` session remains
+authoritative. Additional variables must be provided through
+`harness.settings.env`.
 
 Codex continues to load its system, user, profile, and trusted project config.
 Fabric adds only explicitly configured invocation overrides:
@@ -22,6 +23,7 @@ Fabric adds only explicitly configured invocation overrides:
 - `harness.settings.config_overrides` emits repeated `--config key=value`
   arguments.
 - `harness.settings.codex_args` is an escape hatch for additional CLI flags.
+- `harness.settings.timeout_seconds` bounds each invocation and defaults to 1800.
 
 `codex_command`, `codex_state_dir`, `cwd`, `env`, and
 `skip_git_repo_check` are available for prepared environments and tests.
@@ -29,12 +31,13 @@ Fabric adds only explicitly configured invocation overrides:
 ## Runtime Modes
 
 One-shot mode runs `codex exec --json --ephemeral` and returns the final agent
-message, usage, thread ID, and Codex events in the normalized Fabric result.
+message, usage, and thread ID in the normalized Fabric result.
 
 Session mode omits `--ephemeral`. The first invocation records Codex's generated
 thread ID against Fabric's session ID; later invocations use
 `codex exec resume <thread-id>`. Codex owns its transcript and authentication;
 Fabric owns the lifecycle and the session-to-thread correlation record.
+Both modes accept text input; Codex owns conversation history for session runs.
 
 Use the `codex_cli` and `codex_cli_session` profiles under
 `examples/code-review-agent/profiles/` for local one-shot and `fabric chat`

--- a/adapters/codex-cli/README.md
+++ b/adapters/codex-cli/README.md
@@ -1,0 +1,41 @@
+# Codex CLI Adapter
+
+Runs an installed Codex CLI through Fabric's process-adapter lifecycle. The
+same adapter supports one-shot and session runtime modes.
+
+## Authentication and Codex Config
+
+The adapter does not read, copy, or rewrite Codex credentials. The child Codex
+process inherits `HOME`, `CODEX_HOME`, and its environment, so an existing
+`codex login` session remains authoritative. Automation may provide
+`CODEX_API_KEY` directly to the Codex process.
+
+Codex continues to load its system, user, profile, and trusted project config.
+Fabric adds only explicitly configured invocation overrides:
+
+- `models.default.model` selects `--model`; omit it to use Codex's configured
+  default.
+- `environment.workspace` selects the process working directory.
+- `harness.settings.sandbox` selects `read-only`, `workspace-write`, or
+  `danger-full-access`.
+- `harness.settings.codex_profile` selects a Codex profile.
+- `harness.settings.config_overrides` emits repeated `--config key=value`
+  arguments.
+- `harness.settings.codex_args` is an escape hatch for additional CLI flags.
+
+`codex_command`, `codex_state_dir`, `cwd`, `env`, and
+`skip_git_repo_check` are available for prepared environments and tests.
+
+## Runtime Modes
+
+One-shot mode runs `codex exec --json --ephemeral` and returns the final agent
+message, usage, thread ID, and Codex events in the normalized Fabric result.
+
+Session mode omits `--ephemeral`. The first invocation records Codex's generated
+thread ID against Fabric's session ID; later invocations use
+`codex exec resume <thread-id>`. Codex owns its transcript and authentication;
+Fabric owns the lifecycle and the session-to-thread correlation record.
+
+Use the `codex_cli` and `codex_cli_session` profiles under
+`examples/code-review-agent/profiles/` for local one-shot and `fabric chat`
+examples.

--- a/adapters/codex-cli/fabric-adapter.json
+++ b/adapters/codex-cli/fabric-adapter.json
@@ -1,0 +1,16 @@
+{
+  "adapter_id": "nvidia.fabric.codex.cli",
+  "harness": "codex",
+  "adapter_kind": "process",
+  "runner": {
+    "command": "python3",
+    "script": "src/nemo_fabric_adapters/codex_cli/adapter.py",
+    "stdin_payload": "fabric_request"
+  },
+  "requirements": {
+    "binaries": ["codex"]
+  },
+  "config": {
+    "accepts": ["models"]
+  }
+}

--- a/adapters/codex-cli/src/nemo_fabric_adapters/codex_cli/__init__.py
+++ b/adapters/codex-cli/src/nemo_fabric_adapters/codex_cli/__init__.py
@@ -1,0 +1,4 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Codex CLI adapter package."""

--- a/adapters/codex-cli/src/nemo_fabric_adapters/codex_cli/adapter.py
+++ b/adapters/codex-cli/src/nemo_fabric_adapters/codex_cli/adapter.py
@@ -179,9 +179,15 @@ def resolve_command(payload: dict[str, Any], value: Any) -> str:
 
 
 def toml_value(value: Any) -> str:
-    if isinstance(value, float):
-        if not math.isfinite(value):
+    pending = [value]
+    while pending:
+        item = pending.pop()
+        if isinstance(item, float) and not math.isfinite(item):
             raise ValueError("Codex config overrides require finite numbers")
+        if isinstance(item, Mapping):
+            pending.extend(item.values())
+        elif isinstance(item, (list, tuple)):
+            pending.extend(item)
     try:
         document = tomli_w.dumps({"value": value})
     except TypeError as error:

--- a/adapters/codex-cli/src/nemo_fabric_adapters/codex_cli/adapter.py
+++ b/adapters/codex-cli/src/nemo_fabric_adapters/codex_cli/adapter.py
@@ -15,6 +15,8 @@ import sys
 from pathlib import Path
 from typing import Any
 
+import tomli_w
+
 CUR_DIR = Path(__file__).parent
 ADAPTERS_DIR = CUR_DIR.parent.parent.parent.parent
 COMMON_DIR = (ADAPTERS_DIR / "common/src").resolve().as_posix()
@@ -176,25 +178,19 @@ def resolve_command(payload: dict[str, Any], value: Any) -> str:
 
 
 def toml_value(value: Any) -> str:
-    if isinstance(value, bool):
-        return str(value).lower()
-    if isinstance(value, str):
-        return json.dumps(value)
-    if isinstance(value, int):
-        return str(value)
     if isinstance(value, float):
         if not math.isfinite(value):
             raise ValueError("Codex config overrides require finite numbers")
-        return repr(value)
-    if isinstance(value, list):
-        return f"[{','.join(toml_value(item) for item in value)}]"
-    if isinstance(value, dict):
-        fields = ",".join(
-            f"{json.dumps(str(key))}={toml_value(item)}"
-            for key, item in sorted(value.items())
-        )
-        return f"{{{fields}}}"
-    raise ValueError(f"unsupported Codex config override value: {value!r}")
+    try:
+        document = tomli_w.dumps({"value": value})
+    except TypeError as error:
+        raise ValueError(
+            "Codex config override values must be a TOML scalar or array"
+        ) from error
+    prefix = "value = "
+    if not document.startswith(prefix):
+        raise ValueError("Codex config override values must be a TOML scalar or array")
+    return document.removeprefix(prefix).rstrip()
 
 
 def parse_events(contents: str) -> dict[str, Any]:

--- a/adapters/codex-cli/src/nemo_fabric_adapters/codex_cli/adapter.py
+++ b/adapters/codex-cli/src/nemo_fabric_adapters/codex_cli/adapter.py
@@ -24,6 +24,36 @@ if COMMON_DIR not in sys.path:
 import nemo_fabric_adapters.common.utils as common_utils  # noqa: E402
 
 SANDBOXES = {"read-only", "workspace-write", "danger-full-access"}
+DEFAULT_TIMEOUT_SECONDS = 1800
+INHERITED_ENV_NAMES = {
+    "APPDATA",
+    "CODEX_HOME",
+    "COMSPEC",
+    "HOME",
+    "HTTP_PROXY",
+    "HTTPS_PROXY",
+    "LANG",
+    "LC_ALL",
+    "LC_CTYPE",
+    "LOCALAPPDATA",
+    "NO_PROXY",
+    "PATH",
+    "PATHEXT",
+    "SHELL",
+    "SSL_CERT_DIR",
+    "SSL_CERT_FILE",
+    "SYSTEMROOT",
+    "TEMP",
+    "TMP",
+    "TMPDIR",
+    "USERPROFILE",
+    "XDG_CACHE_HOME",
+    "XDG_CONFIG_HOME",
+    "XDG_DATA_HOME",
+    "http_proxy",
+    "https_proxy",
+    "no_proxy",
+}
 
 
 def load_payload() -> dict[str, Any]:
@@ -206,7 +236,9 @@ def parse_events(contents: str) -> dict[str, Any]:
 
 def request_to_prompt(payload: dict[str, Any]) -> str:
     value = (payload.get("request") or {}).get("input", "")
-    return value if isinstance(value, str) else json.dumps(value, sort_keys=True)
+    if not isinstance(value, str):
+        raise ValueError("Codex CLI adapter requires text input")
+    return value
 
 
 def resolve_cwd(payload: dict[str, Any]) -> Path:
@@ -217,6 +249,33 @@ def resolve_cwd(payload: dict[str, Any]) -> Path:
     return path.resolve() if path.is_absolute() else (config_root / path).resolve()
 
 
+def build_env(payload: dict[str, Any]) -> dict[str, str]:
+    env = {name: os.environ[name] for name in INHERITED_ENV_NAMES if name in os.environ}
+    configured = common_utils.settings_payload(payload).get("env") or {}
+    env.update({str(key): str(value) for key, value in configured.items()})
+    return env
+
+
+def process_timeout(payload: dict[str, Any]) -> float:
+    value = common_utils.settings_payload(payload).get(
+        "timeout_seconds", DEFAULT_TIMEOUT_SECONDS
+    )
+    if (
+        isinstance(value, bool)
+        or not isinstance(value, (int, float))
+        or not math.isfinite(value)
+        or value <= 0
+    ):
+        raise ValueError("timeout_seconds must be a positive finite number")
+    return float(value)
+
+
+def exception_output(value: str | bytes | None) -> str:
+    if value is None:
+        return ""
+    return value.decode(errors="replace") if isinstance(value, bytes) else value
+
+
 def run_codex(payload: dict[str, Any]) -> dict[str, Any]:
     mode = runtime_mode(payload)
     session_id = fabric_session_id(payload) if mode == "session" else None
@@ -225,25 +284,33 @@ def run_codex(payload: dict[str, Any]) -> dict[str, Any]:
     prior_thread_id = load_thread_id(payload, session_id) if session_id else None
     command = build_command(payload, thread_id=prior_thread_id)
     cwd = resolve_cwd(payload)
-    env = os.environ.copy()
-    env.update(
-        {
-            str(key): str(value)
-            for key, value in (common_utils.settings_payload(payload).get("env") or {}).items()
-        }
-    )
-    completed = subprocess.run(
-        command,
-        cwd=cwd,
-        env=env,
-        input=request_to_prompt(payload),
-        text=True,
-        capture_output=True,
-        check=False,
-    )
+    timeout = process_timeout(payload)
+    launch_error = None
+    try:
+        completed = subprocess.run(
+            command,
+            cwd=cwd,
+            env=build_env(payload),
+            input=request_to_prompt(payload),
+            text=True,
+            capture_output=True,
+            check=False,
+            timeout=timeout,
+        )
+    except subprocess.TimeoutExpired as error:
+        completed = subprocess.CompletedProcess(
+            command,
+            124,
+            exception_output(error.stdout),
+            exception_output(error.stderr),
+        )
+        launch_error = f"Codex CLI timed out after {timeout:g} seconds"
+    except OSError as error:
+        completed = subprocess.CompletedProcess(command, 127, "", str(error))
+        launch_error = f"Codex CLI could not start: {error}"
     parsed = parse_events(completed.stdout)
     thread_id = parsed["thread_id"] or prior_thread_id
-    error = parsed["error"]
+    error = launch_error or parsed["error"]
     if completed.returncode != 0:
         error = error or completed.stderr.strip() or "Codex CLI exited with a non-zero status"
     if parsed["response"] is None:
@@ -268,10 +335,7 @@ def run_codex(payload: dict[str, Any]) -> dict[str, Any]:
         "thread_id": thread_id,
         "response": parsed["response"],
         "usage": parsed["usage"],
-        "events": parsed["events"],
         "returncode": completed.returncode,
-        "stdout": completed.stdout,
-        "stderr": completed.stderr,
         "error": error,
         "failed": error is not None,
         "state_dir": str(state_dir(payload)),

--- a/adapters/codex-cli/src/nemo_fabric_adapters/codex_cli/adapter.py
+++ b/adapters/codex-cli/src/nemo_fabric_adapters/codex_cli/adapter.py
@@ -12,6 +12,7 @@ import math
 import os
 import subprocess
 import sys
+from collections.abc import Mapping
 from pathlib import Path
 from typing import Any
 
@@ -247,7 +248,11 @@ def resolve_cwd(payload: dict[str, Any]) -> Path:
 
 def build_env(payload: dict[str, Any]) -> dict[str, str]:
     env = {name: os.environ[name] for name in INHERITED_ENV_NAMES if name in os.environ}
-    configured = common_utils.settings_payload(payload).get("env") or {}
+    configured = common_utils.settings_payload(payload).get("env")
+    if configured is None:
+        configured = {}
+    if not isinstance(configured, Mapping):
+        raise ValueError("env must be a mapping of variable names to values")
     env.update({str(key): str(value) for key, value in configured.items()})
     return env
 

--- a/adapters/codex-cli/src/nemo_fabric_adapters/codex_cli/adapter.py
+++ b/adapters/codex-cli/src/nemo_fabric_adapters/codex_cli/adapter.py
@@ -1,0 +1,300 @@
+#!/usr/bin/env python3
+# SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Map Fabric one-shot and session invocations onto ``codex exec``."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import math
+import os
+import subprocess
+import sys
+from pathlib import Path
+from typing import Any
+
+CUR_DIR = Path(__file__).parent
+ADAPTERS_DIR = CUR_DIR.parent.parent.parent.parent
+COMMON_DIR = (ADAPTERS_DIR / "common/src").resolve().as_posix()
+if COMMON_DIR not in sys.path:
+    sys.path.append(COMMON_DIR)
+
+import nemo_fabric_adapters.common.utils as common_utils  # noqa: E402
+
+SANDBOXES = {"read-only", "workspace-write", "danger-full-access"}
+
+
+def load_payload() -> dict[str, Any]:
+    invocation_path = os.environ.get("FABRIC_INVOCATION")
+    if invocation_path and Path(invocation_path).is_file():
+        return json.loads(Path(invocation_path).read_text(encoding="utf-8"))
+    return json.load(sys.stdin)
+
+
+def runtime_mode(payload: dict[str, Any]) -> str:
+    runtime = common_utils.fabric_config(payload).get("runtime") or {}
+    mode = str(runtime.get("mode") or "oneshot")
+    if mode not in {"oneshot", "session"}:
+        raise ValueError("Codex CLI adapter supports only oneshot and session modes")
+    return mode
+
+
+def fabric_session_id(payload: dict[str, Any]) -> str | None:
+    context = common_utils.runtime_context(payload)
+    value = context.get("session_id") or context.get("runtime_id")
+    return str(value) if value else None
+
+
+def state_dir(payload: dict[str, Any]) -> Path:
+    settings = common_utils.settings_payload(payload)
+    config_root = Path(common_utils.config_root(payload)).resolve()
+    configured = settings.get("codex_state_dir")
+    if configured:
+        path = Path(str(configured))
+        return path if path.is_absolute() else config_root / path
+    artifacts = common_utils.runtime_context(payload).get("artifacts") or {}
+    root = artifacts.get("root") or os.environ.get("FABRIC_ARTIFACTS")
+    if root:
+        return Path(str(root)).resolve() / ".fabric" / "codex-cli"
+    return config_root / "artifacts" / "codex-cli" / ".fabric"
+
+
+def session_state_path(payload: dict[str, Any], session_id: str) -> Path:
+    key = hashlib.sha256(session_id.encode("utf-8")).hexdigest()
+    return state_dir(payload) / "sessions" / f"{key}.json"
+
+
+def load_thread_id(payload: dict[str, Any], session_id: str) -> str | None:
+    path = session_state_path(payload, session_id)
+    if not path.is_file():
+        return None
+    value = json.loads(path.read_text(encoding="utf-8"))
+    if value.get("session_id") != session_id or not value.get("thread_id"):
+        raise RuntimeError(f"invalid Codex session state in {path}")
+    return str(value["thread_id"])
+
+
+def save_thread_id(payload: dict[str, Any], session_id: str, thread_id: str) -> None:
+    path = session_state_path(payload, session_id)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    invocation_id = common_utils.runtime_context(payload).get("invocation_id") or "pending"
+    temporary = path.with_suffix(f".{invocation_id}.tmp")
+    temporary.write_text(
+        json.dumps({"session_id": session_id, "thread_id": thread_id}, indent=2),
+        encoding="utf-8",
+    )
+    os.replace(temporary, path)
+
+
+def selected_model(payload: dict[str, Any]) -> str | None:
+    settings = common_utils.settings_payload(payload)
+    models = common_utils.models_payload(payload)
+    model_config = models.get(settings.get("model", "default"), {})
+    value = settings.get("model_name")
+    if not value and isinstance(model_config, dict):
+        value = model_config.get("model")
+    if not value:
+        return None
+    model = str(value)
+    return model.removeprefix("openai/")
+
+
+def build_command(
+    payload: dict[str, Any], *, thread_id: str | None = None
+) -> list[str]:
+    settings = common_utils.settings_payload(payload)
+    command = resolve_command(payload, settings.get("codex_command") or "codex")
+    mode = runtime_mode(payload)
+    sandbox = str(settings.get("sandbox") or "read-only")
+    if sandbox not in SANDBOXES:
+        raise ValueError(
+            f"unsupported Codex sandbox {sandbox!r}; expected one of {sorted(SANDBOXES)}"
+        )
+
+    args = [command, "exec", "--json"]
+    if mode == "oneshot":
+        args.append("--ephemeral")
+    args.extend(["--sandbox", sandbox])
+
+    codex_profile = settings.get("codex_profile")
+    if codex_profile:
+        args.extend(["--profile", str(codex_profile)])
+    for key, value in sorted((settings.get("config_overrides") or {}).items()):
+        args.extend(["--config", f"{key}={toml_value(value)}"])
+    model = selected_model(payload)
+    if model:
+        args.extend(["--model", model])
+    if settings.get("skip_git_repo_check", False):
+        args.append("--skip-git-repo-check")
+    args.extend(common_utils.normalize_list(settings.get("codex_args")))
+
+    if thread_id:
+        args.extend(["resume", thread_id, "-"])
+    else:
+        args.append("-")
+    return args
+
+
+def resolve_command(payload: dict[str, Any], value: Any) -> str:
+    command = Path(str(value))
+    if command.is_absolute() or len(command.parts) == 1:
+        return str(command)
+    config_root = Path(common_utils.config_root(payload)).resolve()
+    return str((config_root / command).resolve())
+
+
+def toml_value(value: Any) -> str:
+    if isinstance(value, bool):
+        return str(value).lower()
+    if isinstance(value, str):
+        return json.dumps(value)
+    if isinstance(value, int):
+        return str(value)
+    if isinstance(value, float):
+        if not math.isfinite(value):
+            raise ValueError("Codex config overrides require finite numbers")
+        return repr(value)
+    if isinstance(value, list):
+        return f"[{','.join(toml_value(item) for item in value)}]"
+    if isinstance(value, dict):
+        fields = ",".join(
+            f"{json.dumps(str(key))}={toml_value(item)}"
+            for key, item in sorted(value.items())
+        )
+        return f"{{{fields}}}"
+    raise ValueError(f"unsupported Codex config override value: {value!r}")
+
+
+def parse_events(contents: str) -> dict[str, Any]:
+    events: list[dict[str, Any]] = []
+    thread_id = None
+    response = None
+    usage = None
+    error = None
+    for line in contents.splitlines():
+        if not line.strip():
+            continue
+        try:
+            event = json.loads(line)
+        except json.JSONDecodeError:
+            continue
+        if not isinstance(event, dict):
+            continue
+        events.append(event)
+        event_type = event.get("type")
+        if event_type == "thread.started":
+            thread_id = event.get("thread_id")
+        elif event_type == "item.completed":
+            item = event.get("item") or {}
+            if item.get("type") == "agent_message":
+                response = item.get("text")
+        elif event_type == "turn.completed":
+            usage = event.get("usage")
+        elif event_type in {"turn.failed", "error"}:
+            failure = event.get("error") or event.get("message") or event
+            error = failure.get("message") if isinstance(failure, dict) else str(failure)
+    return {
+        "events": events,
+        "thread_id": str(thread_id) if thread_id else None,
+        "response": response,
+        "usage": usage,
+        "error": error,
+    }
+
+
+def request_to_prompt(payload: dict[str, Any]) -> str:
+    value = (payload.get("request") or {}).get("input", "")
+    return value if isinstance(value, str) else json.dumps(value, sort_keys=True)
+
+
+def resolve_cwd(payload: dict[str, Any]) -> Path:
+    settings = common_utils.settings_payload(payload)
+    environment = common_utils.environment_payload(payload)
+    config_root = Path(common_utils.config_root(payload)).resolve()
+    path = Path(str(settings.get("cwd") or environment.get("workspace") or "."))
+    return path.resolve() if path.is_absolute() else (config_root / path).resolve()
+
+
+def run_codex(payload: dict[str, Any]) -> dict[str, Any]:
+    mode = runtime_mode(payload)
+    session_id = fabric_session_id(payload) if mode == "session" else None
+    if mode == "session" and not session_id:
+        raise RuntimeError("runtime.mode=session requires a session_id or runtime_id")
+    prior_thread_id = load_thread_id(payload, session_id) if session_id else None
+    command = build_command(payload, thread_id=prior_thread_id)
+    cwd = resolve_cwd(payload)
+    env = os.environ.copy()
+    env.update(
+        {
+            str(key): str(value)
+            for key, value in (common_utils.settings_payload(payload).get("env") or {}).items()
+        }
+    )
+    completed = subprocess.run(
+        command,
+        cwd=cwd,
+        env=env,
+        input=request_to_prompt(payload),
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+    parsed = parse_events(completed.stdout)
+    thread_id = parsed["thread_id"] or prior_thread_id
+    error = parsed["error"]
+    if completed.returncode != 0:
+        error = error or completed.stderr.strip() or "Codex CLI exited with a non-zero status"
+    if parsed["response"] is None:
+        error = error or "Codex invocation did not return a final agent message"
+    if session_id and not thread_id:
+        error = error or "Codex session invocation did not return a thread identity"
+    if session_id and prior_thread_id and thread_id != prior_thread_id:
+        error = (
+            f"Codex resumed thread {thread_id}, expected persisted thread {prior_thread_id}"
+        )
+    if session_id and thread_id and not error:
+        save_thread_id(payload, session_id, thread_id)
+
+    return {
+        "harness": "codex",
+        "adapter": "cli",
+        "mode": f"codex_cli_{mode}",
+        "command": redact_command(command),
+        "cwd": str(cwd),
+        "model": selected_model(payload),
+        "session_id": session_id,
+        "thread_id": thread_id,
+        "response": parsed["response"],
+        "usage": parsed["usage"],
+        "events": parsed["events"],
+        "returncode": completed.returncode,
+        "stdout": completed.stdout,
+        "stderr": completed.stderr,
+        "error": error,
+        "failed": error is not None,
+        "state_dir": str(state_dir(payload)),
+    }
+
+
+def redact_command(command: list[str]) -> list[str]:
+    redacted = list(command)
+    for index, value in enumerate(redacted[:-1]):
+        if value == "--config" and any(
+            marker in redacted[index + 1].lower()
+            for marker in ("key", "token", "secret", "password")
+        ):
+            redacted[index + 1] = "<redacted>"
+    return redacted
+
+
+def main() -> None:
+    output = run_codex(load_payload())
+    print(json.dumps(output, sort_keys=True))
+    if output["failed"]:
+        raise SystemExit(2)
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/code-review-agent/profiles/codex-cli-session.yaml
+++ b/examples/code-review-agent/profiles/codex-cli-session.yaml
@@ -1,0 +1,41 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+schema_version: fabric.profile/v1alpha1
+name: codex_cli_session
+description: Reuse one Codex thread across a Fabric runtime session.
+
+harness:
+  adapter_id: nvidia.fabric.codex.cli
+  resolution: preinstalled
+  settings:
+    sandbox: workspace-write
+    skip_git_repo_check: true
+    codex_state_dir: ./artifacts/codex-cli/session-state
+    config_overrides:
+      model_reasoning_effort: high
+
+models:
+  default:
+    provider: openai
+    model: openai/gpt-5.4
+    api_key_env: null
+    temperature: null
+
+skills: null
+mcp: null
+
+runtime:
+  mode: session
+  transport: cli
+  input_schema: chat
+  output_schema: message
+  artifacts: ./artifacts/codex-cli
+
+environment:
+  provider: local
+  workspace: ./repos/my-service
+  artifacts: ./artifacts/codex-cli
+
+telemetry:
+  enabled: false

--- a/examples/code-review-agent/profiles/codex-cli-session.yaml
+++ b/examples/code-review-agent/profiles/codex-cli-session.yaml
@@ -28,7 +28,7 @@ mcp: null
 runtime:
   mode: session
   transport: cli
-  input_schema: chat
+  input_schema: text
   output_schema: message
   artifacts: ./artifacts/codex-cli
 

--- a/examples/code-review-agent/profiles/codex-cli.yaml
+++ b/examples/code-review-agent/profiles/codex-cli.yaml
@@ -1,0 +1,40 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+schema_version: fabric.profile/v1alpha1
+name: codex_cli
+description: Run one isolated Codex CLI invocation using Codex-owned authentication.
+
+harness:
+  adapter_id: nvidia.fabric.codex.cli
+  resolution: preinstalled
+  settings:
+    sandbox: workspace-write
+    skip_git_repo_check: true
+    config_overrides:
+      model_reasoning_effort: high
+
+models:
+  default:
+    provider: openai
+    model: openai/gpt-5.4
+    api_key_env: null
+    temperature: null
+
+skills: null
+mcp: null
+
+runtime:
+  mode: oneshot
+  transport: cli
+  input_schema: text
+  output_schema: message
+  artifacts: ./artifacts/codex-cli
+
+environment:
+  provider: local
+  workspace: ./repos/my-service
+  artifacts: ./artifacts/codex-cli
+
+telemetry:
+  enabled: false

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,6 +38,7 @@ test = [
     "pytest-asyncio>=0.26",
     "pytest-cov~=7.0",
     "pyyaml>=6.0",
+    "tomli>=2; python_version < '3.11'",
     "tomli-w~=1.2",
     "uvicorn~=0.49",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,6 +13,8 @@ requires-python = ">=3.10"
 dependencies = []
 
 [project.optional-dependencies]
+codex = ["tomli-w~=1.2"]
+
 harbor = ["harbor>=0.13.2; python_version >= '3.12'"]
 
 hermes = [
@@ -36,6 +38,7 @@ test = [
     "pytest-asyncio>=0.26",
     "pytest-cov~=7.0",
     "pyyaml>=6.0",
+    "tomli-w~=1.2",
     "uvicorn~=0.49",
 ]
 

--- a/tests/smoke_codex_cli.py
+++ b/tests/smoke_codex_cli.py
@@ -1,0 +1,74 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Opt-in real Codex CLI smoke for Fabric one-shot and session modes.
+
+    RUN_FABRIC_CODEX_INTEGRATION=1 python3 tests/smoke_codex_cli.py
+"""
+
+from __future__ import annotations
+
+import asyncio
+import importlib.util
+import os
+import shutil
+import sys
+import uuid
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT / "python" / "src"))
+
+
+def main() -> None:
+    if os.environ.get("RUN_FABRIC_CODEX_INTEGRATION") != "1":
+        print("skipping: set RUN_FABRIC_CODEX_INTEGRATION=1 to run")
+        return
+    if shutil.which("codex") is None:
+        raise SystemExit("codex CLI is required")
+    if importlib.util.find_spec("nemo_fabric._native") is None:
+        raise SystemExit("the nemo_fabric native extension is required (pip install -e .)")
+    asyncio.run(_run())
+
+
+async def _run() -> None:
+    from nemo_fabric import FabricClient
+
+    agent = ROOT / "examples" / "code-review-agent"
+    nonce = f"fabric-{uuid.uuid4().hex[:8]}"
+    async with FabricClient() as client:
+        oneshot = await client.run(
+            agent,
+            profiles=["codex_cli"],
+            input="Reply with exactly: FABRIC_CODEX_ONESHOT_OK",
+        )
+        assert oneshot["status"] == "succeeded", oneshot.to_mapping()
+        assert "fabric_codex_oneshot_ok" in oneshot["output"]["response"].lower(), (
+            oneshot.to_mapping()
+        )
+        assert "--ephemeral" in oneshot["output"]["command"], oneshot.to_mapping()
+
+        async with await client.start_session(
+            agent,
+            profiles=["codex_cli_session"],
+            session_id=nonce,
+        ) as session:
+            first = await session.invoke(input=f"Remember this value: {nonce}")
+            second = await session.invoke(
+                input="Reply with only the value I asked you to remember."
+            )
+
+        results = (first.to_mapping(), second.to_mapping())
+        assert first["status"] == second["status"] == "succeeded", results
+        assert first["output"]["thread_id"] == second["output"]["thread_id"], results
+        assert nonce in second["output"]["response"], second.to_mapping()
+        assert second["output"]["command"][-3:-1] == [
+            "resume",
+            first["output"]["thread_id"],
+        ], second.to_mapping()
+
+    print("smoke_codex_cli ok")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_codex_cli.py
+++ b/tests/test_codex_cli.py
@@ -4,11 +4,15 @@
 import importlib.util
 import json
 import subprocess
-import tomllib
 from pathlib import Path
 from unittest.mock import MagicMock
 
 import pytest
+
+try:
+    import tomllib
+except ModuleNotFoundError:  # pragma: no cover - exercised on Python 3.10
+    import tomli as tomllib
 
 from nemo_fabric import FabricClient, FabricConfig
 

--- a/tests/test_codex_cli.py
+++ b/tests/test_codex_cli.py
@@ -285,6 +285,16 @@ def test_adapter_rejects_structured_input_until_chat_is_supported(codex_payload)
         adapter.request_to_prompt(codex_payload)
 
 
+@pytest.mark.parametrize("env", [[], "CODEX_FLAG=1"])
+def test_adapter_rejects_non_mapping_env(codex_payload, env):
+    adapter = load_codex_adapter()
+    settings = codex_payload["effective_config"]["config"]["harness"]["settings"]
+    settings["env"] = env
+
+    with pytest.raises(ValueError, match="env must be a mapping"):
+        adapter.build_env(codex_payload)
+
+
 @pytest.mark.parametrize(
     ("error", "message", "returncode"),
     [

--- a/tests/test_codex_cli.py
+++ b/tests/test_codex_cli.py
@@ -187,6 +187,15 @@ def test_reported_command_redacts_secret_config_overrides():
     assert command[-2] == 'provider.api_key="secret"'
 
 
+def test_config_override_values_use_tomli_writer():
+    adapter = load_codex_adapter()
+
+    assert adapter.toml_value("café") == '"café"'
+    assert adapter.toml_value([1, "two"]) == '[\n    1,\n    "two",\n]'
+    with pytest.raises(ValueError, match="scalar or array"):
+        adapter.toml_value({"nested": True})
+
+
 def test_session_reuses_codex_thread_across_invocations(codex_payload, monkeypatch):
     adapter = load_codex_adapter()
     codex_payload["effective_config"]["config"]["runtime"]["mode"] = "session"

--- a/tests/test_codex_cli.py
+++ b/tests/test_codex_cli.py
@@ -4,6 +4,7 @@
 import importlib.util
 import json
 import subprocess
+import tomllib
 from pathlib import Path
 from unittest.mock import MagicMock
 
@@ -191,9 +192,18 @@ def test_config_override_values_use_tomli_writer():
     adapter = load_codex_adapter()
 
     assert adapter.toml_value("café") == '"café"'
-    assert adapter.toml_value([1, "two"]) == '[\n    1,\n    "two",\n]'
+    encoded = adapter.toml_value([1, "two"])
+    assert tomllib.loads(f"value = {encoded}")["value"] == [1, "two"]
     with pytest.raises(ValueError, match="scalar or array"):
         adapter.toml_value({"nested": True})
+
+
+@pytest.mark.parametrize("value", [[float("nan")], [1, [float("inf")]]])
+def test_config_override_values_reject_nested_non_finite_numbers(value):
+    adapter = load_codex_adapter()
+
+    with pytest.raises(ValueError, match="finite numbers"):
+        adapter.toml_value(value)
 
 
 def test_session_reuses_codex_thread_across_invocations(codex_payload, monkeypatch):

--- a/tests/test_codex_cli.py
+++ b/tests/test_codex_cli.py
@@ -1,0 +1,384 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+import importlib.util
+import json
+import subprocess
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+
+from nemo_fabric import FabricClient, FabricConfig
+
+ROOT = Path(__file__).resolve().parents[1]
+ADAPTER_PATH = (
+    ROOT
+    / "adapters"
+    / "codex-cli"
+    / "src"
+    / "nemo_fabric_adapters"
+    / "codex_cli"
+    / "adapter.py"
+)
+
+
+def load_codex_adapter():
+    spec = importlib.util.spec_from_file_location("fabric_codex_adapter", ADAPTER_PATH)
+    assert spec and spec.loader
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+@pytest.fixture(name="codex_payload")
+def codex_payload_fixture(tmp_path):
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    return {
+        "effective_config": {
+            "agent_name": "codex-test",
+            "config_root": str(tmp_path),
+            "config": {
+                "harness": {
+                    "adapter_id": "nvidia.fabric.codex.cli",
+                    "settings": {
+                        "sandbox": "read-only",
+                        "codex_profile": "team",
+                        "config_overrides": {
+                            "features.web_search": False,
+                            "model_reasoning_effort": "high",
+                        },
+                    },
+                },
+                "models": {
+                    "default": {
+                        "provider": "openai",
+                        "model": "openai/gpt-5.4",
+                    }
+                },
+                "runtime": {"mode": "oneshot"},
+            },
+        },
+        "runtime_context": {
+            "runtime_id": "runtime-1",
+            "invocation_id": "invocation-1",
+            "request_id": "request-1",
+            "environment": {"workspace": str(workspace)},
+            "artifacts": {"root": str(tmp_path / "artifacts")},
+        },
+        "request": {"input": "Inspect the change."},
+    }
+
+
+def codex_jsonl(thread_id, response, *, usage=None):
+    events = [
+        {"type": "thread.started", "thread_id": thread_id},
+        {"type": "turn.started"},
+        {
+            "type": "item.completed",
+            "item": {"id": "item-1", "type": "agent_message", "text": response},
+        },
+        {
+            "type": "turn.completed",
+            "usage": usage
+            or {
+                "input_tokens": 10,
+                "cached_input_tokens": 2,
+                "output_tokens": 3,
+            },
+        },
+    ]
+    return "\n".join(json.dumps(event) for event in events) + "\n"
+
+
+def write_mock_codex(path):
+    path.write_text(
+        """#!/usr/bin/env python3
+import json
+import sys
+
+args = sys.argv[1:]
+thread_id = args[args.index("resume") + 1] if "resume" in args else "thread-fake"
+prompt = sys.stdin.read().strip()
+events = [
+    {"type": "thread.started", "thread_id": thread_id},
+    {"type": "turn.started"},
+    {
+        "type": "item.completed",
+        "item": {
+            "id": "item-1",
+            "type": "agent_message",
+            "text": f"{thread_id}:{prompt}",
+        },
+    },
+    {
+        "type": "turn.completed",
+        "usage": {"input_tokens": 1, "cached_input_tokens": 0, "output_tokens": 1},
+    },
+]
+for event in events:
+    print(json.dumps(event))
+""",
+        encoding="utf-8",
+    )
+    path.chmod(0o755)
+
+
+def fabric_config(tmp_path, mock_codex, *, mode):
+    return FabricConfig.from_mapping(
+        {
+            "schema_version": "fabric.agent/v1alpha1",
+            "metadata": {"name": "codex-runtime-test"},
+            "harness": {
+                "adapter_id": "nvidia.fabric.codex.cli",
+                "resolution": "preinstalled",
+                "settings": {
+                    "codex_command": str(mock_codex),
+                    "sandbox": "read-only",
+                    "skip_git_repo_check": True,
+                },
+            },
+            "runtime": {
+                "mode": mode,
+                "transport": "cli",
+                "artifacts": str(tmp_path / "artifacts"),
+            },
+            "environment": {
+                "provider": "local",
+                "workspace": str(tmp_path),
+                "artifacts": str(tmp_path / "artifacts"),
+            },
+        }
+    )
+
+
+def test_oneshot_command_uses_fabric_overrides_and_codex_owned_auth(codex_payload):
+    adapter = load_codex_adapter()
+
+    command = adapter.build_command(codex_payload)
+
+    assert command[:4] == ["codex", "exec", "--json", "--ephemeral"]
+    assert ["--sandbox", "read-only"] == command[4:6]
+    assert ["--profile", "team"] == command[6:8]
+    assert ["--model", "gpt-5.4"] == command[-3:-1]
+    assert 'features.web_search=false' in command
+    assert 'model_reasoning_effort="high"' in command
+    assert command[-1] == "-"
+
+
+def test_relative_codex_command_resolves_from_config_root(codex_payload):
+    adapter = load_codex_adapter()
+    settings = codex_payload["effective_config"]["config"]["harness"]["settings"]
+    settings["codex_command"] = "./tools/codex"
+
+    command = adapter.build_command(codex_payload)
+
+    config_root = Path(codex_payload["effective_config"]["config_root"])
+    assert command[0] == str(config_root / "tools" / "codex")
+
+
+def test_reported_command_redacts_secret_config_overrides():
+    adapter = load_codex_adapter()
+
+    command = ["codex", "exec", "--config", 'provider.api_key="secret"', "-"]
+
+    assert adapter.redact_command(command)[-2] == "<redacted>"
+    assert command[-2] == 'provider.api_key="secret"'
+
+
+def test_session_reuses_codex_thread_across_invocations(codex_payload, monkeypatch):
+    adapter = load_codex_adapter()
+    codex_payload["effective_config"]["config"]["runtime"]["mode"] = "session"
+    codex_payload["runtime_context"]["session_id"] = "review-session"
+    mock_run = MagicMock(
+        side_effect=[
+            subprocess.CompletedProcess(
+                args=[],
+                returncode=0,
+                stdout=codex_jsonl("thread-123", "first response"),
+                stderr="",
+            ),
+            subprocess.CompletedProcess(
+                args=[],
+                returncode=0,
+                stdout=codex_jsonl("thread-123", "second response"),
+                stderr="",
+            ),
+        ]
+    )
+    monkeypatch.setattr(adapter.subprocess, "run", mock_run)
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+    monkeypatch.setenv("CODEX_HOME", "/tmp/codex-home")
+
+    first = adapter.run_codex(codex_payload)
+    codex_payload["runtime_context"]["invocation_id"] = "invocation-2"
+    codex_payload["request"]["input"] = "Continue."
+    second = adapter.run_codex(codex_payload)
+
+    first_command = mock_run.call_args_list[0].args[0]
+    second_command = mock_run.call_args_list[1].args[0]
+    assert "--ephemeral" not in first_command
+    assert "resume" not in first_command
+    assert second_command[-3:] == ["resume", "thread-123", "-"]
+    assert first["response"] == "first response"
+    assert second["response"] == "second response"
+    assert second["session_id"] == "review-session"
+    assert second["thread_id"] == "thread-123"
+    assert second["usage"]["cached_input_tokens"] == 2
+    assert mock_run.call_args_list[0].kwargs["env"]["CODEX_HOME"] == "/tmp/codex-home"
+    assert "OPENAI_API_KEY" not in mock_run.call_args_list[0].kwargs["env"]
+
+    state_path = adapter.session_state_path(codex_payload, "review-session")
+    assert json.loads(state_path.read_text(encoding="utf-8")) == {
+        "session_id": "review-session",
+        "thread_id": "thread-123",
+    }
+
+
+def test_oneshot_does_not_persist_codex_thread(codex_payload, monkeypatch):
+    adapter = load_codex_adapter()
+    mock_run = MagicMock(
+        return_value=subprocess.CompletedProcess(
+            args=[],
+            returncode=0,
+            stdout=codex_jsonl("thread-ephemeral", "done"),
+            stderr="",
+        )
+    )
+    monkeypatch.setattr(adapter.subprocess, "run", mock_run)
+
+    output = adapter.run_codex(codex_payload)
+
+    assert output["thread_id"] == "thread-ephemeral"
+    assert output["response"] == "done"
+    assert not (Path(output["state_dir"]) / "sessions").exists()
+
+
+def test_adapter_rejects_unsupported_runtime_mode(codex_payload):
+    adapter = load_codex_adapter()
+    codex_payload["effective_config"]["config"]["runtime"]["mode"] = "service"
+
+    with pytest.raises(ValueError, match="supports only oneshot and session"):
+        adapter.run_codex(codex_payload)
+
+
+def test_session_fails_if_codex_does_not_return_thread_identity(
+    codex_payload, monkeypatch
+):
+    adapter = load_codex_adapter()
+    codex_payload["effective_config"]["config"]["runtime"]["mode"] = "session"
+    mock_run = MagicMock(
+        return_value=subprocess.CompletedProcess(
+            args=[],
+            returncode=0,
+            stdout=json.dumps(
+                {
+                    "type": "item.completed",
+                    "item": {"type": "agent_message", "text": "untracked"},
+                }
+            ),
+            stderr="",
+        )
+    )
+    monkeypatch.setattr(adapter.subprocess, "run", mock_run)
+
+    output = adapter.run_codex(codex_payload)
+
+    assert output["failed"] is True
+    assert "thread identity" in output["error"]
+
+
+def test_successful_process_without_final_response_is_failed(codex_payload, monkeypatch):
+    adapter = load_codex_adapter()
+    mock_run = MagicMock(
+        return_value=subprocess.CompletedProcess(
+            args=[],
+            returncode=0,
+            stdout="\n".join(
+                [
+                    json.dumps({"type": "thread.started", "thread_id": "thread-123"}),
+                    json.dumps({"type": "turn.completed", "usage": {}}),
+                ]
+            ),
+            stderr="",
+        )
+    )
+    monkeypatch.setattr(adapter.subprocess, "run", mock_run)
+
+    output = adapter.run_codex(codex_payload)
+
+    assert output["failed"] is True
+    assert "final agent message" in output["error"]
+
+
+async def test_fabric_session_invokes_codex_then_resumes(tmp_path):
+    mock_codex = tmp_path / "codex"
+    write_mock_codex(mock_codex)
+    config = fabric_config(tmp_path, mock_codex, mode="session")
+
+    async with await FabricClient().start_session(
+        config,
+        base_dir=tmp_path,
+        session_id="fabric-session",
+    ) as session:
+        first = await session.invoke(input="first")
+        second = await session.invoke(input="second")
+
+    assert first.runtime_id == second.runtime_id
+    assert first.output["response"] == "thread-fake:first"
+    assert second.output["response"] == "thread-fake:second"
+    assert first.output["thread_id"] == second.output["thread_id"] == "thread-fake"
+    assert "resume" not in first.output["command"]
+    assert second.output["command"][-3:] == ["resume", "thread-fake", "-"]
+
+
+async def test_fabric_oneshot_is_ephemeral_and_uses_cached_codex_auth(
+    tmp_path, monkeypatch
+):
+    mock_codex = tmp_path / "codex"
+    write_mock_codex(mock_codex)
+    config = fabric_config(tmp_path, mock_codex, mode="oneshot")
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+
+    async with FabricClient() as client:
+        report = await client.doctor(config, base_dir=tmp_path)
+        result = await client.run(
+            config,
+            base_dir=tmp_path,
+            input="inspect",
+        )
+
+    assert report.status == "pass"
+    assert any(
+        check.name == "requirement.binary" and "codex_command" in check.message
+        for check in report.checks
+    )
+    assert not any(check.name == "requirement.env" for check in report.checks)
+    assert result.output["response"] == "thread-fake:inspect"
+    assert "--ephemeral" in result.output["command"]
+    assert result.output["session_id"] is None
+
+
+@pytest.mark.parametrize(
+    ("profile", "mode", "session_capability"),
+    [
+        ("codex_cli", "oneshot", False),
+        ("codex_cli_session", "session", True),
+    ],
+)
+def test_codex_profiles_resolve_runtime_mode(profile, mode, session_capability):
+    plan = FabricClient().plan(
+        ROOT / "examples" / "code-review-agent",
+        profiles=[profile],
+    )
+
+    assert plan.adapter.adapter_id == "nvidia.fabric.codex.cli"
+    assert plan.adapter.harness == "codex"
+    assert plan.effective_config.config.runtime.mode == mode
+    assert plan.capabilities.session is session_capability
+    settings = plan.effective_config.config.harness.settings
+    assert settings["config_overrides"]["model_reasoning_effort"] == "high"
+    unsupported = plan["capability_plan"]["unsupported"]
+    assert not unsupported.get("skill_paths")
+    assert not unsupported.get("mcp_servers")

--- a/tests/test_codex_cli.py
+++ b/tests/test_codex_cli.py
@@ -210,6 +210,10 @@ def test_session_reuses_codex_thread_across_invocations(codex_payload, monkeypat
     monkeypatch.setattr(adapter.subprocess, "run", mock_run)
     monkeypatch.delenv("OPENAI_API_KEY", raising=False)
     monkeypatch.setenv("CODEX_HOME", "/tmp/codex-home")
+    monkeypatch.setenv("FABRIC_UNRELATED_SECRET", "do-not-forward")
+    codex_payload["effective_config"]["config"]["harness"]["settings"]["env"] = {
+        "CODEX_EXPLICIT": "forward-me"
+    }
 
     first = adapter.run_codex(codex_payload)
     codex_payload["runtime_context"]["invocation_id"] = "invocation-2"
@@ -226,8 +230,12 @@ def test_session_reuses_codex_thread_across_invocations(codex_payload, monkeypat
     assert second["session_id"] == "review-session"
     assert second["thread_id"] == "thread-123"
     assert second["usage"]["cached_input_tokens"] == 2
-    assert mock_run.call_args_list[0].kwargs["env"]["CODEX_HOME"] == "/tmp/codex-home"
-    assert "OPENAI_API_KEY" not in mock_run.call_args_list[0].kwargs["env"]
+    child_env = mock_run.call_args_list[0].kwargs["env"]
+    assert child_env["CODEX_HOME"] == "/tmp/codex-home"
+    assert child_env["CODEX_EXPLICIT"] == "forward-me"
+    assert "OPENAI_API_KEY" not in child_env
+    assert "FABRIC_UNRELATED_SECRET" not in child_env
+    assert mock_run.call_args_list[0].kwargs["timeout"] == 1800
 
     state_path = adapter.session_state_path(codex_payload, "review-session")
     assert json.loads(state_path.read_text(encoding="utf-8")) == {
@@ -252,7 +260,56 @@ def test_oneshot_does_not_persist_codex_thread(codex_payload, monkeypatch):
 
     assert output["thread_id"] == "thread-ephemeral"
     assert output["response"] == "done"
+    assert "events" not in output
+    assert "stdout" not in output
+    assert "stderr" not in output
     assert not (Path(output["state_dir"]) / "sessions").exists()
+
+
+def test_adapter_rejects_structured_input_until_chat_is_supported(codex_payload):
+    adapter = load_codex_adapter()
+    codex_payload["request"]["input"] = {
+        "messages": [{"role": "user", "content": "Inspect the change."}]
+    }
+
+    with pytest.raises(ValueError, match="requires text input"):
+        adapter.request_to_prompt(codex_payload)
+
+
+@pytest.mark.parametrize(
+    ("error", "message", "returncode"),
+    [
+        (FileNotFoundError("codex not found"), "codex not found", 127),
+        (
+            subprocess.TimeoutExpired(["codex"], 1800),
+            "timed out after 1800 seconds",
+            124,
+        ),
+    ],
+)
+def test_process_launch_failures_return_structured_results(
+    codex_payload, monkeypatch, error, message, returncode
+):
+    adapter = load_codex_adapter()
+    monkeypatch.setattr(adapter.subprocess, "run", MagicMock(side_effect=error))
+
+    output = adapter.run_codex(codex_payload)
+
+    assert output["failed"] is True
+    assert output["returncode"] == returncode
+    assert message in output["error"]
+    assert "stdout" not in output
+    assert "stderr" not in output
+
+
+@pytest.mark.parametrize("timeout", [0, -1, float("inf"), "30"])
+def test_adapter_rejects_invalid_timeout(codex_payload, timeout):
+    adapter = load_codex_adapter()
+    settings = codex_payload["effective_config"]["config"]["harness"]["settings"]
+    settings["timeout_seconds"] = timeout
+
+    with pytest.raises(ValueError, match="timeout_seconds"):
+        adapter.run_codex(codex_payload)
 
 
 def test_adapter_rejects_unsupported_runtime_mode(codex_payload):
@@ -322,6 +379,7 @@ async def test_fabric_session_invokes_codex_then_resumes(tmp_path):
         base_dir=tmp_path,
         session_id="fabric-session",
     ) as session:
+        assert session.session_id == "fabric-session"
         first = await session.invoke(input="first")
         second = await session.invoke(input="second")
 
@@ -376,6 +434,7 @@ def test_codex_profiles_resolve_runtime_mode(profile, mode, session_capability):
     assert plan.adapter.adapter_id == "nvidia.fabric.codex.cli"
     assert plan.adapter.harness == "codex"
     assert plan.effective_config.config.runtime.mode == mode
+    assert plan.effective_config.config.runtime.input_schema == "text"
     assert plan.capabilities.session is session_capability
     settings = plan.effective_config.config.harness.settings
     assert settings["config_overrides"]["model_reasoning_effort"] == "high"


### PR DESCRIPTION
## Summary

- add a Codex CLI process adapter for Fabric one-shot and session runtimes
- inherit Codex-owned authentication and configuration while applying explicit Fabric model, sandbox, profile, and `--config` overrides
- persist the Fabric session ID to Codex thread ID correlation and resume later turns with `codex exec resume`
- add runnable profiles, public usage docs, deterministic fake-CLI coverage, and an opt-in real integration smoke

## Runtime contract

One-shot runs use `codex exec --json --ephemeral`. Session runs capture the Codex-generated thread ID on the first turn and resume that same thread on subsequent Fabric invocations. Fabric does not read or copy Codex credentials or transcripts.

This PR is stacked on the Python SDK contract branch from #26.

closes FABRIC-8

## Validation

- `uv run pytest -q` (`100 passed, 4 skipped`)
- `cargo fmt --all -- --check`
- `cargo test --workspace --locked` (`40 passed`)
- `cargo check -p fabric-python`
- `python3 tests/smoke_cli.py`
- `uv run python python/tests/smoke_native_sdk.py`
- `RUN_FABRIC_CODEX_INTEGRATION=1 uv run python tests/smoke_codex_cli.py` (real one-shot plus two-turn resume using existing Codex authentication)
- `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Codex CLI adapter support for one-shot and session workflows, including automatic thread resume and persisted per-session state.
  * Added new Codex CLI example profiles for code-review runs.
* **Documentation**
  * Updated README to include Codex CLI in multi-adapter guidance and added login/session and run instructions.
  * Expanded Codex CLI adapter documentation with settings/flag mappings and session behavior.
* **Tests**
  * Added a full pytest suite for adapter behavior and an opt-in real smoke test for one-shot and session integration.
* **Chores**
  * Added an optional Codex dependency group.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->