### PR TITLE
Update license and contributor docs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -148,11 +148,45 @@ clearly separates entry-point changes, reference changes, examples, and
 maintenance updates.
 
 ## DCO Sign-Off
+* We require that all contributors "sign-off" on their commits. This certifies that the contribution is your original work, or you have rights to submit it under the same license, or a compatible license.
+  * Any contribution which contains commits that are not Signed-Off will not be accepted.
+* To sign off on a commit you simply use the `--signoff` (or `-s`) option when committing your changes:
+  ```bash
+  $ git commit -s -m "Add cool feature."
+  ```
+  This will append the following to your commit message:
+  ```
+  Signed-off-by: Your Name <your@email.com>
+  ```
+* Full text of the DCO (https://developercertificate.org/):
+  ```
+    Developer Certificate of Origin
+    Version 1.1
+    Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
+    Everyone is permitted to copy and distribute verbatim copies of this
+    license document, but changing it is not allowed.
+    Developer's Certificate of Origin 1.1
+    By making a contribution to this project, I certify that:
+    (a) The contribution was created in whole or in part by me and I
+        have the right to submit it under the open source license
+        indicated in the file; or
+    (b) The contribution is based upon previous work that, to the best
+        of my knowledge, is covered under an appropriate open source
+        license and I have the right under that license to submit that
+        work with modifications, whether created in whole or in part
+        by me, under the same open source license (unless I am
+        permitted to submit under a different license), as indicated
+        in the file; or
+    (c) The contribution was provided directly to me by some other
+        person who certified (a), (b) or (c) and I have not modified
+        it.
+    (d) I understand and agree that this project and the contribution
+        are public and that a record of the contribution (including all
+        personal information I submit with it, including my sign-off) is
+        maintained indefinitely and may be redistributed consistent with
+        this project or the open source license(s) involved.
+  ```
 
-Every commit in a pull request must include a Developer Certificate of Origin
-sign-off.
-
-Use `git commit --signoff` when creating commits, or add a `Signed-off-by:` trailer when fixing an older commit before review.
 
 ## Pull Request Process
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -152,8 +152,7 @@ maintenance updates.
 Every commit in a pull request must include a Developer Certificate of Origin
 sign-off.
 
-Use the `-s`/`--signoff` flag with `git commit` when creating commits, or add a `Signed-off-by:` trailer when
-fixing an older commit before review.
+Use `git commit --signoff` when creating commits, or add a `Signed-off-by:` trailer when fixing an older commit before review.
 
 ## Pull Request Process
 

--- a/LICENSE
+++ b/LICENSE
@@ -1,3 +1,8 @@
+<!--
+SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+SPDX-License-Identifier: Apache-2.0
+-->
+
                                  Apache License
                            Version 2.0, January 2004
                         http://www.apache.org/licenses/


### PR DESCRIPTION
- [x] I confirm this contribution is my own work, or I have the right to submit it under this project's license.
- [x] I searched existing issues and open pull requests, and this does not duplicate existing work.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Expanded the contribution guidance for DCO sign-offs, including a concrete `git commit -s -m ...` example and the exact `Signed-off-by:` trailer text, with full DCO v1.1 wording.

* **Legal and Licensing**
  * Updated the license header to include SPDX attribution and `SPDX-License-Identifier: Apache-2.0`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->