### PR TITLE
ci: Add nightly CI tags/builds

### DIFF
--- a/.github/workflows/ci_python.yml
+++ b/.github/workflows/ci_python.yml
@@ -71,10 +71,6 @@ jobs:
       - name: Set up uv
         uses: astral-sh/setup-uv@cec208311dfd045dd5311c1add060b2062131d57 # v8
 
-      - name: Set version from tag
-        if: ${{ (inputs.ref_type || github.ref_type) == 'tag' }}
-        run: just set-version "${{ inputs.ref_name || github.ref_name }}"
-
       - name: Cache cargo build
         uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
         with:
@@ -133,7 +129,9 @@ jobs:
 
       - name: Set version from tag
         if: ${{ (inputs.ref_type || github.ref_type) == 'tag' }}
-        run: just set-version "${{ inputs.ref_name || github.ref_name }}"
+        env:
+          RELEASE_VERSION: ${{ inputs.ref_name || github.ref_name }}
+        run: just set-version "$RELEASE_VERSION"
 
       - name: Cache cargo build
         uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1

--- a/.github/workflows/ci_python.yml
+++ b/.github/workflows/ci_python.yml
@@ -4,12 +4,29 @@
 name: Python
 
 on:
+  workflow_call:
+    inputs:
+      ref:
+        description: 'The Git ref to check out; defaults to the triggering commit'
+        required: false
+        default: ''
+        type: string
+      ref_name:
+        description: 'The effective ref name; defaults to the triggering ref name'
+        required: false
+        default: ''
+        type: string
+      ref_type:
+        description: 'The effective ref type; defaults to the triggering ref type'
+        required: false
+        default: ''
+        type: string
   pull_request:
   push:
     branches: [main]
 
 concurrency:
-  group: ci-python-${{ github.ref }}
+  group: ci-python-${{ inputs.ref || github.ref }}
   cancel-in-progress: true
 
 defaults:
@@ -36,6 +53,7 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           persist-credentials: false
+          ref: ${{ inputs.ref || github.sha }}
 
       # Rust is needed both to build the native extension (maturin backend) and
       # because the CLI-backed smokes shell out to `cargo run -p fabric-cli`.
@@ -45,11 +63,6 @@ jobs:
           toolchain: stable
           cache: false
 
-      - name: Cache cargo build
-        uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
-        with:
-          shared-key: fabric-rust
-
       - name: Install just
         uses: taiki-e/install-action@c070f87102a1c75b3183910f391c1cb887fe13c8 # v2.77.6
         with:
@@ -57,6 +70,15 @@ jobs:
 
       - name: Set up uv
         uses: astral-sh/setup-uv@cec208311dfd045dd5311c1add060b2062131d57 # v8
+
+      - name: Set version from tag
+        if: ${{ (inputs.ref_type || github.ref_type) == 'tag' }}
+        run: just set-version "${{ inputs.ref_name || github.ref_name }}"
+
+      - name: Cache cargo build
+        uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
+        with:
+          shared-key: fabric-rust
 
       # PyYAML is not a project dependency, but test_hermes_config_mapping
       # imports it to read Hermes config fixtures, so install it for the tests.
@@ -90,17 +112,13 @@ jobs:
         with:
           persist-credentials: false
           fetch-depth: 0
+          ref: ${{ inputs.ref || github.sha }}
 
       - name: Set up Rust
         uses: actions-rust-lang/setup-rust-toolchain@150fca883cd4034361b621bd4e6a9d34e5143606 # v1.15.4
         with:
           toolchain: stable
           cache: false
-
-      - name: Cache cargo build
-        uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
-        with:
-          shared-key: fabric-python-wheels
 
       - name: Install just
         uses: taiki-e/install-action@c070f87102a1c75b3183910f391c1cb887fe13c8 # v2.77.6
@@ -112,6 +130,15 @@ jobs:
         with:
           enable-cache: true
           cache-dependency-glob: uv.lock
+
+      - name: Set version from tag
+        if: ${{ (inputs.ref_type || github.ref_type) == 'tag' }}
+        run: just set-version "${{ inputs.ref_name || github.ref_name }}"
+
+      - name: Cache cargo build
+        uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
+        with:
+          shared-key: fabric-python-wheels
 
       - name: Build wheels
         run: just wheels

--- a/.github/workflows/nightly-alpha-tag.yml
+++ b/.github/workflows/nightly-alpha-tag.yml
@@ -6,7 +6,7 @@ name: Create nightly alpha tag
 on:
   workflow_dispatch:
   schedule:
-    # Create the nightly alpha tag at 08:12 UTC (12:12 PST / 1:12 PDT).
+    # Create the nightly alpha tag at 08:12 UTC (00:12 PST / 01:12 PDT).
     - cron: '12 8 * * *'
 
 concurrency:

--- a/.github/workflows/nightly-alpha-tag.yml
+++ b/.github/workflows/nightly-alpha-tag.yml
@@ -1,0 +1,85 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+name: Create nightly alpha tag
+
+on:
+  workflow_dispatch:
+  schedule:
+    # Create the nightly alpha tag at 08:12 UTC (12:12 PST / 1:12 PDT).
+    - cron: '12 8 * * *'
+
+concurrency:
+  group: '${{ github.workflow }} @ ${{ github.ref }}'
+  cancel-in-progress: false
+
+jobs:
+  tag-nightly-alpha:
+    name: Tag nightly alpha
+    runs-on: ubuntu-24.04
+    timeout-minutes: 10
+    permissions:
+      contents: write
+    outputs:
+      tag: ${{ steps.tag.outputs.tag }}
+    steps:
+      - name: Checkout main
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          fetch-depth: 0
+          persist-credentials: true
+          ref: main
+
+      - name: Create nightly alpha tag
+        id: tag
+        run: |
+          set -euo pipefail
+
+          version="$(sed -n 's/^version = "\(.*\)"$/\1/p' Cargo.toml | head -n 1)"
+          if [[ -z "$version" ]]; then
+            echo "Error: failed to read workspace version from Cargo.toml" >&2
+            exit 1
+          fi
+          if [[ ! "$version" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo "Error: workspace version must be a stable SemVer base for nightly alpha tags: ${version}" >&2
+            exit 1
+          fi
+
+          tag_date="$(date -u +%Y%m%d)"
+          tag="${version}-alpha.${tag_date}"
+          target_sha="$(git rev-parse HEAD)"
+          printf 'tag=%s\n' "$tag" >> "$GITHUB_OUTPUT"
+
+          if git ls-remote --exit-code --tags origin "refs/tags/${tag}" >/dev/null 2>&1; then
+            existing_sha="$(git ls-remote --tags origin "refs/tags/${tag}^{}" | awk '{print $1}' || true)"
+            if [[ -z "$existing_sha" ]]; then
+              existing_sha="$(git ls-remote --tags origin "refs/tags/${tag}" | awk '{print $1}' || true)"
+            fi
+            if [[ "$existing_sha" == "$target_sha" ]]; then
+              echo "Nightly alpha tag already exists for main: ${tag}"
+              exit 0
+            fi
+            echo "Error: nightly alpha tag ${tag} already exists at ${existing_sha}, not main HEAD ${target_sha}" >&2
+            exit 1
+          fi
+
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git tag \
+            --annotate \
+            --message "NeMo Fabric ${version} Nightly ${tag_date}" \
+            "$tag" \
+            "$target_sha"
+          git push origin "refs/tags/${tag}"
+          echo "Created nightly alpha tag for main: ${tag}"
+
+  python-ci:
+    name: Python
+    needs: tag-nightly-alpha
+    permissions:
+      contents: read
+    uses: ./.github/workflows/ci_python.yml
+    with:
+      ref: refs/tags/${{ needs.tag-nightly-alpha.outputs.tag }}
+      ref_name: ${{ needs.tag-nightly-alpha.outputs.tag }}
+      ref_type: tag

--- a/.github/workflows/nightly-alpha-tag.yml
+++ b/.github/workflows/nightly-alpha-tag.yml
@@ -19,6 +19,7 @@ jobs:
     runs-on: ubuntu-24.04
     timeout-minutes: 10
     permissions:
+      # Needed to create and push the nightly alpha tag
       contents: write
     outputs:
       tag: ${{ steps.tag.outputs.tag }}


### PR DESCRIPTION
#### Overview

* Create a nightly alpha tag
* Build Python wheels
* Adapted from Relay

#### Where should the reviewer start?

* `.github/workflows/nightly-alpha-tag.yml`

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)


- [x] I confirm this contribution is my own work, or I have the right to submit it under this project's license.
- [x] I searched existing issues and open pull requests, and this does not duplicate existing work.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Enhanced Python CI workflow to better support reusable runs and tagged revisions by correctly checking out the intended ref/sha.
  * Updated concurrency handling and rearranged caching steps for more reliable execution.
  * Improved wheel builds with tag-based version setting and adjusted cache timing.

* **New Features**
  * Added a new workflow to create and push annotated “nightly alpha” tags on `main`.
  * Avoids retagging when the tag already exists at the current commit, and triggers Python CI for the resulting tag.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->