### PR TITLE
ci: Set minimum glibc compatibility and add macOS builds

### DIFF
--- a/.github/workflows/ci_python.yml
+++ b/.github/workflows/ci_python.yml
@@ -139,7 +139,7 @@ jobs:
       - name: Cache cargo build
         uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
         with:
-          shared-key: fabric-python-wheels
+          shared-key: fabric-python-wheels-${{ runner.os }}-${{ runner.arch }}
 
       - name: Build wheels
         run: just wheels

--- a/.github/workflows/ci_python.yml
+++ b/.github/workflows/ci_python.yml
@@ -95,6 +95,7 @@ jobs:
 
   build-wheels:
     name: Build wheels (${{ matrix.platform }})
+    needs: [test]
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/ci_python.yml
+++ b/.github/workflows/ci_python.yml
@@ -143,7 +143,7 @@ jobs:
       - name: Cache cargo build
         uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
         with:
-          shared-key: fabric-python-wheels
+          shared-key: fabric-python-wheels-${{ matrix.runner }}
 
       - name: Build wheels
         run: just wheels

--- a/.github/workflows/ci_python.yml
+++ b/.github/workflows/ci_python.yml
@@ -40,13 +40,15 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        arch: [x86_64, arm64]
+        arch: [x86_64, arm64, macos-arm64]
         python-version: ['3.11', '3.12', '3.13', '3.14']
         include:
           - arch: x86_64
             runner: ubuntu-24.04
           - arch: arm64
             runner: ubuntu-24.04-arm
+          - arch: macos-arm64
+            runner: macos-15
     runs-on: ${{ matrix.runner }}
     timeout-minutes: 30
     permissions:
@@ -101,6 +103,8 @@ jobs:
             runner: ubuntu-24.04
           - arch: arm64
             runner: ubuntu-24.04-arm
+          - arch: macos-arm64
+            runner: macos-15
     runs-on: ${{ matrix.runner }}
     timeout-minutes: 30
     permissions:

--- a/.github/workflows/ci_python.yml
+++ b/.github/workflows/ci_python.yml
@@ -143,7 +143,7 @@ jobs:
       - name: Cache cargo build
         uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
         with:
-          shared-key: fabric-python-wheels-${{ matrix.runner }}
+          shared-key: fabric-python-wheels
 
       - name: Build wheels
         run: just wheels

--- a/.github/workflows/ci_python.yml
+++ b/.github/workflows/ci_python.yml
@@ -92,15 +92,11 @@ jobs:
           just test-python
 
   build-wheels:
-    name: Build wheels (${{ matrix.runner }}, ${{ matrix.arch }})
+    name: Build wheels (${{ matrix.arch }})
     strategy:
       fail-fast: false
       matrix:
         include:
-          - arch: x86_64
-            runner: ubuntu-22.04
-          - arch: arm64
-            runner: ubuntu-22.04-arm
           - arch: x86_64
             runner: ubuntu-24.04
           - arch: arm64
