### PR TITLE
docs: distinguish sign-off from commit signing

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -153,6 +153,8 @@ maintenance updates.
   ```bash
   $ git commit -s -m "Add cool feature."
   ```
+  A DCO sign-off is a commit-message trailer, not a cryptographic signature.
+  To add both, use `git commit -S -s`.
   This will append the following to your commit message:
   ```
   Signed-off-by: Your Name <your@email.com>


### PR DESCRIPTION
#### Overview

Clarify that DCO sign-off and cryptographic commit signing are separate operations. This harmless documentation-only change also validates the contributor GPG signing setup with the configured GitHub noreply identity.

#### Details

- Explain that `Signed-off-by` is a commit-message trailer rather than a cryptographic signature.
- Show `git commit -S -s` as the command for applying both.

#### Validation

- `git verify-commit HEAD`
- `just docs`
- GitHub commit verification: `verified: true`, reason `valid`

#### Where should the reviewer start?

Review the two added lines in the `DCO Sign-Off` section of `CONTRIBUTING.md`.

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- Relates to: none

- [x] I confirm this contribution is my own work, or I have the right to submit it under this project's license.
- [x] I searched existing issues and open pull requests, and this does not duplicate existing work.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified that DCO sign-offs are commit-message trailers rather than cryptographic signatures.
  * Added instructions for including both GPG signatures and DCO sign-offs when committing changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->