### PR TITLE
Add a `justfile` for build & test automation

### DIFF
--- a/.github/workflows/ci_python.yml
+++ b/.github/workflows/ci_python.yml
@@ -43,6 +43,11 @@ jobs:
         with:
           shared-key: fabric-rust
 
+      - name: Install just
+        uses: taiki-e/install-action@c070f87102a1c75b3183910f391c1cb887fe13c8 # v2.77.6
+        with:
+          tool: just@1.50.0
+
       - name: Set up uv
         uses: astral-sh/setup-uv@cec208311dfd045dd5311c1add060b2062131d57 # v8
 
@@ -51,7 +56,7 @@ jobs:
       - name: Build SDK with native extension
         run: |
           uv venv --python 3.12 .venv
-          uv pip install --python .venv/bin/python -e . "pyyaml>=6"
+          uv sync --group test --no-group dev --extra harbor --extra hermes --extra relay
 
       # Dependency-free smokes only: the gated integration smokes
       # (smoke_hermes_sdk, smoke_relay_integration, and the Docker-backed
@@ -86,5 +91,4 @@ jobs:
       - name: Run pytest
         run: |
           set -euo pipefail
-          uv sync --group test --no-group dev --extra harbor --extra hermes --extra relay
-          uv run pytest
+          just test-python

--- a/.github/workflows/ci_rust.yml
+++ b/.github/workflows/ci_rust.yml
@@ -33,6 +33,11 @@ jobs:
         with:
           persist-credentials: false
 
+      - name: Install just
+        uses: taiki-e/install-action@c070f87102a1c75b3183910f391c1cb887fe13c8 # v2.77.6
+        with:
+          tool: just@1.50.0
+
       - name: Set up Rust
         uses: actions-rust-lang/setup-rust-toolchain@150fca883cd4034361b621bd4e6a9d34e5143606 # v1.15.4
         with:
@@ -54,4 +59,4 @@ jobs:
       # Includes the schema snapshot tests, which guard the public contract
       # against drift from the Rust types.
       - name: Run workspace tests
-        run: cargo test --workspace --locked
+        run: just test-rust

--- a/.github/workflows/fern-docs.yml
+++ b/.github/workflows/fern-docs.yml
@@ -52,11 +52,6 @@ jobs:
         with:
           node-version: "20"
 
-      # Publishing and previews call `fern` directly in later steps, so keep a
-      # globally available CLI in addition to the validation run by `just docs`.
-      - name: Install Fern CLI
-        run: npm install -g fern-api@5.37.10
-
       # Generate the Python reference from SDK docstrings and the Rust reference
       # from rustdoc, then validate the Fern configuration.
       - name: Generate API references and validate docs
@@ -67,7 +62,7 @@ jobs:
         if: github.ref_name == 'main'
         env:
           FERN_TOKEN: ${{ secrets.FERN_TOKEN }}
-        run: fern generate --docs
+        run: npx --prefix docs --no-install fern generate --docs
 
       # Build a preview deployment for the PR and capture its URL.
       - name: Preview docs
@@ -78,7 +73,7 @@ jobs:
         run: |
           set -euo pipefail
           pr_number="${GITHUB_REF_NAME#pull-request/}"
-          if output="$(fern generate --docs --preview --id "pull-request-${pr_number}" 2>&1)"; then
+          if output="$(npx --prefix docs --no-install fern generate --docs --preview --id "pull-request-${pr_number}" 2>&1)"; then
             fern_exit=0
           else
             fern_exit=$?

--- a/.github/workflows/fern-docs.yml
+++ b/.github/workflows/fern-docs.yml
@@ -31,6 +31,11 @@ jobs:
         with:
           persist-credentials: false
 
+      - name: Install just
+        uses: taiki-e/install-action@c070f87102a1c75b3183910f391c1cb887fe13c8 # v2.77.6
+        with:
+          tool: just@1.50.0
+
       - name: Set up uv
         uses: astral-sh/setup-uv@cec208311dfd045dd5311c1add060b2062131d57 # v8
 
@@ -42,25 +47,20 @@ jobs:
           toolchain: stable
           cache: false
 
