### PR TITLE
docs: Support syncing documentation snapshots to the `docs-website` branch

### DIFF
--- a/.github/ci-path-filters.yml
+++ b/.github/ci-path-filters.yml
@@ -1,0 +1,19 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+docs:
+  - '.github/ci-path-filters.yml'
+  - '.github/workflows/fern-docs.yml'
+  - 'CONTRIBUTING.md'
+  - 'README.md'
+  - 'Cargo.lock'
+  - 'Cargo.toml'
+  - 'crates/fabric-core/**'
+  - 'docs/**'
+  - 'fern/**'
+  - 'justfile'
+  - 'pyproject.toml'
+  - 'python/src/nemo_fabric/**'
+  - 'scripts/generate_api_docs.sh'
+  - 'scripts/docs/**'
+  - 'uv.lock'

--- a/.github/workflows/fern-docs.yml
+++ b/.github/workflows/fern-docs.yml
@@ -3,34 +3,48 @@
 
 name: Fern Docs
 
-# Push-only: copy-pr-bot mirrors each fork PR to an in-repo pull-request/<n>
-# branch (which receives secrets), so preview/publish can authenticate. Using
-# push-only (not pull_request) avoids a duplicate run per PR.
+# copy-pr-bot mirrors fork PRs to pull-request/<n> branches, where the Fern
+# environment secret is available. The pull_request event is used only to
+# remove the corresponding preview after a merged PR closes.
 on:
   push:
     branches:
       - main
       - 'pull-request/**'
+    tags:
+      - '*'
+      - '!*-alpha*'
+  pull_request:
+    types:
+      - closed
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: 'Raw SemVer docs tag, such as 0.1.0 or 0.1.0-rc.1. Alpha tags are not published.'
+        required: false
+        type: string
 
 concurrency:
-  group: fern-docs-${{ github.ref }}
+  group: '${{ github.workflow }} @ ${{ github.event_name }} @ ${{ github.head_ref || github.ref }}'
   cancel-in-progress: true
 
-permissions:
-  contents: read
-  pull-requests: write
-
 jobs:
-  docs:
-    name: Build and publish docs
+  preview-docs:
+    name: Preview docs
+    if: startsWith(github.ref_name, 'pull-request/')
     runs-on: ubuntu-latest
-    timeout-minutes: 15
+    environment: fern
+    timeout-minutes: 60
+    permissions:
+      contents: read
+      pull-requests: write
     steps:
-      - name: Checkout
+      - name: Checkout source branch
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
+          path: source-checkout
+          fetch-depth: 1
           persist-credentials: false
-          fetch-depth: 0
 
       - name: Install just
         uses: taiki-e/install-action@c070f87102a1c75b3183910f391c1cb887fe13c8 # v2.77.6
@@ -39,42 +53,54 @@ jobs:
 
       - name: Set up uv
         uses: astral-sh/setup-uv@cec208311dfd045dd5311c1add060b2062131d57 # v8
+        with:
+          enable-cache: true
+          cache-dependency-glob: source-checkout/uv.lock
 
-      # The Rust library reference is built from rustdoc (cargo doc -> MDX), so a
-      # Rust toolchain is required here in addition to uv/Node.
       - name: Set up Rust
         uses: actions-rust-lang/setup-rust-toolchain@150fca883cd4034361b621bd4e6a9d34e5143606 # v1.15.4
         with:
           toolchain: stable
           cache: false
 
-      - name: Set up Node
+      - name: Set up Node.js
         uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6
         with:
-          node-version: "20"
+          node-version: '20'
+          cache: npm
+          cache-dependency-path: source-checkout/docs/package-lock.json
 
-      # Generate the Python reference from SDK docstrings and the Rust reference
-      # from rustdoc, then validate the Fern configuration.
-      - name: Generate API references and validate docs
+      - name: Generate and validate source docs
+        working-directory: source-checkout
         run: just docs
 
-      # Publish to the (internal-by-default) Fern site on merge to main.
-      - name: Publish docs
-        if: github.ref_name == 'main'
-        env:
-          FERN_TOKEN: ${{ secrets.FERN_TOKEN }}
-        run: npx --prefix docs --no-install fern generate --docs
+      - name: Checkout docs website branch
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          ref: docs-website
+          path: docs-checkout
+          fetch-depth: 1
+          persist-credentials: false
 
-      # Build a preview deployment for the PR and capture its URL.
-      - name: Preview docs
+      - name: Sync docs website layout
+        working-directory: source-checkout
+        run: |
+          set -euo pipefail
+          .venv/bin/python scripts/docs/sync_fern_docs_branch.py sync-dev \
+            --source-root "$GITHUB_WORKSPACE/source-checkout" \
+            --target-root "$GITHUB_WORKSPACE/docs-checkout"
+
+      - name: Generate docs preview
         id: preview
-        if: startsWith(github.ref_name, 'pull-request/')
+        working-directory: docs-checkout/fern
         env:
           FERN_TOKEN: ${{ secrets.FERN_TOKEN }}
         run: |
           set -euo pipefail
           pr_number="${GITHUB_REF_NAME#pull-request/}"
