### PR TITLE
docs: Edits for template alignment

### DIFF
--- a/docs/about-nemo-fabric/overview.mdx
+++ b/docs/about-nemo-fabric/overview.mdx
@@ -1,43 +1,83 @@
 ---
-title: "NVIDIA NeMo Fabric"
+title: "NVIDIA NeMo Fabric Documentation"
+sidebar-title: "Overview"
 description: "Configure, plan, run, and observe agent harnesses through one typed execution contract."
+template-library-version: "1.0.0"
 ---
 {/* SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 SPDX-License-Identifier: Apache-2.0 */}
 
-NeMo Fabric is the harness-management layer that turns multiple agent runtimes
-into one configurable, observable execution surface. Applications use the same
-versioned config, lifecycle, result, artifact, and telemetry contracts whether
-the selected harness is Hermes, Codex SDK, or a custom adapter.
+[NVIDIA NeMo Fabric](https://github.com/NVIDIA/NeMo-Fabric) is the
+harness-management layer that turns multiple agent runtimes into one
+configurable, observable execution surface. Applications use the same versioned
+config, lifecycle, result, artifact, and telemetry contracts whether the
+selected harness is Hermes, Codex SDK, or a custom adapter.
 
 NeMo Fabric owns the seam between an application and its harness. It resolves
-configuration, selects an adapter, drives the runtime lifecycle,
-and returns normalized evidence without leaking harness-specific control code
-into the caller.
+configuration, selects an adapter, drives the runtime lifecycle, and returns
+normalized evidence without leaking harness-specific control code into the
+caller.
 
-## What NeMo Fabric gives you
+## Benefits
+
+NeMo Fabric gives applications one contract across every supported harness.
 
 <CardGroup cols={2}>
-  <Card title="Portable configuration">
+  <Card title="Portable Configuration">
     Use a versioned `agent.yaml` package or construct the same typed
     `FabricConfig` in Python. Applications create variants from typed copies;
     portable file packages can use ordered profiles.
   </Card>
-  <Card title="Harness-neutral execution">
+  <Card title="Harness-Neutral Execution">
     Plan and invoke different harnesses through one Rust core, CLI, and Python
     SDK instead of embedding harness launch logic in every consumer.
   </Card>
-  <Card title="Typed lifecycle contracts">
+  <Card title="Typed Lifecycle Contracts">
     Resolve configs, inspect capabilities, run one-shot jobs, and hold
     multi-turn runtimes with typed requests, plans, handles, and results.
   </Card>
-  <Card title="Normalized evidence">
+  <Card title="Normalized Evidence">
     Collect output, errors, lifecycle events, artifact manifests, and telemetry
     references in stable contracts suitable for platforms and evaluations.
   </Card>
 </CardGroup>
 
-## How NeMo Fabric fits
+## Use Cases
+
+Teams use NeMo Fabric to run agents through a single contract, hold multi-turn
+sessions over a live harness, and integrate agent execution into platforms and
+evaluation pipelines.
+
+| Use Case | Reader Goal | Result |
+| --- | --- | --- |
+| Application integration | Run one-shot agent jobs from an application that owns its own config. | A normalized `RunResult` with output, artifacts, events, and telemetry references. |
+| Multi-turn runtimes | Drive several ordered turns over one live harness runtime. | A stateful runtime handle you start, invoke, and stop through one lifecycle contract. |
+| Platform and evaluation harnesses | Plan and invoke many harnesses behind one typed surface. | Stable, harness-neutral evidence suitable for platforms and evaluations. |
+
+### Application Integration
+
+An application owns its job config and consumes returned evidence. Configure an
+agent package or typed `FabricConfig`, run it through the Python SDK, and read
+the normalized `RunResult`. Refer to the [Python SDK guide](/sdk/python) for
+typed requests and one-shot run examples.
+
+### Multi-Turn Runtimes
+
+When a workflow needs several ordered turns over one live harness, start a
+runtime and invoke it turn by turn before stopping it. Refer to the
+[Runtime reference](/reference/api/python-library-reference/runtime) for the
+start, invoke, and stop lifecycle.
+
+### Platform And Evaluation Harnesses
+
+Platforms and evaluation systems plan and invoke different harnesses behind one
+typed surface, then consume stable evidence contracts. Use the `fabric` CLI or
+committed JSON Schemas to validate packages and build language bindings.
+
+## Core Workflow
+
+NeMo Fabric is organized around one flow from configuration to normalized
+evidence:
 
 ```text
 Application or evaluation harness
@@ -55,125 +95,24 @@ Hermes | Codex SDK | custom harness
 RunResult + artifacts + events + telemetry references
 ```
 
-The CLI and Python SDK are separate interfaces over the same core. File-backed
-and typed configs converge on the same resolved config and run-plan contracts.
-Adapters own harness-specific preparation and invocation; consumers own the
-request and the use of returned evidence.
+- **Configuration**: Use a versioned `agent.yaml` package or a typed
+  `FabricConfig` to describe the harness adapter, environment, models, tools,
+  skills, MCP, and telemetry. File-backed and typed configs converge on the same
+  resolved config and run-plan contracts.
+- **Plan and diagnostics**: Resolve the adapter and check capabilities and
+  requirements before spending work on a runtime.
+- **Runtime lifecycle**: Run a one-shot job or start a stateful runtime through
+  the shared start, invoke, and stop contract. Adapters own harness-specific
+  preparation and invocation; consumers own the request.
+- **Normalized evidence**: Consume `RunResult` for output, structured failure
+  details, artifacts, events, and telemetry references.
 
-## Quick start
+## Learn More
 
-Install `just` 1.50.0+ if it is not already available.
+Continue exploring NeMo Fabric through these resources.
 
-```bash
-cargo install just --locked
-```
-
-Refer to the [official installation guide](https://just.systems/man/en/installation.html)
-for more details.
-
-Ensure that the Cargo bin directory is in your `PATH`:
-
-```bash
-export PATH="$HOME/.cargo/bin:$PATH"
-```
-
-Create a Python virtual environment and activate it (replace `3.13` with your preferred Python version):
-
-```bash
-uv venv -p 3.13 --seed .venv
-source .venv/bin/activate
-```
-
-Install the Python SDK with its native binding and the CLI from a source
-checkout:
-
-```bash
-just build-all
-```
-
-Run the example through the Python SDK:
-
-```python
-import asyncio
-from examples.code_review_agent import BASE_DIR, hermes_config
-from nemo_fabric import Fabric
-
-
-async def main() -> None:
-    config = hermes_config()
-    client = Fabric()
-    result = await client.run(
-        config,
-        base_dir=BASE_DIR,
-        input="Reply with exactly: fabric works",
-    )
-
-    print(result.status)
-
-
-asyncio.run(main())
-```
-
-Harness installation and credential requirements differ by adapter. The
-[repository quick start](https://github.com/NVIDIA/NeMo-Fabric#quick-start-hermes)
-contains the complete Hermes environment recipe.
-
-Refer to the [Python SDK guide](/sdk/python) for planning, diagnostics, typed
-requests, and multi-turn runtime examples.
-
-## Choose your interface
-
-| Interface | Use it when | Start with |
-| --- | --- | --- |
-| Python SDK | Your application owns job config, runtime lifecycle, or multi-turn state | [Client API](/reference/api/python-library-reference/client) |
-| Runtime API | You need multiple ordered turns over one live harness runtime | [Runtime](/reference/api/python-library-reference/runtime) |
-| `fabric` CLI | You are validating packages, debugging profiles, or running reproducible local/CI jobs | `fabric validate`, `plan`, `doctor`, `run`, and `chat` |
-| JSON Schema | You are building editors, validation, code generation, or another language binding | Committed schemas in the [repository](https://github.com/NVIDIA/NeMo-Fabric/tree/main/schemas) |
-
-Use `agent.yaml` when the agent package is the portable artifact. Use
-`FabricConfig` when a platform already owns a larger job or deployment object
-and wants to pass only its NeMo Fabric slice in memory.
-
-## Core workflow
-
-1. **Configure** an agent package or typed `FabricConfig` with a harness adapter,
-   environment, models, tools, skills, MCP, and telemetry.
-2. **Create variants** from deep copies to vary harness, model, environment, or
-   observability settings without mutating the base config. File-backed
-   packages may instead apply ordered profiles.
-3. **Plan and diagnose** to resolve the adapter and check capabilities and
-   requirements before spending work on a runtime.
-4. **Run or start a runtime** through the shared start, invoke, and stop
-   lifecycle contract.
-5. **Consume evidence** from `RunResult`: output, structured failure details,
-   artifacts, events, and telemetry references.
-
-## Next steps
-
-<CardGroup cols={2}>
-  <Card
-    title="Client API"
-    href="/reference/api/python-library-reference/client"
-  >
-    Resolve, plan, diagnose, run, and start stateful runtimes.
-  </Card>
-  <Card
-    title="Runtime"
-    href="/reference/api/python-library-reference/runtime"
-  >
-    Invoke multiple ordered turns and stop runtime handles safely.
-  </Card>
-  <Card
-    title="Types"
-    href="/reference/api/python-library-reference/types"
-  >
-    Explore all mutable config objects and immutable request, plan, result,
-    artifact, telemetry, and runtime models.
-  </Card>
-  <Card
-    title="Errors"
-    href="/reference/api/python-library-reference/errors"
-  >
-    Handle config, capability, lifecycle, state, and native-extension failures.
-  </Card>
-</CardGroup>
+- **Installation** — [Installation](/getting-started/install) to set up the runtime and adapters.
+- **Quickstart** — [Quickstart](/getting-started/quick-start) to build from source and run the SDK example.
+- **Beginner Tutorial** — [Beginner Tutorial](/getting-started/quickstart) to run a simple agent end to end.
+- **Python SDK** — [Python SDK](/sdk/python) for planning, diagnostics, typed requests, and multi-turn runtimes.
+- **API Reference** — [Client API](/reference/api/python-library-reference/client) to resolve, plan, diagnose, run, and start stateful runtimes.

--- a/docs/about-nemo-fabric/overview.mdx
+++ b/docs/about-nemo-fabric/overview.mdx
@@ -11,7 +11,7 @@ SPDX-License-Identifier: Apache-2.0 */}
 harness-management layer that turns multiple agent runtimes into one
 configurable, observable execution surface. Applications use the same versioned
 config, lifecycle, result, artifact, and telemetry contracts whether the
-selected harness is Hermes, Codex SDK, or a custom adapter.
+selected harness is Hermes Agent, Codex, or a custom adapter.
 
 NeMo Fabric owns the seam between an application and its harness. It resolves
 configuration, selects an adapter, drives the runtime lifecycle, and returns

--- a/docs/about-nemo-fabric/overview.mdx
+++ b/docs/about-nemo-fabric/overview.mdx
@@ -68,11 +68,24 @@ runtime and invoke it turn by turn before stopping it. Refer to the
 [Runtime reference](/reference/api/python-library-reference/runtime) for the
 start, invoke, and stop lifecycle.
 
-### Platform And Evaluation Harnesses
+### Platform and Evaluation Harnesses
 
 Platforms and evaluation systems plan and invoke different harnesses behind one
 typed surface, then consume stable evidence contracts. Use the `fabric` CLI or
 committed JSON Schemas to validate packages and build language bindings.
+
+## Choose Your Interface
+
+| Interface | Use it when | Start with |
+| --- | --- | --- |
+| Python SDK | Your application owns job config, runtime lifecycle, or multi-turn state | [Client API](/reference/api/python-library-reference/client) |
+| Runtime API | You need multiple ordered turns over one live harness runtime | [Runtime](/reference/api/python-library-reference/runtime) |
+| `fabric` CLI | You are validating packages, debugging profiles, or running reproducible local/CI jobs | `fabric validate`, `plan`, `doctor`, `run`, and `chat` |
+| JSON Schema | You are building editors, validation, code generation, or another language binding | Committed schemas in the [repository](https://github.com/NVIDIA/NeMo-Fabric/tree/main/schemas) |
+
+Use `agent.yaml` when the agent package is the portable artifact. Use
+`FabricConfig` when a platform already owns a larger job or deployment object
+and wants to pass only its NeMo Fabric slice in memory.
 
 ## Core Workflow
 

--- a/docs/about-nemo-fabric/overview.mdx
+++ b/docs/about-nemo-fabric/overview.mdx
@@ -11,7 +11,7 @@ SPDX-License-Identifier: Apache-2.0 */}
 harness-management layer that turns multiple agent runtimes into one
 configurable, observable execution surface. Applications use the same versioned
 config, lifecycle, result, artifact, and telemetry contracts whether the
-selected harness is Hermes Agent, Codex, or a custom adapter.
+selected harness is [Hermes Agent](https://hermes-agent.nousresearch.com/docs/), [Codex](https://openai.com/codex/), or a custom adapter.
 
 NeMo Fabric owns the seam between an application and its harness. It resolves
 configuration, selects an adapter, drives the runtime lifecycle, and returns

--- a/docs/about-nemo-fabric/overview.mdx
+++ b/docs/about-nemo-fabric/overview.mdx
@@ -76,6 +76,9 @@ committed JSON Schemas to validate packages and build language bindings.
 
 ## Choose Your Interface
 
+Use the following table to choose the NeMo Fabric interface that best fits how
+your application works with harnesses:
+
 | Interface | Use it when | Start with |
 | --- | --- | --- |
 | Python SDK | Your application owns job config, runtime lifecycle, or multi-turn state | [Client API](/reference/api/python-library-reference/client) |
@@ -102,7 +105,7 @@ NeMo Fabric Rust core
         |
         |  resolved adapter contract
         v
-Hermes | Codex SDK | custom harness
+Hermes Agent | Codex | custom harness
         |
         v
 RunResult + artifacts + events + telemetry references

--- a/docs/about-nemo-fabric/overview.mdx
+++ b/docs/about-nemo-fabric/overview.mdx
@@ -95,17 +95,17 @@ Hermes | Codex SDK | custom harness
 RunResult + artifacts + events + telemetry references
 ```
 
-- **Configuration**: Use a versioned `agent.yaml` package or a typed
-  `FabricConfig` to describe the harness adapter, environment, models, tools,
-  skills, MCP, and telemetry. File-backed and typed configs converge on the same
-  resolved config and run-plan contracts.
-- **Plan and diagnostics**: Resolve the adapter and check capabilities and
-  requirements before spending work on a runtime.
-- **Runtime lifecycle**: Run a one-shot job or start a stateful runtime through
-  the shared start, invoke, and stop contract. Adapters own harness-specific
-  preparation and invocation; consumers own the request.
-- **Normalized evidence**: Consume `RunResult` for output, structured failure
-  details, artifacts, events, and telemetry references.
+1. **Configure** an agent package or typed `FabricConfig` with a harness adapter,
+   environment, models, tools, skills, MCP, and telemetry.
+2. **Create variants** from deep copies to vary harness, model, environment, or
+   observability settings without mutating the base config. File-backed packages
+   may instead apply ordered profiles.
+3. **Plan and diagnose** to resolve the adapter and check capabilities and
+   requirements before spending work on a runtime.
+4. **Run or start a runtime** through the shared start, invoke, and stop
+   lifecycle contract.
+5. **Consume evidence** from `RunResult`: output, structured failure details,
+   artifacts, events, and telemetry references.
 
 ## Learn More
 

--- a/docs/about-nemo-fabric/release-notes.mdx
+++ b/docs/about-nemo-fabric/release-notes.mdx
@@ -1,8 +1,60 @@
 ---
-title: "Release Notes"
-description: "Release notes for NVIDIA NeMo Fabric."
+title: "Release Notes for NVIDIA NeMo Fabric"
+sidebar-title: "Release Notes"
+description: "New features, fixed issues, and known issues for each NVIDIA NeMo Fabric release."
+template-library-version: "1.0.0"
 ---
 {/* SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 SPDX-License-Identifier: Apache-2.0 */}
 
-To be filled out at release time
+This documentation contains the release notes for [NVIDIA NeMo Fabric](/about-ne-mo-fabric/overview).
+
+## Release `<Number.Number.Number>`
+
+{/* Provide the release summary here. Replace the following paragraph with your own. */}
+This release `<focus / soul / spirit of the release>`...
+
+### Highlights
+
+This release contains the following key changes:
+
+- Item 1. For details, refer to [Link to documentation](doc.mdx).
+- Item 2. For details, refer to [Link to documentation](doc.mdx).
+- Item 3. For details, refer to [Link to documentation](doc.mdx).
+
+{/* Optional: include this section if you have support matrix or compatibility updates for this release. */}
+### Support Matrix and Compatibility Updates
+
+- Added support for `<platform>`. For details, refer to [Support Matrix](support-matrix.mdx).
+
+### Fixed Known Issues
+
+This version fixes the following known issues:
+
+- Fixed known issue 1. For details, refer to [Link to documentation](doc.mdx) or [Link to troubleshooting](troubleshooting.mdx).
+- Fixed known issue 2. For details, refer to [Link to documentation](doc.mdx) or [Link to troubleshooting](troubleshooting.mdx).
+- Fixed known issue 3. For details, refer to [Link to documentation](doc.mdx) or [Link to troubleshooting](troubleshooting.mdx).
+
+For the full list of known issues, refer to [Known Issues](#all-known-issues).
+
+## All Known Issues
+
+{/* Provide the known issues list here. Replace the following information with your own, or state that there are no known issues in this release. */}
+The known issues for NVIDIA NeMo Fabric are the following:
+
+- (New in version N.N.0) Known issue 1. [Link to documentation](doc.mdx) or [Link to troubleshooting](troubleshooting.mdx).
+- (New in version N.N.0) Known issue 2. [Link to documentation](doc.mdx) or [Link to troubleshooting](troubleshooting.mdx).
+- Known issue 3. [Link to documentation](doc.mdx) or [Link to troubleshooting](troubleshooting.mdx).
+
+{/* Optional: include this section if you want to link directly to previous versions of the release notes. */}
+## Release Notes for Previous Versions
+
+- [N.N.N](link.mdx)
+- [N.N.N](link.mdx)
+- [N.N.N](link.mdx)
+
+## Related Topics
+
+{/* Provide a list of links to related topics. Include correct page titles and file names for the links. */}
+- [related-topic-1](link.mdx)
+- [related-topic-2](link.mdx)

--- a/docs/about-nemo-fabric/release-notes.mdx
+++ b/docs/about-nemo-fabric/release-notes.mdx
@@ -25,6 +25,8 @@ This release contains the following key changes:
 {/* Optional: include this section if you have support matrix or compatibility updates for this release. */}
 ### Support Matrix and Compatibility Updates
 
+This release includes the following support matrix and compatibility updates:
+
 - Added support for `<platform>`. For details, refer to [Support Matrix](support-matrix.mdx).
 
 ### Fixed Known Issues
@@ -49,6 +51,8 @@ The known issues for NVIDIA NeMo Fabric are the following:
 {/* Optional: include this section if you want to link directly to previous versions of the release notes. */}
 ## Release Notes for Previous Versions
 
+Find the release notes for previous versions at the following links:
+
 - [N.N.N](link.mdx)
 - [N.N.N](link.mdx)
 - [N.N.N](link.mdx)
@@ -56,5 +60,7 @@ The known issues for NVIDIA NeMo Fabric are the following:
 ## Related Topics
 
 {/* Provide a list of links to related topics. Include correct page titles and file names for the links. */}
+For more information, refer to the following related topics:
+
 - [related-topic-1](link.mdx)
 - [related-topic-2](link.mdx)

--- a/docs/getting-started/install.mdx
+++ b/docs/getting-started/install.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Install NVIDIA NeMo Fabric"
+title: "NVIDIA NeMo Fabric Installation"
 description: "Install guide."
 ---
 {/* SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.

--- a/docs/getting-started/quick-start.mdx
+++ b/docs/getting-started/quick-start.mdx
@@ -1,0 +1,66 @@
+---
+title: "NVIDIA NeMo Fabric Quickstart"
+sidebar-title: "Quickstart"
+description: "Install NeMo Fabric from a source checkout and run a simple agent through the Python SDK."
+---
+{/* SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+SPDX-License-Identifier: Apache-2.0 */}
+
+Install `just` 1.50.0+ if it is not already available.
+
+```bash
+cargo install just --locked
+```
+
+Refer to the [official installation guide](https://just.systems/man/en/installation.html)
+for more details.
+
+Ensure that the Cargo bin directory is in your `PATH`:
+
+```bash
+export PATH="$HOME/.cargo/bin:$PATH"
+```
+
+Create a Python virtual environment and activate it (replace `3.13` with your preferred Python version):
+
+```bash
+uv venv -p 3.13 --seed .venv
+source .venv/bin/activate
+```
+
+Install the Python SDK with its native binding and the CLI from a source
+checkout:
+
+```bash
+just build-all
+```
+
+Run the example through the Python SDK:
+
+```python
+import asyncio
+from examples.code_review_agent import BASE_DIR, hermes_config
+from nemo_fabric import Fabric
+
+
+async def main() -> None:
+    config = hermes_config()
+    client = Fabric()
+    result = await client.run(
+        config,
+        base_dir=BASE_DIR,
+        input="Reply with exactly: fabric works",
+    )
+
+    print(result.status)
+
+
+asyncio.run(main())
+```
+
+Harness installation and credential requirements differ by adapter. The
+[repository quick start](https://github.com/NVIDIA/NeMo-Fabric#quick-start-hermes)
+contains the complete Hermes environment recipe.
+
+Refer to the [Python SDK guide](/sdk/python) for planning, diagnostics, typed
+requests, and multi-turn runtime examples.

--- a/docs/getting-started/quickstart.mdx
+++ b/docs/getting-started/quickstart.mdx
@@ -1,5 +1,5 @@
 ---
-title: "NVIDIA NeMo Fabric Quickstart"
+title: "NVIDIA NeMo Fabric Beginner Tutorial"
 description: "Get started with NVIDIA NeMo Fabric."
 ---
 {/* SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.

--- a/docs/index.yml
+++ b/docs/index.yml
@@ -10,10 +10,15 @@ navigation:
         path: ./about-nemo-fabric/release-notes.mdx
   - section: Getting Started
     contents:
-      - page: Install
+      - page: Installation
         path: ./getting-started/install.mdx
+        slug: install
       - page: Quickstart
+        path: ./getting-started/quick-start.mdx
+        slug: quick-start
+      - page: Beginner Tutorial
         path: ./getting-started/quickstart.mdx
+        slug: quickstart
   - section: SDK
     contents:
       - page: Python SDK


### PR DESCRIPTION
#### Overview

Aligns the About-area documentation with the NVIDIA tech-docs template library and cleans up Getting Started navigation. Docs-only change; no product/runtime code, public API, or packaging is affected.

Changes:
- **Overview** (`docs/about-nemo-fabric/overview.mdx`): headings converted to title case and the page restructured to follow the tech-docs About/overview template — intro, `Benefits`, `Use Cases`, `Core Workflow`, and `Learn More`.
- **Quick Start moved out**: the source-build + SDK-example content moved from the overview into a dedicated Getting Started page (`docs/getting-started/quick-start.mdx`).
- **Navigation renames** (`docs/index.yml`): `Install` → `Installation`, `Quickstart` → `Beginner Tutorial`, and a new `Quickstart` page. Slugs are pinned (`install`, `quickstart`, `quick-start`) so existing published URLs remain stable and no redirects are needed.
- **Release Notes** (`docs/about-nemo-fabric/release-notes.mdx`): scaffolded from the tech-docs release-notes template with placeholders (Highlights, Support Matrix and Compatibility Updates, Fixed Known Issues, All Known Issues, Previous Versions, Related Topics). The NIM-specific Production Branch note was omitted; angle-bracket placeholders are wrapped in backticks so MDX parses cleanly.

Validation: `fern check` passes (0 errors, 0 warnings). The Python API references were regenerated (no diff). The Rust library reference regeneration was not run — `cargo` is not available in this environment.

- [x] I confirm this contribution is my own work, or I have the right to submit it under this project's license.
- [x] I searched existing issues and open pull requests, and this does not duplicate existing work.

#### Where should the reviewer start?

Start with `docs/about-nemo-fabric/overview.mdx` to review the template restructure and title-case headings, then `docs/index.yml` for the nav renames and pinned slugs (the key decision that keeps published URLs stable). `docs/about-nemo-fabric/release-notes.mdx` is a placeholder scaffold to be filled at release time.

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- Relates to: none


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Reorganized the NeMo Fabric overview into clearer **Benefits**, **Use Cases** (including an updated use-case table), and a simplified **Core Workflow** with updated visuals and learning links.
  * Added a complete **NeMo Fabric Release Notes** template with structured sections for highlights, compatibility updates, and known issues.
  * Created an **NVIDIA NeMo Fabric Quickstart** page with prerequisites, setup steps, and a Python SDK example.
  * Renamed **Quickstart** to **Beginner Tutorial** and updated Getting Started navigation for better discoverability.
  * Updated the installation page title for consistency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->