-      # The Python reference is generated from the SDK docstrings (lazydocs) and
-      # the Rust reference from rustdoc (cargo doc --no-deps -p fabric-core),
-      # so the published docs never drift from the code.
-      - name: Generate API reference (Python docstrings + Rust rustdoc)
-        run: |
-          uv sync --extra docs
-          PATH="$PWD/.venv/bin:$PATH" bash scripts/generate_api_docs.sh
-          .venv/bin/python scripts/docs/generate_rust_library_reference.py
-
       - name: Set up Node
         uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6
         with:
           node-version: "20"
 
+      # Publishing and previews call `fern` directly in later steps, so keep a
+      # globally available CLI in addition to the validation run by `just docs`.
       - name: Install Fern CLI
         run: npm install -g fern-api@5.37.10
 
-      - name: Validate docs config
-        run: fern check
+      # Generate the Python reference from SDK docstrings and the Rust reference
+      # from rustdoc, then validate the Fern configuration.
+      - name: Generate API references and validate docs
+        run: just docs
 
       # Publish to the (internal-by-default) Fern site on merge to main.
       - name: Publish docs

--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,7 @@ __pycache__/
 *.egg-info/
 dist/
 build/
+/docs/node_modules/
 
 examples/*/artifacts/
 tests/fixtures/*/artifacts/

--- a/README.md
+++ b/README.md
@@ -57,15 +57,20 @@ Prerequisites:
 - Rust and Cargo
 - Python 3.10+ for Fabric
 - Python 3.11-3.13 for Hermes
+- `just` 1.50.0+
 - `NVIDIA_API_KEY` for NVIDIA-hosted model access
 
