### PR TITLE
docs: clarify Python SDK output and credentials

### DIFF
--- a/docs/sdk/python.mdx
+++ b/docs/sdk/python.mdx
@@ -23,6 +23,16 @@ For installation and a package-backed example, start with the
 
 ## Start With One Run
 
+This example uses an NVIDIA-hosted model. Export your NVIDIA API key before
+running it:
+
+```bash
+export NVIDIA_API_KEY=...
+```
+
+The `api_key_env="NVIDIA_API_KEY"` setting tells the adapter to read the
+credential from that environment variable.
+
 Construct a typed config, then pass it to `Fabric.run(...)`. The SDK starts a
 runtime, invokes it once, collects the result, and stops the runtime.
 
@@ -58,11 +68,15 @@ async def main() -> None:
     )
 
     print(result.status)
-    print(result.output)
+    print(result.output.response)
 
 
 asyncio.run(main())
 ```
+
+For object-shaped adapter output, `result.output` is a `RunOutput`. Read
+`result.output.response` for the adapter response, or call
+`result.output.to_mapping()` to inspect the complete normalized output.
 
 Use `base_dir` to resolve relative paths in an in-memory config. Before running
 in a new environment, call `plan(...)` to inspect adapter selection and
@@ -269,7 +283,7 @@ result = await fabric.run(
 )
 
 print(result.status)
-print(result.output)
+print(result.output.response)
 print(result.artifacts)
 ```
 

--- a/docs/sdk/python.mdx
+++ b/docs/sdk/python.mdx
@@ -30,9 +30,6 @@ running it:
 export NVIDIA_API_KEY=...
 ```
 
-The `api_key_env="NVIDIA_API_KEY"` setting tells the adapter to read the
-credential from that environment variable.
-
 Construct a typed config, then pass it to `Fabric.run(...)`. The SDK starts a
 runtime, invokes it once, collects the result, and stops the runtime.
 
@@ -73,10 +70,6 @@ async def main() -> None:
 
 asyncio.run(main())
 ```
-
-For object-shaped adapter output, `result.output` is a `RunOutput`. Read
-`result.output.response` for the adapter response, or call
-`result.output.to_mapping()` to inspect the complete normalized output.
 
 Use `base_dir` to resolve relative paths in an in-memory config. Before running
 in a new environment, call `plan(...)` to inspect adapter selection and


### PR DESCRIPTION
#### Overview

Clarify the Python SDK examples so users export the required NVIDIA-hosted
model credential and print the adapter response instead of the `RunOutput`
object identity.

This issue predates #103; that PR changes links in `docs/sdk/python.mdx` but
does not change the affected credential or output examples. This PR therefore
targets `main` directly.

#### Details

- Add the required `NVIDIA_API_KEY` export before the first Hermes example.
- Print `result.output.response` in both affected examples.
- Breaking changes: none.

#### Validation

- `just docs` (passed; the unauthenticated Fern redirects check was skipped)
- `uv run --no-sync pre-commit run --files docs/sdk/python.mdx`
- `git diff --check`

#### Where should the reviewer start?

Start with `docs/sdk/python.mdx`, under **Start With One Run**.

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- Relates to #103

- [x] I confirm this contribution is my own work, or I have the right to submit it under this project's license.
- [x] I searched existing issues and open pull requests, and this does not duplicate existing work.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the Python SDK “Start With One Run” example to instruct exporting `NVIDIA_API_KEY` before running.
  * Adjusted output display in both “Start With One Run” and “Single-Invocation Runs” to print only `result.output.response` (instead of the full output).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->