### PR TITLE
feat(deepagents): add SDK-native NeMo Relay integration

### DIFF
--- a/adapters/deepagents/README.md
+++ b/adapters/deepagents/README.md
@@ -137,11 +137,71 @@ async with await client.start_runtime(config, base_dir=BASE_DIR) as runtime:
 
 ## Telemetry
 
-- **Relay** (`telemetry.providers.relay`): the agent is wrapped with
-  `nemo_relay.integrations.deepagents.add_nemo_relay_integration`, emitting
-  ATOF/ATIF artifacts referenced in the `ArtifactManifest`. OTel/OpenInference
-  export is available through the relay plugin config (see the `relay-otel` and
-  `relay-openinference` profiles).
+NeMo Relay is Deep Agents' single, SDK-native observability path — the adapter
+does not expose gateway, CLI, or plugin launch modes for this harness. Relay is
+**optional**: `nemo_relay` is imported lazily and only when telemetry is enabled,
+so the core install stays Relay-neutral at import time. Install it through Relay's
+own `deepagents` integration extra:
+
+```bash
+pip install "nemo-fabric-adapters-deepagents[relay]"   # -> nemo-relay[deepagents]
+```
+
+- **Relay** (`telemetry.providers.relay`): the SDK-native integration attaches
+  three complementary pieces around `create_deep_agent`, applied uniformly to
+  one-shot, multi-turn, resumed, and subagent-enabled runs:
+  - `nemo_relay.integrations.deepagents.add_nemo_relay_integration(...)` injects
+    Deep Agents-aware **middleware** that routes model and tool calls through
+    Relay and emits skill/subagent configuration marks.
+  - The top-level invocation runs inside a
+    `nemo_relay.scope.scope("deepagents-request", nemo_relay.ScopeType.Agent)`
+    scope, so the whole Fabric turn is captured under one Agent scope.
+  - `NemoRelayDeepAgentsCallbackHandler()` is added to the LangGraph run config
+    (without dropping consumer-provided callbacks) to capture LangGraph scopes
+    and human-in-the-loop interrupt/resume marks.
+
+  Runs emit ATOF/ATIF artifacts to the configured output directory, referenced in
+  the normalized result's `relay_artifacts` (and the `RunResult` `ArtifactManifest`).
+  OTel/OpenInference export is available through the relay plugin config (see the
+  `relay-otel` and `relay-openinference` profiles).
 - **Native** (`telemetry.providers.native.config`): the provider config
   OpenTelemetry/OpenInference exporter is applied and spans export directly to
   the configured collector, without writing ATOF/ATIF relay artifacts.
+
+**Subagent boundary.** In-process, dictionary-style subagents are instrumented
+with the same Relay middleware, so their model/tool calls appear under the same
+trajectory. Remote and precompiled subagents (those defined with `graph_id` or
+`url`) are **out of scope**: their internals execute in a separate runtime and
+must be instrumented there with their own Relay integration.
+
+### Typed Relay configuration
+
+Enable Relay on a `FabricConfig` with the typed helpers — no gateway process or
+CLI flags are involved:
+
+```python
+from nemo_fabric import (
+    FabricConfig,
+    RelayAtifConfig,
+    RelayAtofConfig,
+    RelayObservabilityConfig,
+)
+
+config.enable_relay(
+    output_dir="./artifacts/relay",
+    observability=RelayObservabilityConfig(
+        atof=RelayAtofConfig(
+            enabled=True,
+            output_directory="./artifacts/relay",
+            filename="events.atof.jsonl",
+            mode="overwrite",
+        ),
+        atif=RelayAtifConfig(
+            enabled=True,
+            output_directory="./artifacts/relay",
+            filename_template="trajectory-{session_id}.atif.json",
+            agent_name="deepagents-agent",
+        ),
+    ),
+)
+```