-Install Fabric and the `fabric` CLI:
+Install `just` if not already installed.
+```bash
+cargo install just --locked
+```
+
+Refer to the [official installation guide](https://just.systems/man/en/installation.html) for more details.
+
+Install Fabric and the `fabric` CLI from the source checkout:
 
 ```bash
-python3 -m venv .tmp/fabric-venv
-.tmp/fabric-venv/bin/python -m pip install -e .
-
-cargo install --path crates/fabric-cli --locked --force
+just build-all
 export PATH="$HOME/.cargo/bin:$PATH"
 ```
 
@@ -314,8 +319,8 @@ The opt-in real integration checks are `tests/smoke_hermes_session.py` and
 `start_session(...)` drive the core Fabric runtime lifecycle (`start_runtime` /
 `invoke_runtime` / `stop_runtime`) so one-shot and session paths use the same
 adapter execution contract. The CLI is a separate interface over the same Rust
-core. For source-tree development, install the package with
-`python3 -m pip install -e .` before using the SDK.
+core. For source-tree development, run `just build-python` before using the
+SDK.
 
 ## Harbor Integration
 

--- a/docs/getting-started/overview.mdx
+++ b/docs/getting-started/overview.mdx
@@ -64,12 +64,21 @@ request and the use of returned evidence.
 
 ## Quick start
 
+Install `just` 1.50.0+ if it is not already available.
+
+```bash
+cargo install just --locked
+```
+
+Refer to the [official installation guide](https://just.systems/man/en/installation.html)
+for more details.
+
 Install the Python SDK with its native binding and the CLI from a source
 checkout:
 
 ```bash
-python3 -m pip install -e .
-cargo install --path crates/fabric-cli --locked --force
+just build-all
+export PATH="$HOME/.cargo/bin:$PATH"
 ```
 
 Inspect and diagnose an agent package before running it:

--- a/docs/package-lock.json
+++ b/docs/package-lock.json
@@ -1,0 +1,212 @@
+{
+  "name": "nemo-fabric-docs",
+  "version": "0.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "nemo-fabric-docs",
+      "version": "0.0.0",
+      "devDependencies": {
+        "fern-api": "5.37.10"
+      }
+    },
+    "node_modules/@boundaryml/baml": {
+      "version": "0.219.0",
+      "resolved": "https://registry.npmjs.org/@boundaryml/baml/-/baml-0.219.0.tgz",
+      "integrity": "sha512-hE6t6G/1Td9yYN/T6E13igF06ZHD0J9dr5FH3tjCCZQplqTLBiVn4wyVoboK7ypjdHdGkg6O0vAcXrcbdwM6pA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@scarf/scarf": "^1.3.0"
+      },
+      "bin": {
+        "baml": "cli.js",
+        "baml-cli": "cli.js"
+      },
+      "engines": {
+        "node": ">= 10"
+      },
+      "optionalDependencies": {
+        "@boundaryml/baml-darwin-arm64": "0.219.0",
+        "@boundaryml/baml-darwin-x64": "0.219.0",
+        "@boundaryml/baml-linux-arm64-gnu": "0.219.0",
+        "@boundaryml/baml-linux-arm64-musl": "0.219.0",
+        "@boundaryml/baml-linux-x64-gnu": "0.219.0",
+        "@boundaryml/baml-linux-x64-musl": "0.219.0",
+        "@boundaryml/baml-win32-arm64-msvc": "0.219.0",
+        "@boundaryml/baml-win32-x64-msvc": "0.219.0"
+      }
+    },
+    "node_modules/@boundaryml/baml-darwin-arm64": {
+      "version": "0.219.0",
+      "resolved": "https://registry.npmjs.org/@boundaryml/baml-darwin-arm64/-/baml-darwin-arm64-0.219.0.tgz",
+      "integrity": "sha512-jhPN83UM+9Y99aCbzIS/3OpC7N8dOukPZO2piueIbzsmpaJrzTW+srKxYtVDE26Q9riFypOmizSs5SBFst04Fw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@boundaryml/baml-darwin-x64": {
+      "version": "0.219.0",
+      "resolved": "https://registry.npmjs.org/@boundaryml/baml-darwin-x64/-/baml-darwin-x64-0.219.0.tgz",
+      "integrity": "sha512-t7pnbVT3KEE3+stOrW7nATdipCWK8OK1gTV8qiD4pN8lZwGMtJpzrVvgWeycroWCaeJ8tNsQA/V2FyFU9pqjkg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@boundaryml/baml-linux-arm64-gnu": {
+      "version": "0.219.0",
+      "resolved": "https://registry.npmjs.org/@boundaryml/baml-linux-arm64-gnu/-/baml-linux-arm64-gnu-0.219.0.tgz",
+      "integrity": "sha512-a3ikRhlOdX+Lb08TaZU4k1Qb55mAHMuwArxpM1No/ltc0ylvo9EbJ4Nv0ZKemEHdngM6udagwdDxohpNzR1QTg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@boundaryml/baml-linux-arm64-musl": {
+      "version": "0.219.0",
+      "resolved": "https://registry.npmjs.org/@boundaryml/baml-linux-arm64-musl/-/baml-linux-arm64-musl-0.219.0.tgz",
+      "integrity": "sha512-KjwJL5aXf4XvwpX3RwMau19XcHDcffhbiTX+tk41kGC4LZl7UXB4FgnOBtSOMvWtHj2f4cIN81+yCZBRsMxdNg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@boundaryml/baml-linux-x64-gnu": {
+      "version": "0.219.0",
+      "resolved": "https://registry.npmjs.org/@boundaryml/baml-linux-x64-gnu/-/baml-linux-x64-gnu-0.219.0.tgz",
+      "integrity": "sha512-JWMhzx1LDfCPwDbOUQbFaPgNb7TUvLCb4+1TjRAJR+Z2Nl08RqNWUUfFctMEzsN6HrcHVOZ0xSl/hJRxN8OcTA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@boundaryml/baml-linux-x64-musl": {
+      "version": "0.219.0",
+      "resolved": "https://registry.npmjs.org/@boundaryml/baml-linux-x64-musl/-/baml-linux-x64-musl-0.219.0.tgz",
+      "integrity": "sha512-lPosn6eJqI+8EjMI71AUEb3B9uk4dUfQgerbDyu6FvNMWx+HZDPB4UWl66+OlEeMA2Gb6DUp3LLE/Jl9/KDKSg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@boundaryml/baml-win32-arm64-msvc": {
+      "version": "0.219.0",
+      "resolved": "https://registry.npmjs.org/@boundaryml/baml-win32-arm64-msvc/-/baml-win32-arm64-msvc-0.219.0.tgz",
+      "integrity": "sha512-djy9pn8s1Ogr3ovTDxDcOiM1YOhkBwNsBnlZDQzrIdR/LgSh/GGmrwW5Ks3gfa2NvvNOIFPccdUp0nDZZNsjfQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@boundaryml/baml-win32-x64-msvc": {
+      "version": "0.219.0",
+      "resolved": "https://registry.npmjs.org/@boundaryml/baml-win32-x64-msvc/-/baml-win32-x64-msvc-0.219.0.tgz",
+      "integrity": "sha512-BJkgq/qyn3BcBZt3iyfYWirZyZrKiqa1J0OTWd45P8OQ8dJhRnU6JGcpXPTXNmkryXQFY+O4HA+lQBKA5SZ7kg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@scarf/scarf": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@scarf/scarf/-/scarf-1.4.0.tgz",
+      "integrity": "sha512-xxeapPiUXdZAE3che6f3xogoJPeZgig6omHEy1rIY5WVsB3H2BHNnZH+gHG6x91SCWyQCzWGsuL2Hh3ClO5/qQ==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "Apache-2.0",
+      "optional": true
+    },
+    "node_modules/fern-api": {
+      "version": "5.37.10",
+      "resolved": "https://registry.npmjs.org/fern-api/-/fern-api-5.37.10.tgz",
+      "integrity": "sha512-GQ/lrHsB2nw0ZkuUas/nWLtxd/SSwX0Sj6QFwLSMPAImeVrN/m8871EH3pXH+Ht8cuSSxHUWlEU4buPtznwavA==",
+      "dev": true,
+      "bin": {
+        "fern": "cli.cjs"
+      },
+      "optionalDependencies": {
+        "@boundaryml/baml": "^0.219.0"
+      }
+    }
+  }
+}

--- a/docs/package.json
+++ b/docs/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "nemo-fabric-docs",
+  "private": true,
+  "version": "0.0.0",
+  "devDependencies": {
+    "fern-api": "5.37.10"
+  }
+}

--- a/examples/README.md
+++ b/examples/README.md
@@ -19,11 +19,14 @@ The first example focuses on the shared Fabric contract:
 Start with:
 
 ```bash
-cargo run -p fabric-cli -- validate examples/code-review-agent
-cargo run -p fabric-cli -- inspect examples/code-review-agent
-cargo run -p fabric-cli -- plan examples/code-review-agent
-cargo run -p fabric-cli -- plan examples/code-review-agent --profile env_local --profile mcp_github
-cargo run -p fabric-cli -- plan examples/code-review-agent --profile hermes_cli
+just build-rust
+export PATH="$HOME/.cargo/bin:$PATH"
+
+fabric validate examples/code-review-agent
+fabric inspect examples/code-review-agent
+fabric plan examples/code-review-agent
+fabric plan examples/code-review-agent --profile env_local --profile mcp_github
+fabric plan examples/code-review-agent --profile hermes_cli
 ```
 
 The dependency-free Hermes shim used by smoke tests lives under

--- a/justfile
+++ b/justfile
@@ -34,6 +34,7 @@ build-rust:
 # --set [no_uv=true|false]
 build-python:
     #!/usr/bin/env bash
+    set -euo pipefail
     if [[ "{{ no_uv }}" == "true" ]]; then
         uv pip install --python .venv/bin/python --no-deps --reinstall --editable .
     else
@@ -47,6 +48,7 @@ build-all: build-rust build-python
 # --set [no_uv=true|false]
 docs:
     #!/usr/bin/env bash
+    set -euo pipefail
     if [[ "{{ no_uv }}" != "true" ]]; then
         uv sync --extra docs
     fi
@@ -59,6 +61,7 @@ docs:
 # --set [no_uv=true|false]
 test-python:
     #!/usr/bin/env bash
+    set -euo pipefail
     if [[ "{{ no_uv }}" != "true" ]]; then
         uv sync --group test --no-group dev --extra harbor --extra hermes --extra relay
     fi

--- a/justfile
+++ b/justfile
@@ -30,6 +30,7 @@ build-rust:
     cargo install --path crates/fabric-cli --locked --force
 
 # Build and install the Python package and native extension in the project environment.
+# --set [no_uv=true|false]
 build-python:
     #!/usr/bin/env bash
     if [[ "{{ no_uv }}" == "true" ]]; then
@@ -42,6 +43,7 @@ build-python:
 build-all: build-rust build-python
 
 # Generate the Python and Rust API references and validate the Fern configuration.
+# --set [no_uv=true|false]
 docs:
     #!/usr/bin/env bash
     if [[ "{{ no_uv }}" != "true" ]]; then
@@ -52,6 +54,7 @@ docs:
     npx --yes fern-api@5.37.10 check
 
 # Run the Python test suite with the same optional integrations used by CI.
+# --set [no_uv=true|false]
 test-python:
     #!/usr/bin/env bash
     if [[ "{{ no_uv }}" != "true" ]]; then

--- a/justfile
+++ b/justfile
@@ -22,6 +22,7 @@ clean:
         **/*.so \
         **/coverage.xml \
         **/dist \
+        docs/node_modules \
         target/
 
 # Build the Rust workspace using the locked dependency set.
@@ -49,9 +50,10 @@ docs:
     if [[ "{{ no_uv }}" != "true" ]]; then
         uv sync --extra docs
     fi
+    npm ci --prefix docs --ignore-scripts
     PATH="{{ REPO_ROOT }}/.venv/bin:$PATH" bash scripts/generate_api_docs.sh
     uv run --no-sync python scripts/docs/generate_rust_library_reference.py
-    npx --yes fern-api@5.37.10 check
+    npx --prefix docs --no-install fern check
 
 # Run the Python test suite with the same optional integrations used by CI.
 # --set [no_uv=true|false]

--- a/justfile
+++ b/justfile
@@ -1,0 +1,67 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+set shell := ["bash", "-eu", "-o", "pipefail", "-c"]
+
+export REPO_ROOT := justfile_directory()
+
+# Skip dependency synchronization when the project environment is already fully synced.
+no_uv := "false"
+
+# Remove local Rust and Python build and test artifacts.
+clean:
+    #!/usr/bin/env bash
+    shopt -s globstar nullglob
+    cargo clean
+    rm -rf \
+        .coverage \
+        .pytest_cache \
+        python/.pytest_cache \
+        **/__pycache__ \
+        **/*.egg-info \
+        **/*.so \
+        **/coverage.xml \
+        **/dist \
+        target/
+
+# Build the Rust workspace using the locked dependency set.
+build-rust:
+    cargo build --workspace --locked
+    cargo install --path crates/fabric-cli --locked --force
+
+# Build and install the Python package and native extension in the project environment.
+build-python:
+    #!/usr/bin/env bash
+    if [[ "{{ no_uv }}" == "true" ]]; then
+        uv pip install --python .venv/bin/python --no-deps --reinstall --editable .
+    else
+        uv sync --no-default-groups --reinstall-package nemo-fabric
+    fi
+
+# Build all supported language packages.
+build-all: build-rust build-python
+
+# Generate the Python and Rust API references and validate the Fern configuration.
+docs:
+    #!/usr/bin/env bash
+    if [[ "{{ no_uv }}" != "true" ]]; then
+        uv sync --extra docs
+    fi
+    PATH="{{ REPO_ROOT }}/.venv/bin:$PATH" bash scripts/generate_api_docs.sh
+    uv run --no-sync python scripts/docs/generate_rust_library_reference.py
+    npx --yes fern-api@5.37.10 check
+
+# Run the Python test suite with the same optional integrations used by CI.
+test-python:
+    #!/usr/bin/env bash
+    if [[ "{{ no_uv }}" != "true" ]]; then
+        uv sync --group test --no-group dev --extra harbor --extra hermes --extra relay
+    fi
+    uv run --no-sync pytest
+
+# Run the Rust workspace test suite using the locked dependency set.
+test-rust:
+    cargo test --workspace --locked
+
+# Run all Rust and Python tests.
+test-all: test-rust test-python


### PR DESCRIPTION
* Update Github CI workflows to use `just`
* Update documentation to use `just`
* Just recipes:
  -  build-all
  -  build-python
  -  build-rust
  -  clean
  -  docs
  -  test-all
  -  test-python
  -  test-rust
* Optional `no_uv` avoids commands that would modify the user's local venv


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a unified `just`-based automation workflow for building, testing, cleanup, and docs across Rust and Python.

* **CI / Testing**
  * Updated Rust and Python CI to run tests via `just`.
  * Standardized CI dependency setup and streamlined docs validation using `just docs` (including Fern generation via `npx`).

* **Documentation**
  * Updated README, getting-started, and examples to require `just` (v1.50.0+) and use `just build-*` steps.

* **Chores**
  * Ignored `docs/node_modules` and added docs-specific `package.json` configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->