-          if output="$(npx --prefix docs --no-install fern generate --docs --preview --id "pull-request-${pr_number}" 2>&1)"; then
+          printf 'pr_number=%s\n' "$pr_number" >> "$GITHUB_OUTPUT"
+          preview_id="pull-request-${pr_number}"
+          if output="$("$GITHUB_WORKSPACE/source-checkout/docs/node_modules/.bin/fern" generate --docs --preview --id "$preview_id" 2>&1)"; then
             fern_exit=0
           else
             fern_exit=$?
@@ -85,22 +111,275 @@ jobs:
             exit "$fern_exit"
           fi
           line="$(printf '%s\n' "$output" | sed -n 's/^.*Published docs to //p' | tail -n 1)"
-          # Extract just the URL: Fern appends a zero-width space (and may add
-          # ANSI codes); a strict charset drops them so the link is clean.
           url="$(printf '%s' "$line" | grep -oE 'https?://[A-Za-z0-9._~:/?#@!$&()*+,;=%-]+' | head -n 1)"
           if [ -n "$url" ]; then
             printf 'url=%s\n' "$url" >> "$GITHUB_OUTPUT"
           fi
 
-      # Post (or update) the preview link as a comment on the originating PR.
       - name: Comment preview URL on PR
         if: ${{ steps.preview.outputs.url != '' }}
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           set -euo pipefail
-          pr_number="${GITHUB_REF_NAME#pull-request/}"
-          gh pr comment "https://github.com/${{ github.repository }}/pull/${pr_number}" \
+          gh pr comment "https://github.com/${{ github.repository }}/pull/${{ steps.preview.outputs.pr_number }}" \
             --edit-last \
             --create-if-none \
