### PR TITLE
ci: Fix set-version recipe to account for python version pins

### DIFF
--- a/justfile
+++ b/justfile
@@ -193,7 +193,7 @@ project_paths = (
     Path("pyproject.toml"),
     *sorted(Path("adapters").glob("**/pyproject.toml")),
 )
-pin_pattern = re.compile(r'(nemo-fabric-[a-z0-9-]+\s*==\s*)([^"\s,]+)')
+pin_pattern = re.compile(r'(nemo-fabric-[a-z0-9-]+\s*==\s*)([^"\s,;]+)')
 
 for path in project_paths:
     text = path.read_text()


### PR DESCRIPTION
- [x] I confirm this contribution is my own work, or I have the right to submit it under this project's license.
- [x] I searched existing issues and open pull requests, and this does not duplicate existing work.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Python dependency version matching by rejecting invalid semicolon-containing version values.
  * No changes to versioning workflows or build and test commands.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->