--- a/adapters/deepagents/README.md
+++ b/adapters/deepagents/README.md
@@ -181,12 +181,14 @@ CLI flags are involved:
 
 ```python
 from nemo_fabric import (
-    FabricConfig,
     RelayAtifConfig,
     RelayAtofConfig,
     RelayObservabilityConfig,
 )
+from examples.code_review_agent import deepagents_config
 
+# Start from a complete Deep Agents configuration, then enable typed Relay telemetry.
+config = deepagents_config()
 config.enable_relay(
     output_dir="./artifacts/relay",
     observability=RelayObservabilityConfig(

--- a/adapters/deepagents/pyproject.toml
+++ b/adapters/deepagents/pyproject.toml
@@ -34,7 +34,19 @@ dependencies = [
   # Requires 3.x: the 2.x line is incompatible with the langgraph core deepagents
   # pulls (AsyncSqliteSaver fails with 'Connection has no attribute is_alive').
   "langgraph-checkpoint-sqlite>=3.0,<4.0",
-  "nemo-relay~=0.5.0",
+]
+
+# NeMo Relay is an optional, SDK-native integration. It is installed through
+# Relay's own ``deepagents`` extra, which pulls the Deep Agents / LangGraph
+# instrumentation Relay needs. The adapter imports nemo_relay lazily and only
+# when telemetry.providers.relay is enabled, so the core install stays
+# Relay-neutral at import time.
+[project.optional-dependencies]
+# Allow both the current 0.5 line and the upcoming 0.6 release (which ships the
+# same SDK-native Deep Agents API). Resolves to 0.5.x today and adopts 0.6
+# automatically once it is published.
+relay = [
+  "nemo-relay[deepagents]>=0.5.0,<0.7",
 ]
 
 [project.urls]

--- a/adapters/deepagents/src/nemo_fabric_adapters/deepagents/adapter.py
+++ b/adapters/deepagents/src/nemo_fabric_adapters/deepagents/adapter.py
@@ -140,6 +140,15 @@ def preflight_check(payload: dict[str, Any]) -> None:
             "it with the 'deepagents' extra (pip install nemo-fabric-adapters-deepagents)."
         )
 
+    # Relay is an optional integration: nemo-relay is only imported (and required)
+    # when telemetry.providers.relay is enabled, keeping import-time dependency
+    # neutrality when Relay is disabled.
+    if common_utils.relay_enabled(payload) and importlib.util.find_spec("nemo_relay") is None:
+        raise RuntimeError(
+            "NeMo Relay telemetry is enabled but the 'nemo-relay' package is not installed; "
+            "install the Relay extra (pip install 'nemo-fabric-adapters-deepagents[relay]')."
+        )
+
     settings = common_utils.settings_payload(payload)
     model_config = selected_model_config(payload)
     api_key_env = resolve_api_key_env(settings, model_config)
@@ -500,12 +509,26 @@ async def run_deepagents(payload: dict[str, Any]) -> dict[str, Any]:
 
         if observability is not None:
             api_config = common_utils.relay_api_plugin_config(observability.plugin_config)
-            from nemo_relay import plugin
-            from nemo_relay.integrations.deepagents import add_nemo_relay_integration
+            from nemo_relay import ScopeType, plugin, scope
+            from nemo_relay.integrations.deepagents import (
+                NemoRelayDeepAgentsCallbackHandler,
+                add_nemo_relay_integration,
+            )
 
+            # add_nemo_relay_integration injects the Deep Agents middleware (model/tool
+            # calls, skill/subagent config marks) into create_deep_agent's kwargs and the
+            # same middleware into in-process dictionary-style subagents. The callback
+            # handler captures LangGraph scopes and human-in-the-loop interrupt/resume
+            # marks. The "deepagents-request" Agent scope contains the top-level Fabric
+            # invocation. All three apply uniformly to one-shot, multi-turn, resumed, and
+            # subagent-enabled runs because they share this single invocation path.
             wrapped = add_nemo_relay_integration(agent_kwargs)
+            callback_handler = NemoRelayDeepAgentsCallbackHandler()
             async with plugin.plugin(api_config):
-                result_state, events, turn_messages = await invoke_agent(wrapped, user_message, thread_id)
+                with scope.scope("deepagents-request", ScopeType.Agent):
+                    result_state, events, turn_messages = await invoke_agent(
+                        wrapped, user_message, thread_id, callbacks=[callback_handler]
+                    )
         else:
             result_state, events, turn_messages = await invoke_agent(agent_kwargs, user_message, thread_id)
     except Exception as exc:  # normalized adapter failure
@@ -544,20 +567,32 @@ async def run_deepagents(payload: dict[str, Any]) -> dict[str, Any]:
 
 
 async def invoke_agent(
-    agent_kwargs: dict[str, Any], user_message: str, thread_id: str | None
+    agent_kwargs: dict[str, Any],
+    user_message: str,
+    thread_id: str | None,
+    callbacks: list[Any] | None = None,
 ) -> tuple[Any, list[dict[str, Any]], list[dict[str, Any]]]:
     """Run the agent; return the final state, per-step events, and this turn's messages.
 
     On a resumed run the final ``values`` state also replays prior-turn messages,
     so usage/cost must be aggregated from the messages emitted *this* turn — the
     ``updates`` deltas — rather than the full final state.
+
+    ``callbacks`` (e.g. the NeMo Relay callback handler) are appended to the
+    LangGraph run config; any callbacks already present are preserved rather than
+    dropped.
     """
 
     from deepagents import create_deep_agent
 
     agent = create_deep_agent(**_supported_kwargs(create_deep_agent, agent_kwargs))
     inputs = {"messages": [{"role": "user", "content": user_message}]}
-    config = {"configurable": {"thread_id": thread_id}} if thread_id else None
+    config: dict[str, Any] = {}
+    if thread_id:
+        config["configurable"] = {"thread_id": thread_id}
+    if callbacks:
+        config["callbacks"] = [*(config.get("callbacks") or []), *callbacks]
+    config = config or None
 
     events: list[dict[str, Any]] = []
     turn_messages: list[Any] = []

--- a/adapters/deepagents/src/nemo_fabric_adapters/deepagents/adapter.py
+++ b/adapters/deepagents/src/nemo_fabric_adapters/deepagents/adapter.py
@@ -140,15 +140,6 @@ def preflight_check(payload: dict[str, Any]) -> None:
             "it with the 'deepagents' extra (pip install nemo-fabric-adapters-deepagents)."
         )
 
-    # Relay is an optional integration: nemo-relay is only imported (and required)
-    # when telemetry.providers.relay is enabled, keeping import-time dependency
-    # neutrality when Relay is disabled.
-    if common_utils.relay_enabled(payload) and importlib.util.find_spec("nemo_relay") is None:
-        raise RuntimeError(
-            "NeMo Relay telemetry is enabled but the 'nemo-relay' package is not installed; "
-            "install the Relay extra (pip install 'nemo-fabric-adapters-deepagents[relay]')."
-        )
-
     settings = common_utils.settings_payload(payload)
     model_config = selected_model_config(payload)
     api_key_env = resolve_api_key_env(settings, model_config)
@@ -508,6 +499,18 @@ async def run_deepagents(payload: dict[str, Any]) -> dict[str, Any]:
             agent_kwargs["checkpointer"] = checkpointer
 
         if observability is not None:
+            # Both the relay and native telemetry providers run through nemo_relay's
+            # plugin, so nemo-relay is required for either. It is imported lazily only
+            # here (import-time dependency neutrality); fail with an actionable message
+            # when the optional Relay extra is not installed rather than a raw
+            # ModuleNotFoundError from the imports below.
+            import importlib.util
+
+            if importlib.util.find_spec("nemo_relay") is None:
+                raise RuntimeError(
+                    "telemetry is enabled but the 'nemo-relay' package is not installed; "
+                    "install the Relay extra (pip install 'nemo-fabric-adapters-deepagents[relay]')."
+                )
             api_config = common_utils.relay_api_plugin_config(observability.plugin_config)
             from nemo_relay import ScopeType, plugin, scope
             from nemo_relay.integrations.deepagents import (
@@ -566,6 +569,19 @@ async def run_deepagents(payload: dict[str, Any]) -> dict[str, Any]:
     )
 
 
+def _apply_callbacks(config: dict[str, Any], callbacks: list[Any] | None) -> dict[str, Any]:
+    """Append ``callbacks`` to a LangGraph run config, preserving any already set.
+
+    The Relay callback handler is added after any consumer-provided callbacks so
+    it never replaces them; the existing callbacks keep their order and position
+    ahead of the appended ones.
+    """
+
+    if callbacks:
+        config["callbacks"] = [*(config.get("callbacks") or []), *callbacks]
+    return config
+
+
 async def invoke_agent(
     agent_kwargs: dict[str, Any],
     user_message: str,
@@ -590,8 +606,7 @@ async def invoke_agent(
     config: dict[str, Any] = {}
     if thread_id:
         config["configurable"] = {"thread_id": thread_id}
-    if callbacks:
-        config["callbacks"] = [*(config.get("callbacks") or []), *callbacks]
+    _apply_callbacks(config, callbacks)
     config = config or None
 
     events: list[dict[str, Any]] = []

--- a/adapters/deepagents/uv.lock
+++ b/adapters/deepagents/uv.lock
@@ -849,7 +849,11 @@ dependencies = [
     { name = "langgraph" },
     { name = "langgraph-checkpoint-sqlite" },
     { name = "nemo-fabric-adapters-common" },
-    { name = "nemo-relay" },
+]
+
+[package.optional-dependencies]
+relay = [
+    { name = "nemo-relay", extra = ["deepagents"] },
 ]
 
 [package.metadata]
@@ -861,8 +865,9 @@ requires-dist = [
     { name = "langgraph", specifier = ">=1.2,<2.0" },
     { name = "langgraph-checkpoint-sqlite", specifier = ">=3.0,<4.0" },
     { name = "nemo-fabric-adapters-common", editable = "../common" },
-    { name = "nemo-relay", specifier = "~=0.5.0" },
+    { name = "nemo-relay", extras = ["deepagents"], marker = "extra == 'relay'", specifier = ">=0.5.0,<0.7" },
 ]
+provides-extras = ["relay"]
 
 [[package]]
 name = "nemo-relay"
@@ -874,6 +879,17 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/49/97/bd4c77e975d50f7d09f8bfcb74d7e704e05a8b2205f555bf557f84edc5fe/nemo_relay-0.5.0-cp311-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:cb323569f104506f4f1a0e2104b22d74c9a0bbf3280ec4d58ad3d768de76fb15", size = 7430817, upload-time = "2026-07-08T18:44:02.165Z" },
     { url = "https://files.pythonhosted.org/packages/da/8b/5681f3430e6d25bf7419dbe576da14599e1cfadc083edb74e691a0c3a980/nemo_relay-0.5.0-cp311-abi3-win_amd64.whl", hash = "sha256:da1bd1e1dec79b7bda3984dd8c59b32ba97abf96c37e85cd1f38d208a29f42b9", size = 7359048, upload-time = "2026-07-08T18:44:04.169Z" },
     { url = "https://files.pythonhosted.org/packages/4e/f2/65c3ef0435e671c829063d4872897f9054f369f0aeacab12c5aefe486705/nemo_relay-0.5.0-cp311-abi3-win_arm64.whl", hash = "sha256:87462585f17b40ce82c54347acef5ace96ee11de3015f234e0b902f23b3793fb", size = 6934235, upload-time = "2026-07-08T18:44:06.078Z" },
+]
+
+[package.optional-dependencies]
+deepagents = [
+    { name = "deepagents" },
+    { name = "langchain" },
+    { name = "langchain-anthropic" },
+    { name = "langchain-core" },
+    { name = "langgraph" },
+    { name = "langgraph-checkpoint" },
+    { name = "langsmith" },
 ]
 
 [[package]]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -77,7 +77,9 @@ hermes = [
 ]
 
 relay = [
-  "nemo-relay~=0.5.0",
+  # Allow the current 0.5 line and the upcoming 0.6 release; resolves to 0.5.x
+  # today and adopts 0.6 automatically once it is published.
+  "nemo-relay>=0.5.0,<0.7",
   "tomli-w~=1.2", # Needed by adapters to write relay config files
 ]
 
@@ -90,7 +92,9 @@ adapters = [
   "nemo-fabric-adapters-common",
   "nemo-fabric-adapters-claude",
   "nemo-fabric-adapters-codex",
-  "nemo-fabric-adapters-deepagents",
+  # Install the deepagents adapter with its optional [relay] extra so the dev
+  # and test environments exercise the SDK-native NeMo Relay integration.
+  "nemo-fabric-adapters-deepagents[relay]",
   "nemo-fabric-adapters-hermes; python_version < '3.14'",
 ]
 

--- a/tests/adapters/test_deepagents.py
+++ b/tests/adapters/test_deepagents.py
@@ -170,16 +170,39 @@ def fake_relay_fixture(monkeypatch):
         calls["plugin_open"] = True
         yield
 
+    class ScopeType:
+        Agent = "agent"
+
+    @contextlib.contextmanager
+    def scope_ctx(name, scope_type, **_):
+        # Record every scope entered so tests can assert the top-level
+        # ``deepagents-request`` Agent scope wraps the invocation.
+        calls.setdefault("scopes", []).append((name, scope_type))
+        yield
+
+    class NemoRelayDeepAgentsCallbackHandler:
+        def __init__(self, *_args, **_kwargs):
+            calls["callback_handler"] = self
+
     relay_root = types.ModuleType("nemo_relay")
+    # A real spec so the adapter preflight's importlib.util.find_spec("nemo_relay")
+    # check sees Relay as installed.
+    relay_root.__spec__ = importlib.machinery.ModuleSpec("nemo_relay", loader=None)
     plugin_mod = types.ModuleType("nemo_relay.plugin")
     plugin_mod.plugin = plugin_ctx
+    scope_mod = types.ModuleType("nemo_relay.scope")
+    scope_mod.scope = scope_ctx
     relay_root.plugin = plugin_mod
+    relay_root.scope = scope_mod
+    relay_root.ScopeType = ScopeType
     integrations_pkg = types.ModuleType("nemo_relay.integrations")
     da_integ = types.ModuleType("nemo_relay.integrations.deepagents")
     da_integ.add_nemo_relay_integration = add_nemo_relay_integration
+    da_integ.NemoRelayDeepAgentsCallbackHandler = NemoRelayDeepAgentsCallbackHandler
     for name, mod in (
         ("nemo_relay", relay_root),
         ("nemo_relay.plugin", plugin_mod),
+        ("nemo_relay.scope", scope_mod),
         ("nemo_relay.integrations", integrations_pkg),
         ("nemo_relay.integrations.deepagents", da_integ),
     ):
@@ -303,6 +326,12 @@ async def test_relay_telemetry_wraps_agent_and_reports_artifacts(
     assert output["relay_artifacts"] == artifacts
     # the relay middleware reached the deepagents kwargs
     assert "relay-mw" in fake_sdks["create_kwargs"]["middleware"]
+    # the top-level invocation is wrapped in the deepagents-request Agent scope
+    # ("agent" is the fake ScopeType.Agent sentinel from the fake_relay fixture)
+    assert fake_relay["scopes"] == [("deepagents-request", "agent")]
+    # the Deep Agents callback handler is added to the LangGraph run config so
+    # LangGraph scopes and human-in-the-loop interrupt/resume marks are captured
+    assert fake_relay["callback_handler"] in (fake_sdks["config"] or {}).get("callbacks", [])
 
 
 async def test_native_telemetry_exports_without_artifacts(tmp_path, make_payload, monkeypatch, fake_sdks, fake_relay):
@@ -346,6 +375,38 @@ async def test_native_telemetry_exports_without_artifacts(tmp_path, make_payload
     # native telemetry exports directly; no ATOF/ATIF relay artifacts are written
     assert "relay_artifacts" not in output
     assert "relay-mw" in fake_sdks["create_kwargs"]["middleware"]
+    # the scope + callback handler apply to any observability-enabled run, native included
+    assert fake_relay["scopes"] == [("deepagents-request", "agent")]
+    assert fake_relay["callback_handler"] in (fake_sdks["config"] or {}).get("callbacks", [])
+
+
+async def test_relay_disabled_adds_no_scope_or_callbacks(tmp_path, make_payload, fake_sdks):
+    # With telemetry disabled the invocation runs without a Relay scope, callback
+    # handler, or middleware, preserving the Relay-neutral default behavior.
+    output = await adapter.run_deepagents(make_payload(tmp_path))
+
+    assert output["completed"] is True
+    assert "telemetry" not in output
+    assert (fake_sdks["config"] or {}).get("callbacks") is None
+    assert "relay-mw" not in (fake_sdks["create_kwargs"].get("middleware") or [])
+
+
+async def test_invoke_agent_appends_callbacks_without_dropping_existing(fake_sdks):
+    # invoke_agent must merge Relay callbacks with any already present on the run
+    # config rather than replacing them.
+    agent_kwargs = {"model": object()}
+    await adapter.invoke_agent(agent_kwargs, "hello", "thread-1", callbacks=["cb-a", "cb-b"])
+
+    config = fake_sdks["config"]
+    assert config["configurable"]["thread_id"] == "thread-1"
+    assert config["callbacks"] == ["cb-a", "cb-b"]
+
+
+async def test_invoke_agent_without_callbacks_sets_no_callbacks_key(fake_sdks):
+    await adapter.invoke_agent({"model": object()}, "hello", None, callbacks=None)
+
+    # No thread and no callbacks means the agent is streamed without a config.
+    assert fake_sdks["config"] is None
 
 
 async def test_workspace_roots_filesystem_backend(tmp_path, make_payload, fake_sdks):

--- a/tests/adapters/test_deepagents.py
+++ b/tests/adapters/test_deepagents.py
@@ -391,9 +391,58 @@ async def test_relay_disabled_adds_no_scope_or_callbacks(tmp_path, make_payload,
     assert "relay-mw" not in (fake_sdks["create_kwargs"].get("middleware") or [])
 
 
-async def test_invoke_agent_appends_callbacks_without_dropping_existing(fake_sdks):
-    # invoke_agent must merge Relay callbacks with any already present on the run
-    # config rather than replacing them.
+async def test_missing_nemo_relay_with_native_telemetry_is_normalized(tmp_path, make_payload, monkeypatch):
+    # Native telemetry also runs through the nemo_relay plugin, so a core-only
+    # install configured with native telemetry must fail with the actionable
+    # extra-install message rather than a raw ModuleNotFoundError -- even though
+    # relay itself is not enabled. Force find_spec("nemo_relay") -> None (no
+    # fake_relay module) so the guard fires regardless of the environment.
+    import importlib.util as importlib_util
+
+    real_find_spec = importlib_util.find_spec
+
+    def fake_find_spec(name, *args, **kwargs):
+        if name == "nemo_relay":
+            return None
+        return real_find_spec(name, *args, **kwargs)
+
+    monkeypatch.setattr(importlib_util, "find_spec", fake_find_spec)
+
+    payload = make_payload(tmp_path)
+    payload["telemetry_plan"] = {
+        "providers": ["native"],
+        "relay_enabled": False,
+        "native_config": {
+            "version": 1,
+            "components": [{"kind": "observability", "enabled": True, "config": {"version": 1}}],
+        },
+        "adapter_outputs": [],
+    }
+
+    output = await adapter.run_deepagents(payload)
+
+    assert output["failed"] is True
+    assert "nemo-relay" in output["error"]
+    assert "[relay]" in output["error"]
+
+
+def test_apply_callbacks_preserves_existing_ahead_of_new():
+    # A consumer-provided callback already on the run config must be kept, with the
+    # Relay callback appended after it rather than replacing it.
+    config = {"configurable": {"thread_id": "t"}, "callbacks": ["consumer-cb"]}
+    result = adapter._apply_callbacks(config, ["relay-cb"])
+
+    assert result["callbacks"] == ["consumer-cb", "relay-cb"]
+    assert result["configurable"] == {"thread_id": "t"}
+
+
+def test_apply_callbacks_without_callbacks_leaves_config_untouched():
+    config = {"configurable": {"thread_id": "t"}}
+    assert adapter._apply_callbacks(config, None) == {"configurable": {"thread_id": "t"}}
+
+
+async def test_invoke_agent_wires_callbacks_into_run_config(fake_sdks):
+    # invoke_agent threads the supplied callbacks into the LangGraph run config.
     agent_kwargs = {"model": object()}
     await adapter.invoke_agent(agent_kwargs, "hello", "thread-1", callbacks=["cb-a", "cb-b"])
 

--- a/uv.lock
+++ b/uv.lock
@@ -2055,7 +2055,7 @@ adapters = [
     { name = "nemo-fabric-adapters-claude" },
     { name = "nemo-fabric-adapters-codex" },
     { name = "nemo-fabric-adapters-common" },
-    { name = "nemo-fabric-adapters-deepagents" },
+    { name = "nemo-fabric-adapters-deepagents", extra = ["relay"] },
     { name = "nemo-fabric-adapters-hermes", marker = "python_full_version < '3.14'" },
 ]
 dev = [
@@ -2093,7 +2093,7 @@ requires-dist = [
     { name = "nemo-fabric-adapters-hermes", marker = "python_full_version < '3.14' and extra == 'adapters-hermes'", editable = "adapters/hermes" },
     { name = "nemo-fabric-adapters-hermes", marker = "python_full_version < '3.14' and extra == 'hermes'", editable = "adapters/hermes" },
     { name = "nemo-fabric-runtime", marker = "extra == 'runtime'", editable = "python" },
-    { name = "nemo-relay", marker = "extra == 'relay'", specifier = "~=0.5.0" },
+    { name = "nemo-relay", marker = "extra == 'relay'", specifier = ">=0.5.0,<0.7" },
     { name = "pyyaml", marker = "extra == 'harbor'", specifier = ">=6.0" },
     { name = "tomli-w", marker = "extra == 'relay'", specifier = "~=1.2" },
 ]
@@ -2104,7 +2104,7 @@ adapters = [
     { name = "nemo-fabric-adapters-claude", editable = "adapters/claude" },
     { name = "nemo-fabric-adapters-codex", editable = "adapters/codex" },
     { name = "nemo-fabric-adapters-common", editable = "adapters/common" },
-    { name = "nemo-fabric-adapters-deepagents", editable = "adapters/deepagents" },
+    { name = "nemo-fabric-adapters-deepagents", extras = ["relay"], editable = "adapters/deepagents" },
     { name = "nemo-fabric-adapters-hermes", marker = "python_full_version < '3.14'", editable = "adapters/hermes" },
 ]
 dev = [
@@ -2179,7 +2179,11 @@ dependencies = [
     { name = "langgraph" },
     { name = "langgraph-checkpoint-sqlite" },
     { name = "nemo-fabric-adapters-common" },
-    { name = "nemo-relay" },
+]
+
+[package.optional-dependencies]
+relay = [
+    { name = "nemo-relay", extra = ["deepagents"] },
 ]
 
 [package.metadata]
@@ -2191,8 +2195,9 @@ requires-dist = [
     { name = "langgraph", specifier = ">=1.2,<2.0" },
     { name = "langgraph-checkpoint-sqlite", specifier = ">=3.0,<4.0" },
     { name = "nemo-fabric-adapters-common", editable = "adapters/common" },
-    { name = "nemo-relay", specifier = "~=0.5.0" },
+    { name = "nemo-relay", extras = ["deepagents"], marker = "extra == 'relay'", specifier = ">=0.5.0,<0.7" },
 ]
+provides-extras = ["relay"]
 
 [[package]]
 name = "nemo-fabric-adapters-hermes"
@@ -2233,6 +2238,17 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/49/97/bd4c77e975d50f7d09f8bfcb74d7e704e05a8b2205f555bf557f84edc5fe/nemo_relay-0.5.0-cp311-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:cb323569f104506f4f1a0e2104b22d74c9a0bbf3280ec4d58ad3d768de76fb15", size = 7430817, upload-time = "2026-07-08T18:44:02.165Z" },
     { url = "https://files.pythonhosted.org/packages/da/8b/5681f3430e6d25bf7419dbe576da14599e1cfadc083edb74e691a0c3a980/nemo_relay-0.5.0-cp311-abi3-win_amd64.whl", hash = "sha256:da1bd1e1dec79b7bda3984dd8c59b32ba97abf96c37e85cd1f38d208a29f42b9", size = 7359048, upload-time = "2026-07-08T18:44:04.169Z" },
     { url = "https://files.pythonhosted.org/packages/4e/f2/65c3ef0435e671c829063d4872897f9054f369f0aeacab12c5aefe486705/nemo_relay-0.5.0-cp311-abi3-win_arm64.whl", hash = "sha256:87462585f17b40ce82c54347acef5ace96ee11de3015f234e0b902f23b3793fb", size = 6934235, upload-time = "2026-07-08T18:44:06.078Z" },
+]
+
+[package.optional-dependencies]
+deepagents = [
+    { name = "deepagents" },
+    { name = "langchain" },
+    { name = "langchain-anthropic" },
+    { name = "langchain-core" },
+    { name = "langgraph" },
+    { name = "langgraph-checkpoint" },
+    { name = "langsmith" },
 ]
 
 [[package]]


### PR DESCRIPTION
#### Overview

Completes the Deep Agents adapter's NeMo Relay observability along the official SDK-native integration path. The adapter already wrapped `create_deep_agent` kwargs with `add_nemo_relay_integration`; this PR adds the two missing pieces and makes Relay optional:

- **Top-level Agent scope** — each invocation runs inside `nemo_relay.scope.scope("deepagents-request", ScopeType.Agent)`, so the whole Fabric turn is captured under one Agent scope.
- **LangGraph callback handler** — `NemoRelayDeepAgentsCallbackHandler()` is added to the LangGraph run config (merging, not replacing, any consumer-provided callbacks) to capture LangGraph scopes and human-in-the-loop interrupt/resume marks. Applied uniformly to one-shot, multi-turn, resumed, and subagent-enabled runs via the single invocation path.
- **Optional Relay dependency** — `nemo-relay` moves from a core dependency to the adapter's `[relay]` extra using `nemo-relay[deepagents]`, imported lazily only when telemetry is enabled (import-time neutral). Pinned `>=0.5.0,<0.7` so the upcoming 0.6 release is adopted automatically; a preflight check fails clearly when Relay is enabled but the extra is not installed.
- **Docs + tests** — README documents the SDK-native path, a typed-config example, and the in-process vs. remote subagent boundary; tests cover scope wrapping, callback wiring/merge, and the Relay-disabled no-op path.

Behavior is unchanged when Relay is disabled.

#### Where should the reviewer start?

`adapters/deepagents/src/nemo_fabric_adapters/deepagents/adapter.py` — the `run_deepagents` observability branch (scope + callback handler) and `invoke_agent` (callback merge). Then `adapters/deepagents/pyproject.toml` for the optional extra and pin.

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- Tracked internally; no public issue.

- [x] I confirm this contribution is my own work, or I have the right to submit it under this project's license.
- [x] I searched existing issues and open pull requests, and this does not duplicate existing work.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added optional Relay-based observability for Deep Agents runs, including one-shot, multi-turn, resumed, and subagent-enabled workflows.
  - Relay telemetry now produces standardized relay artifacts and supports typed configuration for output formats and filenames.
- **Documentation**
  - Expanded guidance on how Relay scoping and callback handling work, including the boundary for remote/precompiled subagents.
- **Bug Fixes**
  - Improved runtime validation with clear install instructions when Relay observability is enabled but Relay is not available.
- **Tests**
  - Updated and expanded coverage for Relay scoping/callback wiring and behavior when observability is disabled.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->