### PR TITLE
fix: align Deep Agents with Relay 0.6

### DIFF
--- a/ATTRIBUTIONS-Python.md
+++ b/ATTRIBUTIONS-Python.md
@@ -1801,7 +1801,7 @@ USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH
 DAMAGE.
 ```
 
-## deepagents (0.5.9)
+## deepagents (0.6.12)
 
 ### Licenses
 License: `MIT`
@@ -4760,7 +4760,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 ```
 
-## langchain (1.3.12)
+## langchain (1.3.14)
 
 ### Licenses
 License: `MIT`
@@ -5460,7 +5460,7 @@ Copyright 2016 Andrew Svetlov and aio-libs contributors
    limitations under the License.
 ```
 
-## nemo-relay (0.5.0)
+## nemo-relay (0.6.0)
 
 ### Licenses
 License: `Apache-2.0`

--- a/adapters/common/src/nemo_fabric_adapters/common/utils.py
+++ b/adapters/common/src/nemo_fabric_adapters/common/utils.py
@@ -17,6 +17,8 @@ if TYPE_CHECKING:
     from nemo_relay import plugin
     from nemo_relay.observability import AtifConfig
     from nemo_relay.observability import AtofConfig
+    from nemo_relay.observability import AtofFileSinkConfig
+    from nemo_relay.observability import AtofStreamSinkConfig
     from nemo_relay.observability import HttpStorageConfig
     from nemo_relay.observability import OtlpConfig
     from nemo_relay.observability import S3StorageConfig
@@ -283,7 +285,10 @@ def relay_api_plugin_config(plugin_config: dict[str, Any]) -> plugin.PluginConfi
             components.append(
                 ComponentSpec(
                     ObservabilityConfig(
-                        version=int(config.get("version", 1)),
+                        # Relay 0.6 only accepts the v2 observability API model.
+                        # Fabric still accepts its existing flat/v1 configuration
+                        # below and translates it at this API boundary.
+                        version=2,
                         atof=_relay_api_atof_config(config.get("atof")),
                         atif=_relay_api_atif_config(
                             config.get("atif"),
@@ -330,27 +335,56 @@ def _relay_api_atof_config(value: Any) -> AtofConfig | None:
     if not isinstance(value, dict):
         return None
     from nemo_relay.observability import AtofConfig
-    from nemo_relay.observability import AtofEndpointConfig
+    from nemo_relay.observability import AtofFileSinkConfig
+    from nemo_relay.observability import AtofStreamSinkConfig
 
-    endpoint_configs = value.get("endpoints")
-    endpoints = None
-    if isinstance(endpoint_configs, list):
-        endpoints = [
-            AtofEndpointConfig(
-                url=str(endpoint.get("url", "")),
-                transport=endpoint.get("transport", "http_post"),
-                headers=endpoint.get("headers", {}),
-                timeout_millis=int(endpoint.get("timeout_millis", 3000)),
-            )
-            for endpoint in endpoint_configs
-            if isinstance(endpoint, dict)
-        ]
+    sinks: list[AtofFileSinkConfig | AtofStreamSinkConfig] = []
+    has_explicit_file_sink = False
+    for sink in value.get("sinks") or []:
+        if not isinstance(sink, dict):
+            continue
+        if sink.get("type") == "file":
+            has_explicit_file_sink = True
+            sinks.append(_relay_api_atof_file_sink_config(sink))
+        elif sink.get("type") == "stream":
+            sinks.append(_relay_api_atof_stream_sink_config(sink))
+
+    if not has_explicit_file_sink and any(
+        key in value for key in ("output_directory", "filename", "mode")
+    ):
+        sinks.append(_relay_api_atof_file_sink_config(value))
+
+    for endpoint in value.get("endpoints") or []:
+        if isinstance(endpoint, dict):
+            sinks.append(_relay_api_atof_stream_sink_config(endpoint))
+
     return AtofConfig(
         enabled=bool(value.get("enabled", False)),
+        sinks=sinks,
+    )
+
+
+def _relay_api_atof_file_sink_config(value: dict[str, Any]) -> AtofFileSinkConfig:
+    from nemo_relay.observability import AtofFileSinkConfig
+
+    return AtofFileSinkConfig(
         output_directory=value.get("output_directory"),
         filename=value.get("filename"),
         mode=value.get("mode", "append"),
-        endpoints=endpoints,
+    )
+
+
+def _relay_api_atof_stream_sink_config(value: dict[str, Any]) -> AtofStreamSinkConfig:
+    from nemo_relay.observability import AtofStreamSinkConfig
+
+    return AtofStreamSinkConfig(
+        url=str(value.get("url", "")),
+        transport=value.get("transport", "http_post"),
+        headers=value.get("headers", {}),
+        header_env=value.get("header_env", {}),
+        timeout_millis=int(value.get("timeout_millis", 3000)),
+        field_name_policy=value.get("field_name_policy", "preserve"),
+        name=value.get("name"),
     )
 
 

--- a/adapters/deepagents/pyproject.toml
+++ b/adapters/deepagents/pyproject.toml
@@ -26,7 +26,7 @@ readme = "README.md"
 requires-python = ">=3.11"
 dependencies = [
   "nemo-fabric-adapters-common == 0.1.0",
-  "deepagents>=0.5.3,<0.6.0",
+  "deepagents>=0.6.12,<0.7.0",
   "langchain>=1.3,<2.0",
   "langchain-mcp-adapters>=0.1,<0.3.0",
   "langchain-openai>=0.3",
@@ -42,11 +42,8 @@ dependencies = [
 # when telemetry.providers.relay is enabled, so the core install stays
 # Relay-neutral at import time.
 [project.optional-dependencies]
-# Allow both the current 0.5 line and the upcoming 0.6 release (which ships the
-# same SDK-native Deep Agents API). Resolves to 0.5.x today and adopts 0.6
-# automatically once it is published.
 relay = [
-  "nemo-relay[deepagents]>=0.5.0,<0.7",
+  "nemo-relay[deepagents]>=0.6.0,<0.7",
 ]
 
 [project.urls]

--- a/adapters/deepagents/uv.lock
+++ b/adapters/deepagents/uv.lock
@@ -336,7 +336,7 @@ wheels = [
 
 [[package]]
 name = "deepagents"
-version = "0.5.9"
+version = "0.6.12"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "langchain" },
@@ -346,9 +346,9 @@ dependencies = [
     { name = "langsmith" },
     { name = "wcmatch" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/06/74/776e606f0508a4d7d4c9d061c797dcde43eed2452fea546ae29047aeaaa6/deepagents-0.5.9.tar.gz", hash = "sha256:74fe0f998641b20bda8adac662a018051c623a3c8e5ed4b6ff9ad53fc493a783", size = 165651, upload-time = "2026-05-10T22:31:17.095Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/e0/db/a6acdc72a9e90c3f07ed10de35c951734a02d4facb693bb59684ad368801/deepagents-0.6.12.tar.gz", hash = "sha256:1f281c0bc5a63132f62e2ee345c1dc593b23188da6e23016401f6879fbe54b5f", size = 211364, upload-time = "2026-06-25T17:26:52.775Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/e8/f6/9698f98da72dfa8dc8e1d0f0542f2407a40a50cfdccf522fdb5cb43e39e2/deepagents-0.5.9-py3-none-any.whl", hash = "sha256:ce24a41763b2793bd21217411e9fb9f187a9128da6789f5a81654da1de9e4c7c", size = 188118, upload-time = "2026-05-10T22:31:15.974Z" },
+    { url = "https://files.pythonhosted.org/packages/98/49/af7219b3c13520fee047bb807cfaefba17f8e4584c551d946773589a4f08/deepagents-0.6.12-py3-none-any.whl", hash = "sha256:28b8fa0119ca0a689e3e18e288c4634e4046062acfc87a1cb34289d3af3a1c88", size = 236120, upload-time = "2026-06-25T17:26:51.736Z" },
 ]
 
 [[package]]
@@ -608,16 +608,16 @@ wheels = [
 
 [[package]]
 name = "langchain"
-version = "1.3.11"
+version = "1.3.14"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "langchain-core" },
     { name = "langgraph" },
     { name = "pydantic" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/b9/a2/91a7197c604a3ce1b774b3c10dd114c3c745c6186a304fc2573b3f94d400/langchain-1.3.11.tar.gz", hash = "sha256:f3cf9cd4d2329b1a03eb8fd92b9d73e4e58a4d52570d67725fc77fbe0f104b32", size = 633374, upload-time = "2026-06-22T23:00:33.44Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/29/68/a6dbad9c22df4087a0f9e79ddd46226c442b30128bfeee538d5889492a73/langchain-1.3.14.tar.gz", hash = "sha256:1b6696c72ba3bbbce54d745e0180742c9f6ece8bbc59ed5a46c3e20b9a435929", size = 645181, upload-time = "2026-07-16T13:28:18.29Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/df/a4/3a181967294f8876362cc4ba36840d50b8286fa23bb3f5e602b69eb3cb1e/langchain-1.3.11-py3-none-any.whl", hash = "sha256:7ae011f95a09b22feea1e8ae4e43f0b6164aebf4c61b8ad845b45f72ff3a90a2", size = 133639, upload-time = "2026-06-22T23:00:31.619Z" },
+    { url = "https://files.pythonhosted.org/packages/a9/ec/0f942e78a621f8e3162ff1ed24284f469aaf51fb4607ee5831c626f2b2bc/langchain-1.3.14-py3-none-any.whl", hash = "sha256:4d10dbe91005952cddd56d0dc77aa108964da6bae90ab20063653957e901f782", size = 139560, upload-time = "2026-07-16T13:28:16.498Z" },
 ]
 
 [[package]]
@@ -711,7 +711,7 @@ wheels = [
 
 [[package]]
 name = "langgraph"
-version = "1.2.8"
+version = "1.2.9"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "langchain-core" },
@@ -721,9 +721,9 @@ dependencies = [
     { name = "pydantic" },
     { name = "xxhash" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/b6/ad/583fda4c69501390b989770a465ccd0bdab1c1612eba582c012002ddf9b6/langgraph-1.2.8.tar.gz", hash = "sha256:f79d3575f45b404899358976e4fac0294eb75f8df1bfe8cd11286be7539c4548", size = 722464, upload-time = "2026-07-06T20:40:19.487Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/41/4b/0d1130e26b41a99dcc88353bbe7162a1f255c4db746bd94024268e6af27b/langgraph-1.2.9.tar.gz", hash = "sha256:385f87bc1802c35af7e0aa479278ecba8582d103515eb48256cb2ddcd42d0bd4", size = 722869, upload-time = "2026-07-10T01:30:14.985Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/36/49/b958a9963606807e5a20cc75fced14aa77c5cbcc470d5bf8ae13277cd298/langgraph-1.2.8-py3-none-any.whl", hash = "sha256:aa8de1d4df44162353d117589ae0bf6930ca009b62d2d6e26cc32580794c5be6", size = 246983, upload-time = "2026-07-06T20:40:18.242Z" },
+    { url = "https://files.pythonhosted.org/packages/41/16/0b8dc48823f1326f3e0c8012a3c07a40da6f194299e2ec080df236287baf/langgraph-1.2.9-py3-none-any.whl", hash = "sha256:c2d98ad94333937922ba04148641c1da2bfe45b5b8e55d7b6dcb0bb2df809e76", size = 247473, upload-time = "2026-07-10T01:30:13.733Z" },
 ]
 
 [[package]]
@@ -858,27 +858,27 @@ relay = [
 
 [package.metadata]
 requires-dist = [
-    { name = "deepagents", specifier = ">=0.5.3,<0.6.0" },
+    { name = "deepagents", specifier = ">=0.6.12,<0.7.0" },
     { name = "langchain", specifier = ">=1.3,<2.0" },
     { name = "langchain-mcp-adapters", specifier = ">=0.1,<0.3.0" },
     { name = "langchain-openai", specifier = ">=0.3" },
     { name = "langgraph", specifier = ">=1.2,<2.0" },
     { name = "langgraph-checkpoint-sqlite", specifier = ">=3.0,<4.0" },
     { name = "nemo-fabric-adapters-common", editable = "../common" },
-    { name = "nemo-relay", extras = ["deepagents"], marker = "extra == 'relay'", specifier = ">=0.5.0,<0.7" },
+    { name = "nemo-relay", extras = ["deepagents"], marker = "extra == 'relay'", specifier = ">=0.6.0,<0.7" },
 ]
 provides-extras = ["relay"]
 
 [[package]]
 name = "nemo-relay"
-version = "0.5.0"
+version = "0.6.0"
 source = { registry = "https://pypi.org/simple" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/aa/fc/6892859ffbfb60f8cc09a4181c8d407b574d49490e35cd563e7f0a61bf54/nemo_relay-0.5.0-cp311-abi3-macosx_11_0_arm64.whl", hash = "sha256:203409e0f392fc4f40f52277347ed75ba9969b2af28ddb3b6ae53f789185a0ed", size = 7769721, upload-time = "2026-07-08T18:43:57.745Z" },
-    { url = "https://files.pythonhosted.org/packages/dd/13/25c4fcf6fb979af07c9562238819183588a910c2ae09767603500d6948c2/nemo_relay-0.5.0-cp311-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:de61ad0644c5e8c300de814f6884c5de7ae51db14694f5057f938b4da54bfaaf", size = 7037083, upload-time = "2026-07-08T18:44:00.135Z" },
-    { url = "https://files.pythonhosted.org/packages/49/97/bd4c77e975d50f7d09f8bfcb74d7e704e05a8b2205f555bf557f84edc5fe/nemo_relay-0.5.0-cp311-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:cb323569f104506f4f1a0e2104b22d74c9a0bbf3280ec4d58ad3d768de76fb15", size = 7430817, upload-time = "2026-07-08T18:44:02.165Z" },
-    { url = "https://files.pythonhosted.org/packages/da/8b/5681f3430e6d25bf7419dbe576da14599e1cfadc083edb74e691a0c3a980/nemo_relay-0.5.0-cp311-abi3-win_amd64.whl", hash = "sha256:da1bd1e1dec79b7bda3984dd8c59b32ba97abf96c37e85cd1f38d208a29f42b9", size = 7359048, upload-time = "2026-07-08T18:44:04.169Z" },
-    { url = "https://files.pythonhosted.org/packages/4e/f2/65c3ef0435e671c829063d4872897f9054f369f0aeacab12c5aefe486705/nemo_relay-0.5.0-cp311-abi3-win_arm64.whl", hash = "sha256:87462585f17b40ce82c54347acef5ace96ee11de3015f234e0b902f23b3793fb", size = 6934235, upload-time = "2026-07-08T18:44:06.078Z" },
+    { url = "https://files.pythonhosted.org/packages/25/65/d320016505457cc30971f575e8dadffb923b7cfc780ab8bb25a4ce9d305c/nemo_relay-0.6.0-cp311-abi3-macosx_11_0_arm64.whl", hash = "sha256:ad5dae6febf6532d7b113abc2a404679c8feffc499df3034b93d9a078185d2bb", size = 9917779, upload-time = "2026-07-22T20:07:48.961Z" },
+    { url = "https://files.pythonhosted.org/packages/ae/c0/f33250e71c4206da1b339072893f9a1e39295fe1aceb9a2fef4b8620a0f2/nemo_relay-0.6.0-cp311-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:c0cd9570f64c6956fe3bfb82af1cdb3ee70cb50b51098cdb0de831c3f9b4e904", size = 8888375, upload-time = "2026-07-22T20:07:51.049Z" },
+    { url = "https://files.pythonhosted.org/packages/a3/f4/d1dfaed022da0f6f14765a122867f976a69cc520fe1faaf99757f5719d1f/nemo_relay-0.6.0-cp311-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:849daa9e45158ac581e54506e0fcc7a24f557d1ed06dbdc074f5de7a00393cbc", size = 9336372, upload-time = "2026-07-22T20:07:53.224Z" },
+    { url = "https://files.pythonhosted.org/packages/3a/b0/908d77f75b9054e1e403da78f7d9430249a45939070d4298abbb41a04b5b/nemo_relay-0.6.0-cp311-abi3-win_amd64.whl", hash = "sha256:bfbbedfd130fa95c9b8c04643c30910df850e0ed3500beeab82b00ca2d94e7ea", size = 9613425, upload-time = "2026-07-22T20:07:55.175Z" },
+    { url = "https://files.pythonhosted.org/packages/cd/71/c438b9d746303ff7f270d99f13b250bf947cdac3e52de2a83fd132cbca0b/nemo_relay-0.6.0-cp311-abi3-win_arm64.whl", hash = "sha256:82fe132943399d89e6ec34dc28df0be7bbe41b84f6698c545928b8816b6010f6", size = 9034810, upload-time = "2026-07-22T20:07:57.467Z" },
 ]
 
 [package.optional-dependencies]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -64,9 +64,7 @@ hermes-agent = [
 ]
 
 relay = [
-  # Allow the current 0.5 line and the upcoming 0.6 release; resolves to 0.5.x
-  # today and adopts 0.6 automatically once it is published.
-  "nemo-relay>=0.5.0,<0.7",
+  "nemo-relay>=0.6.0,<0.7",
   "tomli-w~=1.2", # Needed by adapters to write relay config files
 ]
 

--- a/tests/adapters/test_adapaters_common_utils.py
+++ b/tests/adapters/test_adapaters_common_utils.py
@@ -2,6 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import builtins
+import dataclasses
 import json
 import os
 import sys
@@ -374,6 +375,64 @@ def test_collect_relay_artifacts(tmp_path: Path):
         {"kind": "atof", "path": str(atof_file)},
         {"kind": "atif", "path": str(atif_file)},
     ]
+
+
+def test_relay_api_plugin_config_translates_flat_atof_to_relay_v06_sinks(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    monkeypatch.setenv("TOKEN", "test-token")
+    plugin_config = {
+        "version": 1,
+        "components": [
+            {
+                "kind": "observability",
+                "enabled": True,
+                "config": {
+                    "version": 1,
+                    "atof": {
+                        "enabled": True,
+                        "output_directory": "/tmp/atof",
+                        "filename": "events.jsonl",
+                        "mode": "overwrite",
+                        "endpoints": [
+                            {
+                                "url": "https://example.test/events",
+                                "headers": {"x-test": "value"},
+                                "header_env": {"authorization": "TOKEN"},
+                                "timeout_millis": 1000,
+                                "field_name_policy": "replace_dots",
+                                "name": "phoenix",
+                            }
+                        ],
+                    },
+                },
+            }
+        ],
+    }
+
+    rendered = common_utils.relay_api_plugin_config(plugin_config)
+    observability = rendered.components[0].config
+
+    assert observability.version == 2
+    assert dataclasses.asdict(observability.atof) == {
+        "enabled": True,
+        "sinks": [
+            {
+                "output_directory": "/tmp/atof",
+                "filename": "events.jsonl",
+                "mode": "overwrite",
+            },
+            {
+                "url": "https://example.test/events",
+                "transport": "http_post",
+                "headers": {"x-test": "value"},
+                "header_env": {"authorization": "TOKEN"},
+                "timeout_millis": 1000,
+                "field_name_policy": "replace_dots",
+                "name": "phoenix",
+            },
+        ],
+    }
 
 
 @pytest.mark.parametrize(

--- a/tests/adapters/test_adapaters_common_utils.py
+++ b/tests/adapters/test_adapaters_common_utils.py
@@ -377,10 +377,8 @@ def test_collect_relay_artifacts(tmp_path: Path):
     ]
 
 
-def test_relay_api_plugin_config_translates_flat_atof_to_relay_v06_sinks(
-    monkeypatch: pytest.MonkeyPatch,
-):
-    monkeypatch.setenv("TOKEN", "test-token")
+def test_relay_api_plugin_config_translates_flat_atof_to_relay_v06_sinks():
+    os.environ["TOKEN"] = "test-token"
     plugin_config = {
         "version": 1,
         "components": [

--- a/uv.lock
+++ b/uv.lock
@@ -723,7 +723,7 @@ wheels = [
 
 [[package]]
 name = "deepagents"
-version = "0.5.9"
+version = "0.6.12"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "langchain" },
@@ -733,9 +733,9 @@ dependencies = [
     { name = "langsmith" },
     { name = "wcmatch" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/06/74/776e606f0508a4d7d4c9d061c797dcde43eed2452fea546ae29047aeaaa6/deepagents-0.5.9.tar.gz", hash = "sha256:74fe0f998641b20bda8adac662a018051c623a3c8e5ed4b6ff9ad53fc493a783", size = 165651, upload-time = "2026-05-10T22:31:17.095Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/e0/db/a6acdc72a9e90c3f07ed10de35c951734a02d4facb693bb59684ad368801/deepagents-0.6.12.tar.gz", hash = "sha256:1f281c0bc5a63132f62e2ee345c1dc593b23188da6e23016401f6879fbe54b5f", size = 211364, upload-time = "2026-06-25T17:26:52.775Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/e8/f6/9698f98da72dfa8dc8e1d0f0542f2407a40a50cfdccf522fdb5cb43e39e2/deepagents-0.5.9-py3-none-any.whl", hash = "sha256:ce24a41763b2793bd21217411e9fb9f187a9128da6789f5a81654da1de9e4c7c", size = 188118, upload-time = "2026-05-10T22:31:15.974Z" },
+    { url = "https://files.pythonhosted.org/packages/98/49/af7219b3c13520fee047bb807cfaefba17f8e4584c551d946773589a4f08/deepagents-0.6.12-py3-none-any.whl", hash = "sha256:28b8fa0119ca0a689e3e18e288c4634e4046062acfc87a1cb34289d3af3a1c88", size = 236120, upload-time = "2026-06-25T17:26:51.736Z" },
 ]
 
 [[package]]
@@ -1527,16 +1527,16 @@ wheels = [
 
 [[package]]
 name = "langchain"
-version = "1.3.12"
+version = "1.3.14"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "langchain-core" },
     { name = "langgraph" },
     { name = "pydantic" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/68/c0/8481c93a3899d7e05ac27f21a4e984dab613b72631f39fe01fe0100e3be0/langchain-1.3.12.tar.gz", hash = "sha256:3321f86824a0c0720004d28797d729a58b9bb8a0ac73c6ea2b856cac38117879", size = 642308, upload-time = "2026-07-08T22:38:12.466Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/29/68/a6dbad9c22df4087a0f9e79ddd46226c442b30128bfeee538d5889492a73/langchain-1.3.14.tar.gz", hash = "sha256:1b6696c72ba3bbbce54d745e0180742c9f6ece8bbc59ed5a46c3e20b9a435929", size = 645181, upload-time = "2026-07-16T13:28:18.29Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/b1/31/33ba60f3aaa88dc7b97f9c7680f431237466804bf6826efb75400dfd2e6c/langchain-1.3.12-py3-none-any.whl", hash = "sha256:19685eb9dce01ebd71b11281d5489453e7ab3d2caf61eacb2a76d15574246535", size = 136863, upload-time = "2026-07-08T22:38:11.003Z" },
+    { url = "https://files.pythonhosted.org/packages/a9/ec/0f942e78a621f8e3162ff1ed24284f469aaf51fb4607ee5831c626f2b2bc/langchain-1.3.14-py3-none-any.whl", hash = "sha256:4d10dbe91005952cddd56d0dc77aa108964da6bae90ab20063653957e901f782", size = 139560, upload-time = "2026-07-16T13:28:16.498Z" },
 ]
 
 [[package]]
@@ -2127,7 +2127,7 @@ requires-dist = [
     { name = "nemo-fabric-adapters-hermes", marker = "python_full_version < '3.14' and extra == 'hermes-agent'", editable = "adapters/hermes" },
     { name = "nemo-fabric-runtime", editable = "python" },
     { name = "nemo-fabric-runtime", marker = "extra == 'runtime'", editable = "python" },
-    { name = "nemo-relay", marker = "extra == 'relay'", specifier = ">=0.5.0,<0.7" },
+    { name = "nemo-relay", marker = "extra == 'relay'", specifier = ">=0.6.0,<0.7" },
     { name = "pyyaml", marker = "extra == 'harbor'", specifier = ">=6.0" },
     { name = "tomli-w", marker = "extra == 'relay'", specifier = "~=1.2" },
 ]
@@ -2227,14 +2227,14 @@ relay = [
 
 [package.metadata]
 requires-dist = [
-    { name = "deepagents", specifier = ">=0.5.3,<0.6.0" },
+    { name = "deepagents", specifier = ">=0.6.12,<0.7.0" },
     { name = "langchain", specifier = ">=1.3,<2.0" },
     { name = "langchain-mcp-adapters", specifier = ">=0.1,<0.3.0" },
     { name = "langchain-openai", specifier = ">=0.3" },
     { name = "langgraph", specifier = ">=1.2,<2.0" },
     { name = "langgraph-checkpoint-sqlite", specifier = ">=3.0,<4.0" },
     { name = "nemo-fabric-adapters-common", editable = "adapters/common" },
-    { name = "nemo-relay", extras = ["deepagents"], marker = "extra == 'relay'", specifier = ">=0.5.0,<0.7" },
+    { name = "nemo-relay", extras = ["deepagents"], marker = "extra == 'relay'", specifier = ">=0.6.0,<0.7" },
 ]
 provides-extras = ["relay"]
 
@@ -2269,14 +2269,14 @@ requires-dist = [
 
 [[package]]
 name = "nemo-relay"
-version = "0.5.0"
+version = "0.6.0"
 source = { registry = "https://pypi.org/simple" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/aa/fc/6892859ffbfb60f8cc09a4181c8d407b574d49490e35cd563e7f0a61bf54/nemo_relay-0.5.0-cp311-abi3-macosx_11_0_arm64.whl", hash = "sha256:203409e0f392fc4f40f52277347ed75ba9969b2af28ddb3b6ae53f789185a0ed", size = 7769721, upload-time = "2026-07-08T18:43:57.745Z" },
-    { url = "https://files.pythonhosted.org/packages/dd/13/25c4fcf6fb979af07c9562238819183588a910c2ae09767603500d6948c2/nemo_relay-0.5.0-cp311-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:de61ad0644c5e8c300de814f6884c5de7ae51db14694f5057f938b4da54bfaaf", size = 7037083, upload-time = "2026-07-08T18:44:00.135Z" },
-    { url = "https://files.pythonhosted.org/packages/49/97/bd4c77e975d50f7d09f8bfcb74d7e704e05a8b2205f555bf557f84edc5fe/nemo_relay-0.5.0-cp311-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:cb323569f104506f4f1a0e2104b22d74c9a0bbf3280ec4d58ad3d768de76fb15", size = 7430817, upload-time = "2026-07-08T18:44:02.165Z" },
-    { url = "https://files.pythonhosted.org/packages/da/8b/5681f3430e6d25bf7419dbe576da14599e1cfadc083edb74e691a0c3a980/nemo_relay-0.5.0-cp311-abi3-win_amd64.whl", hash = "sha256:da1bd1e1dec79b7bda3984dd8c59b32ba97abf96c37e85cd1f38d208a29f42b9", size = 7359048, upload-time = "2026-07-08T18:44:04.169Z" },
-    { url = "https://files.pythonhosted.org/packages/4e/f2/65c3ef0435e671c829063d4872897f9054f369f0aeacab12c5aefe486705/nemo_relay-0.5.0-cp311-abi3-win_arm64.whl", hash = "sha256:87462585f17b40ce82c54347acef5ace96ee11de3015f234e0b902f23b3793fb", size = 6934235, upload-time = "2026-07-08T18:44:06.078Z" },
+    { url = "https://files.pythonhosted.org/packages/25/65/d320016505457cc30971f575e8dadffb923b7cfc780ab8bb25a4ce9d305c/nemo_relay-0.6.0-cp311-abi3-macosx_11_0_arm64.whl", hash = "sha256:ad5dae6febf6532d7b113abc2a404679c8feffc499df3034b93d9a078185d2bb", size = 9917779, upload-time = "2026-07-22T20:07:48.961Z" },
+    { url = "https://files.pythonhosted.org/packages/ae/c0/f33250e71c4206da1b339072893f9a1e39295fe1aceb9a2fef4b8620a0f2/nemo_relay-0.6.0-cp311-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:c0cd9570f64c6956fe3bfb82af1cdb3ee70cb50b51098cdb0de831c3f9b4e904", size = 8888375, upload-time = "2026-07-22T20:07:51.049Z" },
+    { url = "https://files.pythonhosted.org/packages/a3/f4/d1dfaed022da0f6f14765a122867f976a69cc520fe1faaf99757f5719d1f/nemo_relay-0.6.0-cp311-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:849daa9e45158ac581e54506e0fcc7a24f557d1ed06dbdc074f5de7a00393cbc", size = 9336372, upload-time = "2026-07-22T20:07:53.224Z" },
+    { url = "https://files.pythonhosted.org/packages/3a/b0/908d77f75b9054e1e403da78f7d9430249a45939070d4298abbb41a04b5b/nemo_relay-0.6.0-cp311-abi3-win_amd64.whl", hash = "sha256:bfbbedfd130fa95c9b8c04643c30910df850e0ed3500beeab82b00ca2d94e7ea", size = 9613425, upload-time = "2026-07-22T20:07:55.175Z" },
+    { url = "https://files.pythonhosted.org/packages/cd/71/c438b9d746303ff7f270d99f13b250bf947cdac3e52de2a83fd132cbca0b/nemo_relay-0.6.0-cp311-abi3-win_arm64.whl", hash = "sha256:82fe132943399d89e6ec34dc28df0be7bbe41b84f6698c545928b8816b6010f6", size = 9034810, upload-time = "2026-07-22T20:07:57.467Z" },
 ]
 
 [package.optional-dependencies]


### PR DESCRIPTION
## Summary

- update the Deep Agents adapter from `deepagents` 0.5.x to the 0.6.x line
- require NeMo Relay 0.6 for Fabric Relay extras
- refresh repository and adapter lockfiles to select compatible versions
- translate the existing flat Fabric ATOF config into Relay 0.6 v2 file and stream sink objects at the Python API boundary
- refresh Python attribution metadata for the resolved dependency versions

## Why

The previous constraints could not resolve Relay 0.6 together with Deep Agents 0.6. Once those constraints were corrected, CI exposed a second incompatibility at runtime: Relay 0.6 removed the flat `AtofConfig(output_directory=..., filename=..., mode=..., endpoints=...)` constructor in favor of an observability v2 model containing typed sinks.

Without adapting that boundary, every Deep Agents invocation with Relay enabled failed before the agent ran:

```text
TypeError: AtofConfig.__init__() got an unexpected keyword argument "output_directory"
```

## ATOF compatibility behavior

This PR currently preserves the existing Fabric configuration shape and translates it into Relay 0.6 objects internally:

- `output_directory`, `filename`, and `mode` become an `AtofFileSinkConfig`
- each entry in `endpoints` becomes an `AtofStreamSinkConfig`
- stream settings such as `headers`, `header_env`, `timeout_millis`, `field_name_policy`, and `name` are preserved
- already-structured v2 `sinks` entries are also accepted
- the Relay Python API receives observability config version 2

This keeps the dependency upgrade independently usable without forcing a coordinated configuration migration.

However, Fabric has not had its first release yet. This may be the least expensive point to make the Relay 0.6 v2 sink model the canonical typed Fabric configuration and remove the legacy flat representation instead of establishing a compatibility contract that must later be deprecated. Reviewer guidance on that choice is requested below.

## Impact

- `nemo-relay`: 0.5.0 -> 0.6.0
- `deepagents`: 0.5.9 -> 0.6.12
- compatible LangChain/LangGraph transitive versions are refreshed
- existing ATOF file and endpoint settings are preserved as Relay 0.6 file and stream sinks

This PR does not change Hermes behavior, add a Relay CLI/gateway process, or install the separately distributed `nemo-relay` CLI executable.

## Validation

- `tests/adapters/test_adapaters_common_utils.py` and `tests/adapters/test_deepagents.py`: 79 passed
- `tests/e2e/test_deepagents.py::test_deepagents_persistent_host_with_relay_and_mock_model`: passed
- full CI Python matrix: passed on Python 3.11 through 3.14 across Linux, macOS, and Windows
- Rust tests and wheel builds: passed
- pre-commit, DCO, Branch Checker, and CodeRabbit: passed
- `UV_CACHE_DIR=/private/tmp/nemo-fabric-pr0-uv-cache uv lock --check`
- `git diff --check`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for the v2 observability configuration format.
  * Improved ATOF configuration handling with file and stream sink support.
  * Preserved compatibility with existing endpoint-based configurations.

* **Bug Fixes**
  * Corrected translation of legacy observability settings into the newer sink-based format.

* **Tests**
  * Added coverage for migrating endpoint-based ATOF configurations and preserving their settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->