### PR TITLE
ci: Update release pipeline to match both the nightly CI and release tags

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -20,6 +20,7 @@ variables:
   NEMO_FABRIC_CI_UV_VERSION: "0.9.28"
   NEMO_FABRIC_CI_GITHUB_REPOSITORY: "NVIDIA/nemo-fabric"
   NEMO_FABRIC_CI_NIGHTLY_WORKFLOW_FILE: "nightly-alpha-tag.yml"
+  NEMO_FABRIC_CI_RELEASE_WORKFLOW_FILE: "ci_python.yml"
   NEMO_FABRIC_CI_GITHUB_RUN_WAIT_SECONDS: "7200"
   NEMO_FABRIC_CI_GITHUB_RUN_POLL_SECONDS: "60"
 
@@ -71,8 +72,10 @@ collect:github-artifacts:
 
       if printf '%s\n' "$tag" | grep -Eq '^[0-9]+\.[0-9]+\.[0-9]+-alpha\.[0-9]{8}$'; then
         trigger_type="nightly"
+        matched_workflow="$NEMO_FABRIC_CI_NIGHTLY_WORKFLOW_FILE"
       else
         trigger_type="release"
+        matched_workflow="$NEMO_FABRIC_CI_RELEASE_WORKFLOW_FILE"
       fi
 
       echo "Waiting for ${trigger_type} GitHub Actions run for tag ${tag}"
@@ -82,7 +85,7 @@ collect:github-artifacts:
           run_id="$(
             gh run list \
               --repo "$NEMO_FABRIC_CI_GITHUB_REPOSITORY" \
-              --workflow "$NEMO_FABRIC_CI_NIGHTLY_WORKFLOW_FILE" \
+              --workflow "$matched_workflow" \
               --commit "$tag_sha" \
               --limit 1 \
               --json databaseId \
@@ -92,6 +95,7 @@ collect:github-artifacts:
           run_id="$(
             gh run list \
               --repo "$NEMO_FABRIC_CI_GITHUB_REPOSITORY" \
+              --workflow "$matched_workflow" \
               --branch "$tag" \
               --commit "$tag_sha" \
               --event push \
@@ -145,6 +149,7 @@ collect:github-artifacts:
         printf '{\n'
         printf '  "run_id": "%s",\n' "$run_id"
         printf '  "run_url": "%s",\n' "$run_html_url"
+        printf '  "workflow": "%s",\n' "$matched_workflow"
         printf '  "trigger_type": "%s",\n' "$trigger_type"
         printf '  "tag": "%s"\n' "$tag"
         printf '}\n'

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -19,7 +19,7 @@ variables:
   NEMO_FABRIC_CI_RUST_VERSION: "1.93.0"
   NEMO_FABRIC_CI_UV_VERSION: "0.9.28"
   NEMO_FABRIC_CI_GITHUB_REPOSITORY: "NVIDIA/nemo-fabric"
-  NEMO_FABRIC_CI_GITHUB_WORKFLOW_FILE: "nightly-alpha-tag.yml"
+  NEMO_FABRIC_CI_NIGHTLY_WORKFLOW_FILE: "nightly-alpha-tag.yml"
   NEMO_FABRIC_CI_GITHUB_RUN_WAIT_SECONDS: "7200"
   NEMO_FABRIC_CI_GITHUB_RUN_POLL_SECONDS: "60"
 
@@ -69,23 +69,42 @@ collect:github-artifacts:
           --jq '.sha'
       )"
 
-      echo "Waiting for ${NEMO_FABRIC_CI_GITHUB_WORKFLOW_FILE} run for tag ${tag}"
+      if printf '%s\n' "$tag" | grep -Eq '^[0-9]+\.[0-9]+\.[0-9]+-alpha\.[0-9]{8}$'; then
+        trigger_type="nightly"
+      else
+        trigger_type="release"
+      fi
+
+      echo "Waiting for ${trigger_type} GitHub Actions run for tag ${tag}"
       run_id=""
       while [ -z "$run_id" ]; do
-        run_id="$(
-          gh run list \
-            --repo "$NEMO_FABRIC_CI_GITHUB_REPOSITORY" \
-            --workflow "$NEMO_FABRIC_CI_GITHUB_WORKFLOW_FILE" \
-            --commit "$tag_sha" \
-            --limit 1 \
-            --json databaseId \
-            --jq '.[0].databaseId // ""'
-        )"
+        if [ "$trigger_type" = "nightly" ]; then
+          run_id="$(
+            gh run list \
+              --repo "$NEMO_FABRIC_CI_GITHUB_REPOSITORY" \
+              --workflow "$NEMO_FABRIC_CI_NIGHTLY_WORKFLOW_FILE" \
+              --commit "$tag_sha" \
+              --limit 1 \
+              --json databaseId \
+              --jq '.[0].databaseId // ""'
+          )"
+        else
+          run_id="$(
+            gh run list \
+              --repo "$NEMO_FABRIC_CI_GITHUB_REPOSITORY" \
+              --branch "$tag" \
+              --commit "$tag_sha" \
+              --event push \
+              --limit 1 \
+              --json databaseId \
+              --jq '.[0].databaseId // ""'
+          )"
+        fi
         if [ -n "$run_id" ]; then
           break
         fi
         if [ "$(date -u +%s)" -ge "$deadline" ]; then
-          echo "Error: no GitHub Actions run found for tag ${tag} within ${NEMO_FABRIC_CI_GITHUB_RUN_WAIT_SECONDS} seconds." >&2
+          echo "Error: no ${trigger_type} GitHub Actions run found for tag ${tag} within ${NEMO_FABRIC_CI_GITHUB_RUN_WAIT_SECONDS} seconds." >&2
           exit 1
         fi
         sleep "$NEMO_FABRIC_CI_GITHUB_RUN_POLL_SECONDS"
@@ -126,7 +145,7 @@ collect:github-artifacts:
         printf '{\n'
         printf '  "run_id": "%s",\n' "$run_id"
         printf '  "run_url": "%s",\n' "$run_html_url"
-        printf '  "workflow": "%s",\n' "$NEMO_FABRIC_CI_GITHUB_WORKFLOW_FILE"
+        printf '  "trigger_type": "%s",\n' "$trigger_type"
         printf '  "tag": "%s"\n' "$tag"
         printf '}\n'
       } > collected/github-run.json


### PR DESCRIPTION

#### Where should the reviewer start?

* `.gitlab-ci.yml`

- [x] I confirm this contribution is my own work, or I have the right to submit it under this project's license.
- [x] I searched existing issues and open pull requests, and this does not duplicate existing work.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved artifact collection by selecting the correct GitHub Actions workflow for nightly vs release tags.
  * Added support for alpha-version tag patterns to determine the appropriate trigger type.
  * Updated collected run metadata to include `trigger_type` alongside the existing `workflow` details.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->