### PR TITLE
ci: Build nemo-fabric-runtime in pypi compatibility mode

### DIFF
--- a/justfile
+++ b/justfile
@@ -347,7 +347,21 @@ wheels:
     #!/usr/bin/env bash
     set -euo pipefail
     projects=({{ python_projects }})
-    uv build --wheel --clear --out-dir dist "${projects[0]}"
-    for project in "${projects[@]:1}"; do
+    uv build --wheel --clear --out-dir dist .
+    for project in "${projects[@]}"; do
+        if [[ "$project" == "." || "$project" == "python" ]]; then
+            # Exclude the top-level package as we already built that
+            # Exclude the python package as that needs special handling for maturin
+            continue
+        fi
         uv build --wheel --out-dir dist "$project"
     done
+    # uv build forces Maturin compatibility off, producing non-portable linux_* tags.
+    (
+        cd python
+        uvx --from 'maturin>=1.9.3,<2.0' maturin build \
+            --release \
+            --locked \
+            --compatibility pypi \
+            --out ../dist
+    )


### PR DESCRIPTION
#### Overview

* Needed to pass kitmaker pre-flight checks

#### Where should the reviewer start?

* `justfile`

- [x] I confirm this contribution is my own work, or I have the right to submit it under this project's license.
- [x] I searched existing issues and open pull requests, and this does not duplicate existing work.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Build Improvements**
  * Updated wheel creation to build all supported Python projects while excluding non-wheel packages.
  * Added dedicated release wheel builds for the Python package with PyPI-compatible settings.
  * Ensured generated wheels are placed in the distribution directory.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->