### PR TITLE
ci: enforce ruff `B019` to prevent lru_cache/cache memory leaks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -12,6 +12,12 @@ repos:
         files: '\.(rs|py|pyi|toml|yaml|yml|md|mdx|sh)$|\.gitignore$'
         exclude: '(/SKILL\.md|node_modules/|target/|\.venv/|^\.github/pull_request_template\.md)$'
 
+  # Python lint — enforce the flake8-bugbear cached-instance-method rule (B019)
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.15.21
+    hooks:
+      - id: ruff-check
+
   # GitHub Actions — workflow semantics
   - repo: https://github.com/rhysd/actionlint
     rev: v1.7.12

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -131,3 +131,10 @@ nemo-fabric-adapters-hermes = { path = "adapters/hermes", editable = true }
 [tool.pytest.ini_options]
 asyncio_mode = "auto"
 asyncio_default_fixture_loop_scope = "session"
+
+[tool.ruff.lint]
+# flake8-bugbear: enforce only the cached-instance-method rule (B019).
+# Using functools.lru_cache/cache on methods keeps a reference to `self` in
+# the cache, leaking every instance for the process lifetime. The full "B"
+# category is intentionally not enabled to avoid noisy, low-value warnings.
+select = ["B019"]


### PR DESCRIPTION
#### Overview

Add a scoped ruff lint check that enforces the flake8-bugbear rule `B019`
(`cached-instance-method`). Using `functools.lru_cache`/`cache` on instance
methods keeps a reference to `self` in the cache, leaking every instance for
the process lifetime.

Fabric had no ruff integration yet, so this adds a minimal, self-contained setup:

- `pyproject.toml`: new `[tool.ruff.lint]` with `select = ["B019"]`. The full
  `B` category is intentionally not enabled to avoid noisy, low-value warnings;
  only the memory-leak rule is selected.
- `.pre-commit-config.yaml`: add the `astral-sh/ruff-pre-commit` `ruff-check`
  hook (pinned `rev: v0.15.21`, matching the repo's tag-pinning style).

The `Check` workflow already runs `pre-commit run --all-files`, so no workflow
file changes are needed — B019 now blocks regressions in CI automatically.

Testing:
- `ruff check --select B019` across the repo: all checks passed (no existing
  violations, so CI stays green).
- `pre-commit run ruff-check --all-files`: passed.
- `ruff check --show-settings` confirms exactly one enabled rule:
  `cached-instance-method (B019)`.

No breaking changes.

#### Where should the reviewer start?

`pyproject.toml` (`[tool.ruff.lint]`) — the decision to select only `B019`
rather than the full `B` category.

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- Closes #

- [ ] I confirm this contribution is my own work, or I have the right to submit it under this project's license.
- [ ] I searched existing issues and open pull requests, and this does not duplicate existing work.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Expanded the pre-commit workflow with automated Python linting using Ruff.
  * Updated the Ruff configuration to enable a targeted rule set (including only `B019`) to reduce unrelated lint noise.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->