-            --body "📖 Fern docs preview: ${{ steps.preview.outputs.url }}"
+            --body "Fern docs preview: ${{ steps.preview.outputs.url }}"
+
+  cleanup-preview-docs:
+    name: Clean up docs preview
+    if: >-
+      ${{
+        github.event_name == 'pull_request'
+        && github.event.action == 'closed'
+        && github.event.pull_request.merged == true
+      }}
+    runs-on: ubuntu-latest
+    environment: fern
+    timeout-minutes: 10
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout source branch
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          ref: ${{ github.event.pull_request.base.ref }}
+          path: source-checkout
+          fetch-depth: 1
+          persist-credentials: false
+
+      - name: Set up Node.js
+        uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6
+        with:
+          node-version: '20'
+          cache: npm
+          cache-dependency-path: source-checkout/docs/package-lock.json
+
+      - name: Install Fern CLI
+        working-directory: source-checkout
+        run: npm ci --prefix docs --ignore-scripts
+
+      - name: Delete preview deployment
+        working-directory: source-checkout/fern
+        env:
+          FERN_TOKEN: ${{ secrets.FERN_TOKEN }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: |
+          set -euo pipefail
+          preview_id="pull-request-${PR_NUMBER}"
+          echo "Deleting Fern docs preview: ${preview_id}"
+          "$GITHUB_WORKSPACE/source-checkout/docs/node_modules/.bin/fern" docs preview delete --id "$preview_id" \
+            || echo "Fern preview deletion returned non-zero; it may already be deleted."
+
+  publish-dev-docs:
+    name: Publish dev docs
+    if: >-
+      ${{
+        github.ref_name == 'main'
+        || (github.event_name == 'workflow_dispatch' && (inputs.tag == '' || inputs.tag == null))
+      }}
+    runs-on: ubuntu-latest
+    environment: fern
+    timeout-minutes: 60
+    permissions:
+      contents: write
+    steps:
+      - name: Checkout source branch
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          path: source-checkout
+          fetch-depth: 1
+          persist-credentials: false
+
+      - name: Install just
+        uses: taiki-e/install-action@c070f87102a1c75b3183910f391c1cb887fe13c8 # v2.77.6
+        with:
+          tool: just@1.50.0
+
+      - name: Set up uv
+        uses: astral-sh/setup-uv@cec208311dfd045dd5311c1add060b2062131d57 # v8
+        with:
+          enable-cache: true
+          cache-dependency-glob: source-checkout/uv.lock
+
+      - name: Set up Rust
+        uses: actions-rust-lang/setup-rust-toolchain@150fca883cd4034361b621bd4e6a9d34e5143606 # v1.15.4
+        with:
+          toolchain: stable
+          cache: false
+
+      - name: Set up Node.js
+        uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6
+        with:
+          node-version: '20'
+          cache: npm
+          cache-dependency-path: source-checkout/docs/package-lock.json
+
+      - name: Generate and validate source docs
+        working-directory: source-checkout
+        run: just docs
+
+      - name: Checkout docs website branch
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          ref: docs-website
+          path: docs-checkout
+          fetch-depth: 1
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Sync docs website layout
+        working-directory: source-checkout
+        run: |
+          set -euo pipefail
+          .venv/bin/python scripts/docs/sync_fern_docs_branch.py sync-dev \
+            --source-root "$GITHUB_WORKSPACE/source-checkout" \
+            --target-root "$GITHUB_WORKSPACE/docs-checkout"
+
+      - name: Check for docs website changes
+        id: changes
+        working-directory: docs-checkout
+        run: |
+          set -euo pipefail
+          if [ -z "$(git status --porcelain --untracked-files=all)" ]; then
+            echo "has_changes=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "has_changes=true" >> "$GITHUB_OUTPUT"
+            git status --short
+          fi
+
+      - name: Commit and push docs website changes
+        if: ${{ steps.changes.outputs.has_changes == 'true' }}
+        working-directory: docs-checkout
+        run: |
+          set -euo pipefail
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add -A
+          git commit -m "docs(fern): sync dev from main
+
+          Automated sync of docs/ from main.
+          Source commit: ${{ github.sha }}"
+          git push origin docs-website
+
+      - name: Publish docs
+        working-directory: docs-checkout/fern
+        env:
+          FERN_TOKEN: ${{ secrets.FERN_TOKEN }}
+        run: |
+          "$GITHUB_WORKSPACE/source-checkout/docs/node_modules/.bin/fern" generate --docs
+
+  release-version-docs:
+    name: Release docs version
+    if: >-
+      ${{
+        github.ref_type == 'tag'
+        || (github.event_name == 'workflow_dispatch' && inputs.tag != '' && inputs.tag != null)
+      }}
+    runs-on: ubuntu-latest
+    environment: fern
+    timeout-minutes: 60
+    permissions:
+      contents: write
+    steps:
+      - name: Determine version tag
+        id: version
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          INPUT_TAG: ${{ inputs.tag }}
+        run: |
+          set -euo pipefail
+          if [ "$EVENT_NAME" = "workflow_dispatch" ]; then
+            tag="$INPUT_TAG"
+          else
+            tag="$GITHUB_REF_NAME"
+          fi
+          if [[ ! "$tag" =~ ^[0-9]+\.[0-9]+\.[0-9]+(-(beta|rc)\.[0-9]+)?$ ]]; then
+            echo "Error: docs tags must use raw SemVer such as 0.1.0, 0.1.0-beta.1, or 0.1.0-rc.1; alpha tags are not published" >&2
+            exit 1
+          fi
+          printf 'tag=%s\n' "$tag" >> "$GITHUB_OUTPUT"
+
+      - name: Checkout workflow tools
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          path: workflow-checkout
+          fetch-depth: 1
+          persist-credentials: false
+
+      - name: Checkout source tag
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          ref: ${{ steps.version.outputs.tag }}
+          path: source-checkout
+          fetch-depth: 1
+          persist-credentials: false
+
+      - name: Install just
+        uses: taiki-e/install-action@c070f87102a1c75b3183910f391c1cb887fe13c8 # v2.77.6
+        with:
+          tool: just@1.50.0
+
+      - name: Set up uv
+        uses: astral-sh/setup-uv@cec208311dfd045dd5311c1add060b2062131d57 # v8
+        with:
+          enable-cache: true
+          cache-dependency-glob: source-checkout/uv.lock
+
+      - name: Set up Rust
+        uses: actions-rust-lang/setup-rust-toolchain@150fca883cd4034361b621bd4e6a9d34e5143606 # v1.15.4
+        with:
+          toolchain: stable
+          cache: false
+
+      - name: Set up Node.js
+        uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6
+        with:
+          node-version: '20'
+          cache: npm
+          cache-dependency-path: source-checkout/docs/package-lock.json
+
+      - name: Generate and validate source docs
+        working-directory: source-checkout
+        run: just docs
+
+      - name: Checkout docs website branch
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          ref: docs-website
+          path: docs-checkout
+          fetch-depth: 1
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Create docs snapshot
+        working-directory: workflow-checkout
+        run: |
+          set -euo pipefail
+          "$GITHUB_WORKSPACE/source-checkout/.venv/bin/python" scripts/docs/sync_fern_docs_branch.py release-version \
+            --source-root "$GITHUB_WORKSPACE/source-checkout" \
+            --target-root "$GITHUB_WORKSPACE/docs-checkout" \
+            --tag "${{ steps.version.outputs.tag }}"
+
+      - name: Commit and push docs snapshot
+        working-directory: docs-checkout
+        run: |
+          set -euo pipefail
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add -A
+          if git diff --cached --quiet; then
+            echo "No docs snapshot changes to commit."
+          else
+            git commit -m "docs(fern): release version v${{ steps.version.outputs.tag }}
+
+            Automated documentation snapshot.
+            Source tag: ${{ steps.version.outputs.tag }}"
+            git push origin docs-website
+          fi
+
+      - name: Publish docs
+        working-directory: docs-checkout/fern
+        env:
+          FERN_TOKEN: ${{ secrets.FERN_TOKEN }}
+        run: |
+          "$GITHUB_WORKSPACE/source-checkout/docs/node_modules/.bin/fern" generate --docs

--- a/.github/workflows/fern-docs.yml
+++ b/.github/workflows/fern-docs.yml
@@ -146,14 +146,11 @@ jobs:
 
       - name: Comment preview URL on PR
         if: ${{ steps.preview.outputs.url != '' }}
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          set -euo pipefail
-          gh pr comment "https://github.com/${{ github.repository }}/pull/${{ steps.preview.outputs.pr_number }}" \
-            --edit-last \
-            --create-if-none \
-            --body "Fern docs preview: ${{ steps.preview.outputs.url }}"
+        uses: marocchino/sticky-pull-request-comment@0ea0beb66eb9baf113663a64ec522f60e49231c0 # v3.0.4
+        with:
+          header: nemo-fabric-fern-preview
+          number: ${{ steps.preview.outputs.pr_number }}
+          message: 'Fern docs preview: ${{ steps.preview.outputs.url }}'
 
   cleanup-preview-docs:
     name: Clean up docs preview

--- a/.github/workflows/fern-docs.yml
+++ b/.github/workflows/fern-docs.yml
@@ -3,9 +3,6 @@
 
 name: Fern Docs
 
-# copy-pr-bot mirrors fork PRs to pull-request/<n> branches, where the Fern
-# environment secret is available. The pull_request event is used only to
-# remove the corresponding preview after a merged PR closes.
 on:
   push:
     branches:
@@ -29,9 +26,37 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  changed-files:
+    name: Detect docs changes
+    if: ${{ github.ref_type != 'tag' && github.event_name != 'pull_request' }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      contents: read
+    outputs:
+      docs: ${{ github.event_name == 'workflow_dispatch' || steps.filter.outputs.docs == 'true' }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Detect changed paths
+        id: filter
+        if: ${{ github.event_name != 'workflow_dispatch' }}
+        uses: dorny/paths-filter@fbd0ab8f3e69293af611ebaee6363fc25e6d187d # v4.01
+        with:
+          filters: .github/ci-path-filters.yml
+
   preview-docs:
     name: Preview docs
-    if: startsWith(github.ref_name, 'pull-request/')
+    needs: changed-files
+    if: >-
+      ${{
+        needs.changed-files.outputs.docs == 'true'
+        && startsWith(github.ref_name, 'pull-request/')
+      }}
     runs-on: ubuntu-latest
     environment: fern
     timeout-minutes: 60
@@ -54,6 +79,7 @@ jobs:
       - name: Set up uv
         uses: astral-sh/setup-uv@cec208311dfd045dd5311c1add060b2062131d57 # v8
         with:
+          version: 0.9.22
           enable-cache: true
           cache-dependency-glob: source-checkout/uv.lock
 
@@ -72,6 +98,8 @@ jobs:
 
       - name: Generate and validate source docs
         working-directory: source-checkout
+        env:
+          FERN_TOKEN: ${{ secrets.FERN_TOKEN }}
         run: just docs
 
       - name: Checkout docs website branch
@@ -174,10 +202,14 @@ jobs:
 
   publish-dev-docs:
     name: Publish dev docs
+    needs: changed-files
     if: >-
       ${{
-        github.ref_name == 'main'
-        || (github.event_name == 'workflow_dispatch' && (inputs.tag == '' || inputs.tag == null))
+        needs.changed-files.outputs.docs == 'true'
+        && (
+          github.ref_name == 'main'
+          || (github.event_name == 'workflow_dispatch' && (inputs.tag == '' || inputs.tag == null))
+        )
       }}
     runs-on: ubuntu-latest
     environment: fern
@@ -200,6 +232,7 @@ jobs:
       - name: Set up uv
         uses: astral-sh/setup-uv@cec208311dfd045dd5311c1add060b2062131d57 # v8
         with:
+          version: 0.9.22
           enable-cache: true
           cache-dependency-glob: source-checkout/uv.lock
 
@@ -218,6 +251,8 @@ jobs:
 
       - name: Generate and validate source docs
         working-directory: source-checkout
+        env:
+          FERN_TOKEN: ${{ secrets.FERN_TOKEN }}
         run: just docs
 
       - name: Checkout docs website branch
@@ -323,6 +358,7 @@ jobs:
       - name: Set up uv
         uses: astral-sh/setup-uv@cec208311dfd045dd5311c1add060b2062131d57 # v8
         with:
+          version: 0.9.22
           enable-cache: true
           cache-dependency-glob: source-checkout/uv.lock
 
@@ -341,6 +377,8 @@ jobs:
 
       - name: Generate and validate source docs
         working-directory: source-checkout
+        env:
+          FERN_TOKEN: ${{ secrets.FERN_TOKEN }}
         run: just docs
 
       - name: Checkout docs website branch
@@ -369,13 +407,13 @@ jobs:
           git add -A
           if git diff --cached --quiet; then
             echo "No docs snapshot changes to commit."
-          else
-            git commit -m "docs(fern): release version v${{ steps.version.outputs.tag }}
-
-            Automated documentation snapshot.
-            Source tag: ${{ steps.version.outputs.tag }}"
-            git push origin docs-website
+            exit 0
           fi
+          git commit -m "docs(fern): release version v${{ steps.version.outputs.tag }}
+
+          Automated documentation snapshot.
+          Source tag: ${{ steps.version.outputs.tag }}"
+          git push origin docs-website
 
       - name: Publish docs
         working-directory: docs-checkout/fern

--- a/docs/about-nemo-fabric/overview.mdx
+++ b/docs/about-nemo-fabric/overview.mdx
@@ -1,5 +1,6 @@
 ---
 title: "NVIDIA NeMo Fabric"
+slug: "/about-nemo-fabric/overview"
 description: "Configure, plan, run, and observe agent harnesses through one typed execution contract."
 ---
 {/* SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.

--- a/docs/about-nemo-fabric/overview.mdx
+++ b/docs/about-nemo-fabric/overview.mdx
@@ -118,8 +118,8 @@ Harness installation and credential requirements differ by adapter. The
 [repository quick start](https://github.com/NVIDIA/NeMo-Fabric#quick-start-hermes)
 contains the complete Hermes environment recipe.
 
-Refer to the [Python SDK guide](/sdk/python) for planning, diagnostics, typed
-requests, and multi-turn runtime examples.
+Refer to the [Python SDK guide](/nemo/fabric/sdk/python-sdk) for planning,
+diagnostics, typed requests, and multi-turn runtime examples.
 
 ## Choose your interface
 

--- a/docs/sdk/python.mdx
+++ b/docs/sdk/python.mdx
@@ -20,7 +20,7 @@ Generated API reference pages remain the source of truth for exact signatures.
 This guide explains how the pieces are intended to fit together.
 
 For installation and a package-backed example, start with the
-[NeMo Fabric overview](/nemo/fabric/about-ne-mo-fabric/overview).
+[NeMo Fabric overview](/nemo/fabric/about-nemo-fabric/overview).
 
 ## Start With One Run
 

--- a/docs/sdk/python.mdx
+++ b/docs/sdk/python.mdx
@@ -20,7 +20,7 @@ Generated API reference pages remain the source of truth for exact signatures.
 This guide explains how the pieces are intended to fit together.
 
 For installation and a package-backed example, start with the
-[NeMo Fabric overview](/about-nemo-fabric/overview).
+[NeMo Fabric overview](/nemo/fabric/about-ne-mo-fabric/overview).
 
 ## Start With One Run
 

--- a/justfile
+++ b/justfile
@@ -323,7 +323,8 @@ docs:
     npm ci --prefix docs --ignore-scripts
     PATH="{{ REPO_ROOT }}/.venv/bin:$PATH" bash scripts/generate_api_docs.sh
     uv run --no-sync python scripts/docs/generate_rust_library_reference.py
-    npx --prefix docs --no-install fern check
+    npx --prefix docs --no-install fern check --warnings
+    npx --prefix docs --no-install fern docs broken-links --strict
 
 # Launch Jupyter Lab for the onboarding notebooks under examples/notebooks/.
 # Jupyter is fetched on demand so it stays out of the project lockfile.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -109,6 +109,7 @@ dev = [
 docs = [
   "lazydocs>=0.4",
   "beautifulsoup4>=4.12",
+  "pyyaml>=6.0",
 ]
 
 test = [

--- a/scripts/docs/sync_fern_docs_branch.py
+++ b/scripts/docs/sync_fern_docs_branch.py
@@ -1,0 +1,325 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Prepare the CI-managed Fern docs branch layout.
+
+The source branch keeps author-facing content in ``docs/`` and local Fern
+configuration in ``fern/``. The ``docs-website`` branch stores a Fern-native
+layout with versioned navigation under ``fern/versions/`` and page content
+under ``fern/pages-*``.
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+import shutil
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+VERSION_RE = re.compile(
+    r"^(?P<base>[0-9]+\.[0-9]+\.[0-9]+)"
+    r"(?:-(?P<label>alpha|beta|rc)\.(?P<number>[0-9]+))?$"
+)
+COPY_EXCLUDES = {
+    ".DS_Store",
+    "__pycache__",
+    "_build",
+    "_generated",
+    "_source",
+    "index.yml",
+}
+FERN_SYNC_ITEMS = (
+    ".gitignore",
+    "assets",
+    "components",
+    "fern.config.json",
+    "README.md",
+)
+YAML_HEADER = (
+    "# SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.\n"
+    "# SPDX-License-Identifier: Apache-2.0\n\n"
+)
+
+
+def read_yaml(path: Path) -> Any:
+    with path.open("r", encoding="utf-8") as handle:
+        return yaml.safe_load(handle)
+
+
+def write_yaml(path: Path, value: Any) -> None:
+    with path.open("w", encoding="utf-8") as handle:
+        handle.write(YAML_HEADER)
+        yaml.safe_dump(value, handle, sort_keys=False, allow_unicode=False)
+
+
+def copy_path(source: Path, destination: Path) -> None:
+    if destination.exists() or destination.is_symlink():
+        if destination.is_dir() and not destination.is_symlink():
+            shutil.rmtree(destination)
+        else:
+            destination.unlink()
+    if source.is_dir():
+        shutil.copytree(source, destination)
+    else:
+        destination.parent.mkdir(parents=True, exist_ok=True)
+        shutil.copy2(source, destination)
+
+
+def docs_ignore(_directory: str, names: list[str]) -> set[str]:
+    return {name for name in names if name in COPY_EXCLUDES}
+
+
+def prefixed_doc_path(value: str, pages_directory: str) -> str:
+    if value.startswith(("http://", "https://", "/", "../")):
+        return value
+    normalized = value[2:] if value.startswith("./") else value
+    return f"../{pages_directory}/{normalized}"
+
+
+def rewrite_doc_references(value: Any, pages_directory: str) -> Any:
+    if isinstance(value, dict):
+        return {
+            key: (
+                prefixed_doc_path(item, pages_directory)
+                if key in {"folder", "path"} and isinstance(item, str)
+                else rewrite_doc_references(item, pages_directory)
+            )
+            for key, item in value.items()
+        }
+    if isinstance(value, list):
+        return [rewrite_doc_references(item, pages_directory) for item in value]
+    return value
+
+
+def parse_release_tag(tag: str) -> tuple[str, str, bool]:
+    match = VERSION_RE.fullmatch(tag)
+    if match is None:
+        raise ValueError(f"docs tags must use raw SemVer, got: {tag}")
+    base_version = match.group("base")
+    label = match.group("label")
+    if label == "alpha":
+        raise ValueError(f"alpha docs tags are not published: {tag}")
+    is_stable = label is None
+    return f"v{base_version}", "stable" if is_stable else "beta", is_stable
+
+
+def docs_website_product(source_product: dict[str, Any]) -> dict[str, Any]:
+    product = dict(source_product)
+    product["path"] = "./versions/dev.yml"
+    product["versions"] = [
+        {
+            "display-name": "dev",
+            "path": "./versions/dev.yml",
+            "slug": "dev",
+            "availability": "beta",
+        }
+    ]
+    return product
+
+
+def load_preserved_product(target_docs_yml: Path) -> dict[str, Any] | None:
+    if not target_docs_yml.exists():
+        return None
+    docs_yml = read_yaml(target_docs_yml)
+    products = docs_yml.get("products") if isinstance(docs_yml, dict) else None
+    if not products:
+        return None
+    return products[0]
+
+
+def write_docs_yml(source_docs_yml: Path, target_docs_yml: Path) -> None:
+    preserved_product = load_preserved_product(target_docs_yml)
+    docs_yml = read_yaml(source_docs_yml)
+    products = docs_yml.get("products")
+    if not isinstance(products, list) or not products:
+        raise ValueError(f"{source_docs_yml} must define products[0]")
+
+    docs_yml["products"][0] = preserved_product or docs_website_product(products[0])
+    write_yaml(target_docs_yml, docs_yml)
+
+
+def sync_dev(source_root: Path, target_root: Path) -> None:
+    source_docs = source_root / "docs"
+    source_fern = source_root / "fern"
+    target_fern = target_root / "fern"
+
+    if not source_docs.is_dir():
+        raise FileNotFoundError(f"source docs directory not found: {source_docs}")
+    if not source_fern.is_dir():
+        raise FileNotFoundError(f"source Fern directory not found: {source_fern}")
+
+    target_fern.mkdir(parents=True, exist_ok=True)
+    versions_dir = target_fern / "versions"
+    versions_dir.mkdir(parents=True, exist_ok=True)
+
+    pages_dev = target_fern / "pages-dev"
+    if pages_dev.exists():
+        shutil.rmtree(pages_dev)
+    shutil.copytree(source_docs, pages_dev, ignore=docs_ignore)
+
+    navigation = read_yaml(source_docs / "index.yml")
+    write_yaml(
+        versions_dir / "dev.yml",
+        rewrite_doc_references(navigation, "pages-dev"),
+    )
+
+    for item in FERN_SYNC_ITEMS:
+        source = source_fern / item
+        if source.exists():
+            copy_path(source, target_fern / item)
+
+    write_docs_yml(source_fern / "docs.yml", target_fern / "docs.yml")
+
+
+def update_github_links(pages_dir: Path, tag: str) -> None:
+    replacements = (
+        (
+            "github.com/NVIDIA/NeMo-Fabric/blob/main",
+            f"github.com/NVIDIA/NeMo-Fabric/blob/{tag}",
+        ),
+        (
+            "github.com/NVIDIA/NeMo-Fabric/tree/main",
+            f"github.com/NVIDIA/NeMo-Fabric/tree/{tag}",
+        ),
+    )
+    for path in pages_dir.rglob("*"):
+        if path.suffix not in {".md", ".mdx"} or not path.is_file():
+            continue
+        text = path.read_text(encoding="utf-8")
+        updated = text
+        for old, new in replacements:
+            updated = updated.replace(old, new)
+        if updated != text:
+            path.write_text(updated, encoding="utf-8")
+
+
+def release_version(target_root: Path, tag: str, source_root: Path) -> None:
+    display_tag, availability, is_stable = parse_release_tag(tag)
+    target_fern = target_root / "fern"
+    pages_version = target_fern / f"pages-{display_tag}"
+    versions_dir = target_fern / "versions"
+    version_yml = versions_dir / f"{display_tag}.yml"
+    docs_yml_path = target_fern / "docs.yml"
+    source_docs = source_root / "docs"
+
+    if not source_docs.is_dir():
+        raise FileNotFoundError(f"source docs directory not found: {source_docs}")
+    versions_dir.mkdir(parents=True, exist_ok=True)
+    if pages_version.exists():
+        shutil.rmtree(pages_version)
+    if version_yml.exists():
+        version_yml.unlink()
+
+    shutil.copytree(source_docs, pages_version, ignore=docs_ignore)
+    update_github_links(pages_version, tag)
+    version_navigation = rewrite_doc_references(
+        read_yaml(source_docs / "index.yml"), f"pages-{display_tag}"
+    )
+    write_yaml(version_yml, version_navigation)
+
+    docs_yml = read_yaml(docs_yml_path)
+    product = docs_yml["products"][0]
+    versions = product.get("versions", [])
+    dev_entry = next(
+        (
+            entry
+            for entry in versions
+            if entry.get("display-name") == "dev" or entry.get("slug") == "dev"
+        ),
+        {
+            "display-name": "dev",
+            "path": "./versions/dev.yml",
+            "slug": "dev",
+            "availability": "beta",
+        },
+    )
+    dev_entry = {
+        **dev_entry,
+        "path": "./versions/dev.yml",
+        "slug": "dev",
+        "availability": "beta",
+    }
+
+    latest_entry = {
+        "display-name": f"Latest ({display_tag})",
+        "path": f"./versions/{display_tag}.yml",
+        "slug": "latest",
+        "availability": "stable",
+    }
+    version_entry = {
+        "display-name": display_tag,
+        "path": f"./versions/{display_tag}.yml",
+        "slug": display_tag,
+        "availability": availability,
+    }
+    existing_latest_entries = [
+        entry
+        for entry in versions
+        if entry.get("slug") == "latest"
+        or entry.get("display-name") == "Latest"
+        or str(entry.get("display-name", "")).startswith("Latest (")
+    ]
+    remaining_versions = [
+        entry
+        for entry in versions
+        if entry.get("slug") not in {"latest", "dev", display_tag}
+        and entry.get("display-name") != "Latest"
+        and entry.get("display-name") != display_tag
+        and not str(entry.get("display-name", "")).startswith("Latest (")
+    ]
+
+    if is_stable:
+        product["path"] = f"./versions/{display_tag}.yml"
+        product["versions"] = [
+            latest_entry,
+            dev_entry,
+            version_entry,
+            *remaining_versions,
+        ]
+    else:
+        product["versions"] = [
+            *existing_latest_entries[:1],
+            dev_entry,
+            version_entry,
+            *remaining_versions,
+        ]
+    write_yaml(docs_yml_path, docs_yml)
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    sync_parser = subparsers.add_parser(
+        "sync-dev", help="sync source docs into docs-website layout"
+    )
+    sync_parser.add_argument("--source-root", type=Path, required=True)
+    sync_parser.add_argument("--target-root", type=Path, required=True)
+
+    release_parser = subparsers.add_parser(
+        "release-version", help="snapshot source docs as a version"
+    )
+    release_parser.add_argument("--source-root", type=Path, required=True)
+    release_parser.add_argument("--target-root", type=Path, required=True)
+    release_parser.add_argument("--tag", required=True)
+
+    return parser.parse_args()
+
+
+def main() -> None:
+    args = parse_args()
+    if args.command == "sync-dev":
+        sync_dev(args.source_root.resolve(), args.target_root.resolve())
+    elif args.command == "release-version":
+        release_version(
+            args.target_root.resolve(), args.tag, args.source_root.resolve()
+        )
+    else:
+        raise AssertionError(f"unhandled command: {args.command}")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/scripts/test_sync_fern_docs_branch.py
+++ b/tests/scripts/test_sync_fern_docs_branch.py
@@ -1,0 +1,181 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+import yaml
+
+DOCS_SCRIPTS = Path(__file__).resolve().parents[2] / "scripts" / "docs"
+sys.path.insert(0, str(DOCS_SCRIPTS))
+
+import sync_fern_docs_branch  # noqa: E402
+
+
+def _write_yaml(path: Path, value: object) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(yaml.safe_dump(value, sort_keys=False), encoding="utf-8")
+
+
+def _source_tree(root: Path) -> None:
+    docs = root / "docs"
+    docs.mkdir(parents=True)
+    (docs / "guide.mdx").write_text(
+        "See https://github.com/NVIDIA/NeMo-Fabric/blob/main/README.md\n",
+        encoding="utf-8",
+    )
+    (docs / "_source").mkdir()
+    (docs / "_source" / "ignored.md").write_text("ignored\n", encoding="utf-8")
+    _write_yaml(
+        docs / "index.yml",
+        {
+            "navigation": [
+                {"page": "Guide", "path": "guide.mdx"},
+                {"page": "External", "path": "https://example.com"},
+            ]
+        },
+    )
+
+    fern = root / "fern"
+    fern.mkdir()
+    (fern / "fern.config.json").write_text('{"version": "5.37.10"}\n', encoding="utf-8")
+    _write_yaml(
+        fern / "docs.yml",
+        {
+            "title": "NVIDIA NeMo Fabric",
+            "products": [
+                {
+                    "display-name": "NeMo Fabric",
+                    "slug": "/",
+                    "path": "../docs/index.yml",
+                }
+            ],
+        },
+    )
+
+
+def test_sync_dev_rewrites_navigation_and_preserves_versions(tmp_path: Path):
+    source_root = tmp_path / "source"
+    target_root = tmp_path / "target"
+    _source_tree(source_root)
+
+    target_fern = target_root / "fern"
+    (target_fern / "pages-dev").mkdir(parents=True)
+    (target_fern / "pages-dev" / "stale.mdx").write_text("stale\n", encoding="utf-8")
+    preserved_product = {
+        "display-name": "NeMo Fabric",
+        "slug": "/",
+        "path": "./versions/v0.1.0.yml",
+        "versions": [
+            {
+                "display-name": "Latest (v0.1.0)",
+                "path": "./versions/v0.1.0.yml",
+                "slug": "latest",
+                "availability": "stable",
+            }
+        ],
+    }
+    _write_yaml(
+        target_fern / "docs.yml",
+        {"title": "Old title", "products": [preserved_product]},
+    )
+
+    sync_fern_docs_branch.sync_dev(source_root, target_root)
+
+    assert (target_fern / "pages-dev" / "guide.mdx").is_file()
+    assert not (target_fern / "pages-dev" / "stale.mdx").exists()
+    assert not (target_fern / "pages-dev" / "index.yml").exists()
+    assert not (target_fern / "pages-dev" / "_source").exists()
+    assert (target_fern / "fern.config.json").is_file()
+
+    navigation = sync_fern_docs_branch.read_yaml(target_fern / "versions" / "dev.yml")
+    assert navigation["navigation"][0]["path"] == "../pages-dev/guide.mdx"
+    assert navigation["navigation"][1]["path"] == "https://example.com"
+
+    docs_yml = sync_fern_docs_branch.read_yaml(target_fern / "docs.yml")
+    assert docs_yml["title"] == "NVIDIA NeMo Fabric"
+    assert docs_yml["products"][0] == preserved_product
+
+
+@pytest.mark.parametrize(
+    ("tag", "expected"),
+    [
+        ("1.2.3", ("v1.2.3", "stable", True)),
+        ("1.2.3-beta.4", ("v1.2.3", "beta", False)),
+        ("1.2.3-rc.4", ("v1.2.3", "beta", False)),
+    ],
+)
+def test_parse_release_tag(tag: str, expected: tuple[str, str, bool]):
+    assert sync_fern_docs_branch.parse_release_tag(tag) == expected
+
+
+@pytest.mark.parametrize("tag", ["v1.2.3", "1.2", "1.2.3-alpha.4", "1.2.3-beta"])
+def test_parse_release_tag_rejects_unpublished_tags(tag: str):
+    with pytest.raises(ValueError):
+        sync_fern_docs_branch.parse_release_tag(tag)
+
+
+def test_release_version_promotes_stable_snapshot(tmp_path: Path):
+    source_root = tmp_path / "source"
+    target_root = tmp_path / "target"
+    _source_tree(source_root)
+
+    target_fern = target_root / "fern"
+    _write_yaml(target_fern / "versions" / "dev.yml", {"navigation": []})
+    _write_yaml(
+        target_fern / "docs.yml",
+        {
+            "products": [
+                {
+                    "display-name": "NeMo Fabric",
+                    "slug": "/",
+                    "path": "./versions/v0.1.0.yml",
+                    "versions": [
+                        {
+                            "display-name": "Latest (v0.1.0)",
+                            "path": "./versions/v0.1.0.yml",
+                            "slug": "latest",
+                            "availability": "stable",
+                        },
+                        {
+                            "display-name": "dev",
+                            "path": "./versions/dev.yml",
+                            "slug": "dev",
+                            "availability": "beta",
+                        },
+                        {
+                            "display-name": "v0.1.0",
+                            "path": "./versions/v0.1.0.yml",
+                            "slug": "v0.1.0",
+                            "availability": "stable",
+                        },
+                    ],
+                }
+            ]
+        },
+    )
+
+    sync_fern_docs_branch.release_version(target_root, "0.2.0-rc.1", source_root)
+    beta_docs_yml = sync_fern_docs_branch.read_yaml(target_fern / "docs.yml")
+    beta_product = beta_docs_yml["products"][0]
+    assert beta_product["path"] == "./versions/v0.1.0.yml"
+    assert [entry["slug"] for entry in beta_product["versions"]] == [
+        "latest",
+        "dev",
+        "v0.2.0",
+        "v0.1.0",
+    ]
+    assert beta_product["versions"][2]["availability"] == "beta"
+
+    sync_fern_docs_branch.release_version(target_root, "0.2.0", source_root)
+    stable_docs_yml = sync_fern_docs_branch.read_yaml(target_fern / "docs.yml")
+    stable_product = stable_docs_yml["products"][0]
+    assert stable_product["path"] == "./versions/v0.2.0.yml"
+    assert stable_product["versions"][0]["display-name"] == "Latest (v0.2.0)"
+    assert stable_product["versions"][2]["availability"] == "stable"
+    assert "blob/0.2.0/README.md" in (
+        target_fern / "pages-v0.2.0" / "guide.mdx"
+    ).read_text(encoding="utf-8")

--- a/uv.lock
+++ b/uv.lock
@@ -2009,6 +2009,7 @@ dev = [
 docs = [
     { name = "beautifulsoup4" },
     { name = "lazydocs" },
+    { name = "pyyaml" },
 ]
 test = [
     { name = "fastapi" },
@@ -2058,6 +2059,7 @@ dev = [
 docs = [
     { name = "beautifulsoup4", specifier = ">=4.12" },
     { name = "lazydocs", specifier = ">=0.4" },
+    { name = "pyyaml", specifier = ">=6.0" },
 ]
 test = [
     { name = "fastapi", specifier = "~=0.138" },


### PR DESCRIPTION
#### Overview

* On documentation changes docs are synced to the `docs-website` branch

#### Where should the reviewer start?

* `scripts/docs/sync_fern_docs_branch.py`

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

PR #84

- [x] I confirm this contribution is my own work, or I have the right to submit it under this project's license.
- [x] I searched existing issues and open pull requests, and this does not duplicate existing work.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced a Fern docs pipeline for PR previews with automatic cleanup, plus dev docs publishing for `main`.
  - Added versioned docs releases with stable/beta/RC handling and stricter tag validation.
- **Documentation**
  - Updated NeMo Fabric overview and Python SDK guide links.
- **CI/CD**
  - Added docs change path filtering to avoid running docs work when unrelated files change.
  - Improved docs generation/validation and broken-link checking.
- **Tests**
  - Added coverage for docs branch synchronization, navigation rewriting, and release-tag/version promotion behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->