### PR TITLE
Remove work-around for a Relay bug that has been fixed

### DIFF
--- a/adapters/codex-cli/src/nemo_fabric_adapters/codex_cli/adapter.py
+++ b/adapters/codex-cli/src/nemo_fabric_adapters/codex_cli/adapter.py
@@ -670,8 +670,6 @@ def run_codex(payload: dict[str, Any]) -> dict[str, Any]:
             codex_settings.codex_profile_path.unlink(missing_ok=True)
 
         if relay_gateway_process is not None:
-            # Work-around for RELAY-399, wait for subscribed events to be flushed before stopping nemo-relay
-            time.sleep(5)
             stop_relay_gateway(relay_gateway_process)
 
     parsed = parse_events(completed.stdout)


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved shutdown behavior so the relay gateway stops more reliably instead of waiting for queued relay events to finish flushing.
  * Reduced the chance of shutdown delays or hangs when closing the CLI integration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->