### PR TITLE
docs: broaden product naming review

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -74,9 +74,9 @@ reviews:
     - path: "{docs/**,README.md,AGENTS.md}"
       instructions: |
         Review documentation for technical accuracy against the current API, command correctness, and consistency with generated schemas.
-    - path: "{*.md,**/*.md,**/*.mdx,**/*.ipynb}"
+    - path: "{**/*,**/.*,.*/**/*,.*/**/.*}"
       instructions: |
-        Enforce the product name in user-facing prose: use "NVIDIA NeMo Fabric" on first use and "NeMo Fabric" thereafter. Flag standalone capitalized "Fabric" when it refers to the product. Do not flag the lowercase `fabric` CLI command, package/import/crate names, code identifiers, API symbols, configuration keys, file paths, or unrelated generic uses of the word.
+        Enforce the product name in user-facing prose: use "NVIDIA NeMo Fabric" on first use and "NeMo Fabric" thereafter. Flag standalone capitalized "Fabric" when it refers to the product. Do not flag package/import/crate/command names, code identifiers, API symbols, configuration keys, file paths, or unrelated generic uses of the word.
     - path: "**/SKILL.md"
       instructions: |
         Do not flag SKILL.md files for missing SPDX headers. Skill entrypoints intentionally start with YAML frontmatter instead.


### PR DESCRIPTION
#### Overview

Extends NVIDIA NeMo Fabric naming review to every currently tracked path CodeRabbit can review, including dot-prefixed paths. No runtime changes.

#### Details

- Broadens the path glob and removes the stale `fabric` CLI exception; the executable is `nemo-fabric`.

#### Validation

- `uv run pre-commit run --files .coderabbit.yaml`
- `uvx check-jsonschema --schemafile https://coderabbit.ai/integrations/schema.v2.json .coderabbit.yaml`
- Minimatch audit: 382/382 tracked paths
- YAML parse and `git diff --check`

#### Where should the reviewer start?

Review `.coderabbit.yaml`.

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- Relates to #105

- [x] I confirm this contribution is my own work, or I have the right to submit it under this project's license.
- [x] I searched existing issues and open pull requests, and this does not duplicate existing work.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated product naming guidance enforcement to consistently use “NVIDIA NeMo Fabric,” “NeMo Fabric,” and capitalize standalone “Fabric.”
* **Chores**
  * Broadened automated naming review coverage to apply across the entire repository and dotfile-like patterns (not just Markdown), while preserving existing exclusions for code identifiers, symbols, configuration keys, file paths, and unrelated generic uses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->