### PR TITLE
fix(hermes): default `max_iterations` to Hermes' default

### DIFF
--- a/adapters/hermes/src/nemo_fabric_adapters/hermes/adapter.py
+++ b/adapters/hermes/src/nemo_fabric_adapters/hermes/adapter.py
@@ -26,7 +26,7 @@ import nemo_fabric_adapters.common.utils as common_utils
 # Mirrors Hermes' own AIAgent default (agent/agent_init.py); a lower value such
 # as 1 silently starves multi-step tasks (they run out of budget before
 # answering while the trial still reports success). See FABRIC-85.
-DEFAULT_MAX_ITERATIONS = 90
+DEFAULT_MAX_ITERATIONS: int = 90
 
 
 def validate_hermes_telemetry_provider(payload: dict[str, Any]) -> None:
@@ -284,6 +284,10 @@ def _invoke_hermes(
         session_id = common_utils.runtime_id(payload)
         session_db = SessionDB()
         conversation_history = load_runtime_history(session_db, session_id)
+        # Treat an explicit null max_iterations like an unset one (avoid int(None)).
+        max_iterations = settings.get("max_iterations")
+        if max_iterations is None:
+            max_iterations = DEFAULT_MAX_ITERATIONS
         agent = None
         agent = AIAgent(
             **filter_supported_kwargs(
@@ -292,7 +296,7 @@ def _invoke_hermes(
                 api_key=api_key,
                 provider=settings.get("provider") or model_config.get("provider"),
                 model=settings.get("model_name") or model_config.get("model", ""),
-                max_iterations=int(settings.get("max_iterations", DEFAULT_MAX_ITERATIONS)),
+                max_iterations=int(max_iterations),
                 enabled_toolsets=enabled_toolsets,
                 disabled_toolsets=settings.get("disabled_toolsets"),
                 quiet_mode=True,

--- a/adapters/hermes/src/nemo_fabric_adapters/hermes/adapter.py
+++ b/adapters/hermes/src/nemo_fabric_adapters/hermes/adapter.py
@@ -22,6 +22,12 @@ from typing import Any
 
 import nemo_fabric_adapters.common.utils as common_utils
 
+# Default agent loop budget when harness.settings.max_iterations is unset.
+# Mirrors Hermes' own AIAgent default (agent/agent_init.py); a lower value such
+# as 1 silently starves multi-step tasks (they run out of budget before
+# answering while the trial still reports success). See FABRIC-85.
+DEFAULT_MAX_ITERATIONS = 90
+
 
 def validate_hermes_telemetry_provider(payload: dict[str, Any]) -> None:
     providers = common_utils.telemetry_providers(payload)
@@ -286,7 +292,7 @@ def _invoke_hermes(
                 api_key=api_key,
                 provider=settings.get("provider") or model_config.get("provider"),
                 model=settings.get("model_name") or model_config.get("model", ""),
-                max_iterations=int(settings.get("max_iterations", 1)),
+                max_iterations=int(settings.get("max_iterations", DEFAULT_MAX_ITERATIONS)),
                 enabled_toolsets=enabled_toolsets,
                 disabled_toolsets=settings.get("disabled_toolsets"),
                 quiet_mode=True,

--- a/tests/adapters/test_hermes_adapter.py
+++ b/tests/adapters/test_hermes_adapter.py
@@ -147,6 +147,23 @@ def test_build_hermes_config_omits_max_turns_when_max_iterations_unset():
     assert "max_turns" not in config["agent"]
 
 
+def test_build_hermes_config_omits_max_turns_when_max_iterations_null():
+    # An explicit null max_iterations is treated like unset: agent.max_turns is
+    # omitted so Hermes applies its own default instead of a starving override.
+    payload = {
+        "effective_config": {
+            "config": {
+                "harness": {"settings": {"max_iterations": None}},
+                "models": {"default": {"provider": "nvidia", "model": "nvidia/test-model"}},
+            }
+        }
+    }
+
+    config = adapter.build_hermes_config(payload)
+
+    assert "max_turns" not in config["agent"]
+
+
 def test_hermes_config_variation_matrix_surfaces_supported_capabilities(
     tmp_path: Path,
 ):
@@ -387,6 +404,8 @@ async def test_fabric_runtime_id_drives_hermes_session_id_and_db_history(
                         "hermes_home": "./hermes-home",
                         "enabled_toolsets": [],
                         "system_prompt": "system",
+                        # Explicit null must resolve to DEFAULT_MAX_ITERATIONS (not int(None)).
+                        "max_iterations": None,
                     }
                 },
                 "models": {

--- a/tests/adapters/test_hermes_adapter.py
+++ b/tests/adapters/test_hermes_adapter.py
@@ -120,6 +120,33 @@ def test_build_hermes_config_maps_fabric_config_to_hermes_config():
     }
 
 
+def test_default_max_iterations_matches_hermes_library_default():
+    # Regression guard for FABRIC-85: the adapter must not override Hermes' own
+    # sane loop budget with a starving value like 1, which silently truncates
+    # multi-step tasks while the trial still reports success.
+    assert adapter.DEFAULT_MAX_ITERATIONS > 1
+
+    hermes_default = inspect.signature(AIAgent.__init__).parameters["max_iterations"].default
+    assert adapter.DEFAULT_MAX_ITERATIONS == hermes_default
+
+
+def test_build_hermes_config_omits_max_turns_when_max_iterations_unset():
+    # When max_iterations is unset the config layer must leave agent.max_turns
+    # absent so Hermes applies its own default rather than a starving override.
+    payload = {
+        "effective_config": {
+            "config": {
+                "harness": {"settings": {}},
+                "models": {"default": {"provider": "nvidia", "model": "nvidia/test-model"}},
+            }
+        }
+    }
+
+    config = adapter.build_hermes_config(payload)
+
+    assert "max_turns" not in config["agent"]
+
+
 def test_hermes_config_variation_matrix_surfaces_supported_capabilities(
     tmp_path: Path,
 ):
@@ -393,7 +420,7 @@ async def test_fabric_runtime_id_drives_hermes_session_id_and_db_history(
         api_key="secret",
         provider="test-provider",
         model="test-model",
-        max_iterations=1,
+        max_iterations=90,
         enabled_toolsets=[],
         disabled_toolsets=None,
         quiet_mode=True,


### PR DESCRIPTION
## Summary

The Hermes adapter constructed `AIAgent` with `max_iterations` defaulting to **1** when `harness.settings.max_iterations` was unset (`adapters/hermes/.../adapter.py`), giving the agent a single model turn. Multi-step tasks ran out of budget before producing an answer, yet the trial still reported `succeeded` — a **silently-wrong result**, not an error.

This changes the default to Hermes' own `AIAgent` default (**90**) via a named constant `DEFAULT_MAX_ITERATIONS`, so the adapter no longer overrides a sane default with a starving one.

## Changes

- `adapters/hermes/src/nemo_fabric_adapters/hermes/adapter.py`: add `DEFAULT_MAX_ITERATIONS = 90` (mirrors Hermes' `agent/agent_init.py` default) and use it at the `AIAgent(...)` call site instead of the literal `1`.
- `tests/adapters/test_hermes_adapter.py`:
  - Update the runtime-mapping test to expect `max_iterations=90` when unset (regression guard for the "unconfigured → not 1" path).
  - Add `test_default_max_iterations_matches_hermes_library_default` — cross-checks the constant against Hermes' own `AIAgent.__init__` default so drift is caught.
  - Add `test_build_hermes_config_omits_max_turns_when_max_iterations_unset` — documents that the config layer leaves `agent.max_turns` to Hermes when unset.

## Testing

`uv run --no-sync pytest tests/adapters/test_hermes_adapter.py` → 18 passed.

## Notes / follow-ups (tracked in FABRIC-85)

- If a low iteration cap is ever intentional as a cost guard, it should be documented and emit a one-line log when the loop terminates on the cap, so "hit the budget" is distinguishable from "the model chose to stop."
- Consider surfacing "hit iteration limit" as a degraded (non-`succeeded`) outcome so a truncated run doesn't read as a clean pass downstream.

Fixes FABRIC-85.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the Hermes adapter to use a higher default agent iteration budget (90) when no custom limit is provided.
  * Treated an explicitly unset iteration setting as “not provided” to avoid conversion issues, while keeping turn-limit fields omitted in generated configuration.
* **Tests**
  * Added/updated Hermes regression tests to validate the new default iteration budget and configuration omission behavior, plus runtime construction expectations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->