### PR TITLE
ci: Enable pypi publishing

### DIFF
--- a/scripts/ci/artifactory_upload.py
+++ b/scripts/ci/artifactory_upload.py
@@ -61,7 +61,7 @@ def perform_release(published_wheels: list[tuple[Path, str]]) -> None:
                 "pic": kitmaker_owner,
                 "job_type": "wheel-release-job",
                 "url": wheel_url,
-                "upload": False,  # For now just use a dry run
+                "upload": True,
             }],
         }
 


### PR DESCRIPTION
#### Overview

* Currently with `upload=False` we are running in dry-run mode, setting to True enables publishing to pypi.org

#### Where should the reviewer start?

* `scripts/ci/artifactory_upload.py`


- [x] I confirm this contribution is my own work, or I have the right to submit it under this project's license.
- [x] I searched existing issues and open pull requests, and this does not duplicate existing work.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Release uploads now correctly submit built packages instead of treating each upload as a dry run.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->