@@ -151,6 +147,6 @@ jobs:
       - name: Upload wheels
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
-          name: python-wheels-${{ matrix.runner }}-${{ matrix.arch }}
+          name: python-wheels-${{ matrix.arch }}
           path: dist/*.whl
           if-no-files-found: error

--- a/.github/workflows/ci_python.yml
+++ b/.github/workflows/ci_python.yml
@@ -92,11 +92,15 @@ jobs:
           just test-python
 
   build-wheels:
-    name: Build wheels (${{ matrix.arch }})
+    name: Build wheels (${{ matrix.runner }}, ${{ matrix.arch }})
     strategy:
       fail-fast: false
       matrix:
         include:
+          - arch: x86_64
+            runner: ubuntu-22.04
+          - arch: arm64
+            runner: ubuntu-22.04-arm
           - arch: x86_64
             runner: ubuntu-24.04
           - arch: arm64
@@ -147,6 +151,6 @@ jobs:
       - name: Upload wheels
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
-          name: python-wheels-${{ matrix.arch }}
+          name: python-wheels-${{ matrix.runner }}-${{ matrix.arch }}
           path: dist/*.whl
           if-no-files-found: error

--- a/.github/workflows/ci_python.yml
+++ b/.github/workflows/ci_python.yml
@@ -36,18 +36,18 @@ defaults:
 
 jobs:
   test:
-    name: Test (Python ${{ matrix.python-version }}, ${{ matrix.arch }})
+    name: Test (Python ${{ matrix.python-version }}, ${{ matrix.platform }})
     strategy:
       fail-fast: false
       matrix:
-        arch: [x86_64, arm64, macos-arm64]
+        platform: [linux-amd64, linux-arm64, macos-arm64]
         python-version: ['3.11', '3.12', '3.13', '3.14']
         include:
-          - arch: x86_64
+          - platform: linux-amd64
             runner: ubuntu-24.04
-          - arch: arm64
+          - platform: linux-arm64
             runner: ubuntu-24.04-arm
-          - arch: macos-arm64
+          - platform: macos-arm64
             runner: macos-15
     runs-on: ${{ matrix.runner }}
     timeout-minutes: 30
@@ -79,7 +79,7 @@ jobs:
       - name: Cache cargo build
         uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
         with:
-          shared-key: fabric-rust
+          shared-key: fabric-rust-${{ runner.os }}-${{ runner.arch }}
 
       # PyYAML is not a project dependency, but test_hermes_config_mapping
       # imports it to read Hermes config fixtures, so install it for the tests.
@@ -94,16 +94,16 @@ jobs:
           just test-python
 
   build-wheels:
-    name: Build wheels (${{ matrix.arch }})
+    name: Build wheels (${{ matrix.platform }})
     strategy:
       fail-fast: false
       matrix:
         include:
-          - arch: x86_64
+          - platform: linux-amd64
             runner: ubuntu-24.04
-          - arch: arm64
+          - platform: linux-arm64
             runner: ubuntu-24.04-arm
-          - arch: macos-arm64
+          - platform: macos-arm64
             runner: macos-15
     runs-on: ${{ matrix.runner }}
     timeout-minutes: 30
@@ -151,6 +151,6 @@ jobs:
       - name: Upload wheels
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
-          name: python-wheels-${{ matrix.arch }}
+          name: python-wheels-${{ matrix.platform }}
           path: dist/*.whl
           if-no-files-found: error

--- a/ATTRIBUTIONS-Python.md
+++ b/ATTRIBUTIONS-Python.md
@@ -5319,6 +5319,40 @@ OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 ```
 
+## maturin (1.14.1)
+
+### Licenses
+License: `MIT OR Apache-2.0`
+
+  - `license-mit`:
+```
+Copyright (c) 2018 konstin
+
+Permission is hereby granted, free of charge, to any
+person obtaining a copy of this software and associated
+documentation files (the "Software"), to deal in the
+Software without restriction, including without
+limitation the rights to use, copy, modify, merge,
+publish, distribute, sublicense, and/or sell copies of
+the Software, and to permit persons to whom the Software
+is furnished to do so, subject to the following
+conditions:
+
+The above copyright notice and this permission notice
+shall be included in all copies or substantial portions
+of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF
+ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED
+TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT
+SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR
+IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+DEALINGS IN THE SOFTWARE.
+```
+
 ## mcp (1.28.1)
 
 ### Licenses
@@ -11622,6 +11656,36 @@ Apache License
    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
    See the License for the specific language governing permissions and
    limitations under the License.
+```
+
+## ziglang (0.16.0)
+
+### Licenses
+License: `MIT`
+
+  - `licenses/ziglang/LICENSE`:
+```
+The MIT License (Expat)
+
+Copyright (c) Zig contributors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
 ```
 
 ## zipp (4.1.0)

--- a/justfile
+++ b/justfile
@@ -9,6 +9,8 @@ export REPO_ROOT := justfile_directory()
 no_uv := "false"
 # When set, versioning and packaging targets use this exact release version.
 ref_name := ""
+# Linux wheel artifacts target this minimum glibc version for compatibility.
+linux_glibc_version := "2.17"
 
 python_projects := ". python adapters/common adapters/claude adapters/codex adapters/deepagents adapters/hermes"
 
@@ -20,6 +22,62 @@ uv_python_executable() {
         cd "$REPO_ROOT"
         uv python find
     )
+}
+
+activate_project_venv() {
+    local venv_bin=""
+    if [[ -x "$REPO_ROOT/.venv/bin/python" ]]; then
+        venv_bin="$REPO_ROOT/.venv/bin"
+    elif [[ -x "$REPO_ROOT/.venv/Scripts/python.exe" ]]; then
+        venv_bin="$REPO_ROOT/.venv/Scripts"
+    else
+        echo "ERROR: expected project virtualenv Python executable under .venv" >&2
+        exit 1
+    fi
+    export PATH="$venv_bin:$PATH"
+}
+
+prepend_ziglang_to_path() {
+    local python_executable="$1"
+    local zig_dir=""
+    zig_dir="$("$python_executable" - <<'PY'
+from pathlib import Path
+import importlib.util
+
+spec = importlib.util.find_spec("ziglang")
+if spec is None or spec.origin is None:
+    raise SystemExit("ERROR: expected ziglang from the locked uv environment")
+
+zig = Path(spec.origin).resolve().parent / "zig"
+if not zig.exists():
+    raise SystemExit(f"ERROR: expected zig binary at {zig}")
+
+print(zig.parent)
+PY
+    )"
+    export PATH="$zig_dir:$PATH"
+}
+
+linux_manylinux_compatibility() {
+    local glibc_version="${linux_glibc_version:-2.17}"
+    printf 'manylinux_%s\n' "${glibc_version//./_}"
+}
+
+python_wheel_build_args() {
+    local os_name=""
+    os_name="$(uname -s)"
+    case "$os_name" in
+        Linux)
+            printf '%s\0' --compatibility "$(linux_manylinux_compatibility)" --zig
+            ;;
+        Darwin|CYGWIN*|MINGW*|MSYS*)
+            printf '%s\0' --compatibility pypi
+            ;;
+        *)
+            echo "ERROR: unsupported OS for wheels: $os_name" >&2
+            exit 1
+            ;;
+    esac
 }
 
 semver_to_pep440() {
@@ -351,7 +409,13 @@ test-all: test-rust test-python
 # Build wheels for every Python project into the repository dist directory.
 wheels:
     #!/usr/bin/env bash
-    set -euo pipefail
+    {{ bash_helpers }}
+    linux_glibc_version="{{ linux_glibc_version }}"
+    uv sync --inexact --only-group package
+    activate_project_venv
+    if [[ "$(uname -s)" == "Linux" ]]; then
+        prepend_ziglang_to_path "$(uv_python_executable)"
+    fi
     projects=({{ python_projects }})
     uv build --wheel --clear --out-dir dist .
     for project in "${projects[@]}"; do
@@ -363,11 +427,15 @@ wheels:
         uv build --wheel --out-dir dist "$project"
     done
     # uv build forces Maturin compatibility off, producing non-portable linux_* tags.
+    build_args=()
+    while IFS= read -r -d '' arg; do
+        build_args+=("$arg")
+    done < <(python_wheel_build_args)
     (
         cd python
-        uvx --from 'maturin>=1.9.3,<2.0' maturin build \
+        maturin build \
             --release \
             --locked \
-            --compatibility pypi \
+            "${build_args[@]}" \
             --out ../dist
     )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -114,6 +114,11 @@ docs = [
   "pyyaml>=6.0",
 ]
 
+package = [
+  "maturin[zig]>=1.9.3,<2.0; sys_platform == 'linux'",
+  "maturin>=1.9.3,<2.0; sys_platform != 'linux'",
+]
+
 test = [
     "fastapi~=0.138",
     "pytest>=8",

--- a/tests/e2e/test_claude.py
+++ b/tests/e2e/test_claude.py
@@ -157,6 +157,10 @@ async def test_fabric_session_launches_fresh_processes_and_resumes(tmp_path):
     assert not any(artifact.kind == "stderr" for artifact in second.artifacts.artifacts)
 
 
+@pytest.mark.skipif(
+    sys.platform == "darwin",
+    reason="mock Relay gateway cannot pass its loopback health check on macOS",
+)
 async def test_fabric_claude_relay_supervises_gateway_and_injects_plugin(tmp_path):
     mock_relay = tmp_path / "nemo-relay"
     relay_args_path = tmp_path / "relay-args.json"

--- a/uv.lock
+++ b/uv.lock
@@ -4,11 +4,14 @@ requires-python = ">=3.11"
 resolution-markers = [
     "python_full_version >= '3.14' and sys_platform == 'win32'",
     "python_full_version >= '3.14' and sys_platform == 'emscripten'",
-    "python_full_version >= '3.14' and sys_platform != 'emscripten' and sys_platform != 'win32'",
+    "python_full_version >= '3.14' and sys_platform == 'linux'",
+    "python_full_version >= '3.14' and sys_platform != 'emscripten' and sys_platform != 'linux' and sys_platform != 'win32'",
     "python_full_version >= '3.12' and python_full_version < '3.14' and sys_platform == 'win32'",
     "python_full_version >= '3.12' and python_full_version < '3.14' and sys_platform == 'emscripten'",
-    "python_full_version >= '3.12' and python_full_version < '3.14' and sys_platform != 'emscripten' and sys_platform != 'win32'",
-    "python_full_version < '3.12'",
+    "python_full_version >= '3.12' and python_full_version < '3.14' and sys_platform == 'linux'",
+    "python_full_version >= '3.12' and python_full_version < '3.14' and sys_platform != 'emscripten' and sys_platform != 'linux' and sys_platform != 'win32'",
+    "python_full_version < '3.12' and sys_platform == 'linux'",
+    "python_full_version < '3.12' and sys_platform != 'linux'",
 ]
 
 [[package]]
@@ -471,7 +474,7 @@ name = "concurrent-log-handler"
 version = "0.9.29"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "portalocker", marker = "(python_full_version < '3.12' and sys_platform != 'win32') or (python_full_version < '3.14' and sys_platform == 'win32')" },
+    { name = "portalocker", marker = "(python_full_version < '3.14' and sys_platform == 'win32') or (python_full_version < '3.12' and sys_platform != 'linux' and sys_platform != 'win32')" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/9c/2c/ba185acc438cff6b58cd8f8dec27e7f4fcabf6968a1facbb6d0cacbde7fe/concurrent_log_handler-0.9.29.tar.gz", hash = "sha256:bc37a76d3f384cbf4a98f693ebd770543edc0f4cd5c6ab6bc70e9e1d7d582265", size = 42114, upload-time = "2026-02-22T18:18:25.758Z" }
 wheels = [
@@ -1792,6 +1795,32 @@ wheels = [
 ]
 
 [[package]]
+name = "maturin"
+version = "1.14.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/e7/b3/addd877f871fb1860d46d3a4f206ecb10b946c85846805e6367631926fd3/maturin-1.14.1.tar.gz", hash = "sha256:9d6577a62cd08e0ceba7a0db06fb098e0c9b1b3429bad747a4f3a18215a1b3df", size = 369637, upload-time = "2026-06-19T05:19:49.774Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f4/f0/97c5a5bd9c71653a066c0976a484eaaae50b9369557838a4176b7b0bdaa5/maturin-1.14.1-py3-none-linux_armv6l.whl", hash = "sha256:522292398945442cdafa9daeb2271b2340fbde57027b818f923f88eab04174f8", size = 10207496, upload-time = "2026-06-19T05:19:09.321Z" },
+    { url = "https://files.pythonhosted.org/packages/fe/83/294bca639b0e052f1e2f65199b3db258780c7d4e31408b934c9c974a1379/maturin-1.14.1-py3-none-macosx_10_12_x86_64.macosx_11_0_arm64.macosx_10_12_universal2.whl", hash = "sha256:ffe5ad71f21d1e6603c4dd75f7fee34adf5ed5ebcebb692886549888ebb329ed", size = 19680113, upload-time = "2026-06-19T05:19:13.43Z" },
+    { url = "https://files.pythonhosted.org/packages/43/b6/79c881410a3b1c187f7eb3d407aecae646c6a4433d630d72200359015e83/maturin-1.14.1-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:f3306078070c1508fd715b9116070cbcaff5959024272a9f1e6f5cb29768b86c", size = 10169205, upload-time = "2026-06-19T05:19:16.615Z" },
+    { url = "https://files.pythonhosted.org/packages/93/9d/44b6f26dcb7f7a04c5501ac2dbb6ca1490150682baa525ca5860504f9eab/maturin-1.14.1-py3-none-manylinux_2_12_i686.manylinux2010_i686.musllinux_1_1_i686.whl", hash = "sha256:cd457cd88961156e26379e1155bd287cc0ec1c8b2f1582b0660fb31b87c8842d", size = 10188098, upload-time = "2026-06-19T05:19:19.736Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/bd/9c0d5d6983905ce2c9edaa073a7e89355a9cf7f396988e05d32f1c37785d/maturin-1.14.1-py3-none-manylinux_2_12_x86_64.manylinux2010_x86_64.musllinux_1_1_x86_64.whl", hash = "sha256:dfc54ae32e6fcb18302193ab9a30b0b25eefffba994ae13238974805533ef75e", size = 10627576, upload-time = "2026-06-19T05:19:22.713Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/33/b096412bd6a7cb399652b260666f901adf88a687181a6dbd6a3f89f0a94e/maturin-1.14.1-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.musllinux_1_1_aarch64.whl", hash = "sha256:a131d912b5267e640bc96d70f4914e10590aed64082ec9abacba7cea52004224", size = 10085181, upload-time = "2026-06-19T05:19:25.69Z" },
+    { url = "https://files.pythonhosted.org/packages/56/8d/08c3bf469c38a23c9e6c877e338193001eb604d010fedc08341974e38528/maturin-1.14.1-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.musllinux_1_1_armv7l.whl", hash = "sha256:be18fc568fb76884c0205456336892a75105ec398e6b667cd777c6268bd06d69", size = 10026363, upload-time = "2026-06-19T05:19:28.904Z" },
+    { url = "https://files.pythonhosted.org/packages/3a/a4/c4d1a92839f8745ab4aab988a7db884a79d6d710bd3b286fcf9316dece1a/maturin-1.14.1-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.musllinux_1_1_ppc64le.whl", hash = "sha256:994a0c8ba3ad8a92b3a9ee1b02645d200d610216b15cff5102b0fe65e8e08666", size = 13321347, upload-time = "2026-06-19T05:19:32.411Z" },
+    { url = "https://files.pythonhosted.org/packages/b3/fa/170f04624d03fd07d2a8b1b67de83a127af93aef9eaa425839553347297b/maturin-1.14.1-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:be80866363e605d137991b491a741a84cde9ae350183c4c85f49690ca9aaaa65", size = 10877609, upload-time = "2026-06-19T05:19:35.448Z" },
+    { url = "https://files.pythonhosted.org/packages/61/ad/1ae2e1d0ded282bf2c55ac13f0811d87deb425e200ae64a15785675dede9/maturin-1.14.1-py3-none-manylinux_2_31_riscv64.musllinux_1_1_riscv64.whl", hash = "sha256:5282dffd4b539d2be245f4e5b1a5ab6bc1033b58f4a4872f5833f9d43c954aa4", size = 10417316, upload-time = "2026-06-19T05:19:38.28Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/27/bf677183920718da49cd7982d6a3ffc440aad8919329f571d189f81b7bdf/maturin-1.14.1-py3-none-win32.whl", hash = "sha256:1a04de0a20188f95c721b5702eed18140bdcccb28c386797093eca3f62f4d4e0", size = 8931293, upload-time = "2026-06-19T05:19:41.183Z" },
+    { url = "https://files.pythonhosted.org/packages/63/4b/585adeb9167b08d3cdff0032a938b0e72655c92003df4f52c3f696a1bcc2/maturin-1.14.1-py3-none-win_amd64.whl", hash = "sha256:3c9f94640ecc4895e94abaf834a0684430032c865b2748a36c12461fd9252fdd", size = 10314067, upload-time = "2026-06-19T05:19:44.389Z" },
+    { url = "https://files.pythonhosted.org/packages/51/d4/dac8c0720ae246be1700afb6fbdbbea20fe35b13f6570b2f70faa005df77/maturin-1.14.1-py3-none-win_arm64.whl", hash = "sha256:15cea8fcb3ba47dd636f50092bb34baea8b04ac777392f23e6bf8a9a61efb894", size = 9718943, upload-time = "2026-06-19T05:19:47.49Z" },
+]
+
+[package.optional-dependencies]
+zig = [
+    { name = "ziglang", marker = "sys_platform == 'linux'" },
+]
+
+[[package]]
 name = "mcp"
 version = "1.28.1"
 source = { registry = "https://pypi.org/simple" }
@@ -2011,6 +2040,10 @@ docs = [
     { name = "lazydocs" },
     { name = "pyyaml" },
 ]
+package = [
+    { name = "maturin" },
+    { name = "maturin", extra = ["zig"], marker = "sys_platform == 'linux'" },
+]
 test = [
     { name = "fastapi" },
     { name = "pytest" },
@@ -2061,6 +2094,10 @@ docs = [
     { name = "beautifulsoup4", specifier = ">=4.12" },
     { name = "lazydocs", specifier = ">=0.4" },
     { name = "pyyaml", specifier = ">=6.0" },
+]
+package = [
+    { name = "maturin", marker = "sys_platform != 'linux'", specifier = ">=1.9.3,<2.0" },
+    { name = "maturin", extras = ["zig"], marker = "sys_platform == 'linux'", specifier = ">=1.9.3,<2.0" },
 ]
 test = [
     { name = "fastapi", specifier = "~=0.138" },
@@ -4495,6 +4532,20 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/8f/be/f9f7594e23b5b93affff0318e4593c1920331bcaefda326cabcad94296a1/yarl-1.24.2-cp314-cp314t-win_amd64.whl", hash = "sha256:a7624b1ca46ca5d7b864ef0d2f8efe3091454085ee1855b4e992314529972215", size = 102980, upload-time = "2026-05-19T21:30:59.735Z" },
     { url = "https://files.pythonhosted.org/packages/65/a4/ba80dccd3593ff1f01051a818694d07b58cb8232677ee9a22a5a1f93a9fc/yarl-1.24.2-cp314-cp314t-win_arm64.whl", hash = "sha256:e434a45ce2e7a947f951fc5a8944c8cc080b7e59f9c50ae80fd39107cf88126d", size = 91219, upload-time = "2026-05-19T21:31:01.934Z" },
     { url = "https://files.pythonhosted.org/packages/fd/4d/4b880086bd0d3e034d25647be1d830afc3e3f610e98c4ab3490af6b1b6d5/yarl-1.24.2-py3-none-any.whl", hash = "sha256:2783d9226db8797636cd6896e4de81feed252d1db72265686c9558d97a4d94b9", size = 53576, upload-time = "2026-05-19T21:31:03.909Z" },
+]
+
+[[package]]
+name = "ziglang"
+version = "0.16.0"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/cd/aa/7966d158d768fb0e40bf5fef6e7ffe230dfee502382782ec39be1331ee4a/ziglang-0.16.0-py3-none-manylinux_2_12_i686.manylinux2010_i686.musllinux_1_1_i686.whl", hash = "sha256:8b83661247430aa335b3cbc29569084900412dde5633b02c80a6d2ff734de3d2", size = 101810276, upload-time = "2026-04-15T03:55:17.843Z" },
+    { url = "https://files.pythonhosted.org/packages/3e/ed/7b79023aa27ceb5d461ecf761181e7c33c57bbc1a6256a39535d1c7083d2/ziglang-0.16.0-py3-none-manylinux_2_12_x86_64.manylinux2010_x86_64.musllinux_1_1_x86_64.whl", hash = "sha256:9fcda73f62b851dd72a54b710ad40a209896db14cfb13649e62191243556342b", size = 97941847, upload-time = "2026-04-15T03:55:23.246Z" },
+    { url = "https://files.pythonhosted.org/packages/7e/ed/d6663a5e52c504944d578b9e0bfcb7857f292803bcd09ebe0d10fe2b293d/ziglang-0.16.0-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.musllinux_1_1_aarch64.whl", hash = "sha256:e27d409812b11e0fb89ed0200cf2e55b6464d43f9461553104e4a4f9a94a1fd5", size = 95008112, upload-time = "2026-04-15T03:55:32.025Z" },
+    { url = "https://files.pythonhosted.org/packages/07/e4/beae76926e3070978d06fa156b243642d5f75ffd784f7cd64e783520e456/ziglang-0.16.0-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.musllinux_1_1_armv7l.whl", hash = "sha256:7249779f0f916cfd2d1a9d54eb7600f3901384dc8dcbe1eea226bd32a8237fb5", size = 95860236, upload-time = "2026-04-15T03:55:37.069Z" },
+    { url = "https://files.pythonhosted.org/packages/b6/fc/5cb1555281d2a998355ee7081f05f45d2f6a2789ca0fcb02015cfcb4b900/ziglang-0.16.0-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.musllinux_1_1_ppc64le.whl", hash = "sha256:0fd671c599f6961638cc302cf1f9461486696385311d4c0276171dcf7d2b67f5", size = 104100995, upload-time = "2026-04-15T03:55:42.594Z" },
+    { url = "https://files.pythonhosted.org/packages/4a/34/e0138d89ec47da986ac08009ae8802af052c1e335163d983c074d9eaa1c3/ziglang-0.16.0-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.musllinux_1_1_s390x.whl", hash = "sha256:df0e6599e41d087c912b0d3d7cedef6c9cb1f0032465c8fc820e9986772d11e4", size = 103517876, upload-time = "2026-04-15T03:55:48.695Z" },
+    { url = "https://files.pythonhosted.org/packages/fe/29/d281591fa0be47aefcb23ac379cdbff5b34a1fdaafa139a5f8703ca9559c/ziglang-0.16.0-py3-none-manylinux_2_31_riscv64.musllinux_1_1_riscv64.whl", hash = "sha256:d4bd8197344fffe276e1d6446e4ef7bc38637d821b4685fe96a936503d4b0619", size = 98388042, upload-time = "2026-04-15T03:55:54.114Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
#### Overview

* Set glibc v2.17 as the build target for Linux compatibility
* Add macOS wheel builds
* Skip `tests/e2e/test_claude.py:test_fabric_claude_relay_supervises_gateway_and_injects_plugin` on macOS (to be fixed later FABRIC-118)

#### Where should the reviewer start?

* `.github/workflows/ci_python.yml`

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- Closes FABRIC-115 FABRIC-112

- [x] I confirm this contribution is my own work, or I have the right to submit it under this project's license.
- [x] I searched existing issues and open pull requests, and this does not duplicate existing work.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Improved wheel build automation with configurable Linux glibc compatibility tagging, platform-specific build tooling, and dynamically generated wheel build arguments.
  * Added a dedicated build dependency group for installing the appropriate wheel-building tools by platform.
* **CI / Build**
  * Expanded wheel/test matrix coverage to include macOS arm64.
  * Scoped wheel build cache keys by runner OS and architecture to avoid cross-runner artifact sharing.
* **Documentation**
  * Regenerated third-party attributions to include new wheel-building tool licenses.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->