### PR TITLE
fix: repair documented workflows and API references

### DIFF
--- a/crates/fabric-cli/src/scaffold.rs
+++ b/crates/fabric-cli/src/scaffold.rs
@@ -112,7 +112,25 @@ fn language_files(language: Language, config: &FabricConfig, example: &str) -> V
 }
 
 fn rust_core_dependency() -> String {
-    rust_string(env!("CARGO_PKG_VERSION"))
+    let source_path = Path::new(env!("CARGO_MANIFEST_DIR")).join("../fabric-core");
+    rust_core_dependency_for_path(&source_path)
+}
+
+fn rust_core_dependency_for_path(source_path: &Path) -> String {
+    let version = rust_string(env!("CARGO_PKG_VERSION"));
+    if !source_path.join("Cargo.toml").is_file() {
+        return version;
+    }
+    let Ok(source_path) = source_path.canonicalize() else {
+        return version;
+    };
+    let Some(source_path) = source_path.to_str() else {
+        return version;
+    };
+    format!(
+        "{{ path = {}, version = {version} }}",
+        rust_string(source_path)
+    )
 }
 
 fn write_files(destination: &Path, files: &[ScaffoldFile]) -> Result<(), String> {
@@ -308,10 +326,69 @@ mod tests {
                 assert!(
                     manifest.contains(&format!("nemo-fabric-core = {}", rust_core_dependency()))
                 );
-                assert!(!manifest.contains("path ="));
+                assert!(manifest.contains("[workspace]"));
             }
             fs::remove_dir_all(destination).expect("remove scaffold");
         }
+    }
+
+    #[test]
+    fn source_checkout_rust_scaffold_builds_inside_the_repository() {
+        let destination = Path::new(env!("CARGO_MANIFEST_DIR")).join(format!(
+            ".nemo-fabric-scaffold-test-{}-build",
+            std::process::id()
+        ));
+        let _ = fs::remove_dir_all(&destination);
+        init(
+            examples::find("code-review").expect("example"),
+            None,
+            Language::Rust,
+            &destination,
+        )
+        .expect("generate scaffold");
+
+        let output = std::process::Command::new(env!("CARGO"))
+            .args(["check", "--offline"])
+            .current_dir(&destination)
+            .output()
+            .expect("run cargo check");
+        assert!(
+            output.status.success(),
+            "generated Rust scaffold did not build:\n{}",
+            String::from_utf8_lossy(&output.stderr)
+        );
+        fs::remove_dir_all(destination).expect("remove scaffold");
+    }
+
+    #[test]
+    fn rust_core_dependency_uses_local_checkout_when_available() {
+        let source_path = destination("core-dependency-local", Language::Rust);
+        let _ = fs::remove_dir_all(&source_path);
+        fs::create_dir_all(&source_path).expect("create source checkout");
+        fs::write(source_path.join("Cargo.toml"), "").expect("write Cargo manifest");
+        let canonical_path = source_path.canonicalize().expect("canonicalize checkout");
+
+        assert_eq!(
+            rust_core_dependency_for_path(&source_path),
+            format!(
+                "{{ path = {}, version = {} }}",
+                rust_string(canonical_path.to_str().expect("UTF-8 checkout path")),
+                rust_string(env!("CARGO_PKG_VERSION"))
+            )
+        );
+
+        fs::remove_dir_all(source_path).expect("remove source checkout");
+    }
+
+    #[test]
+    fn rust_core_dependency_falls_back_when_checkout_is_unavailable() {
+        let source_path = destination("core-dependency-missing", Language::Rust);
+        let _ = fs::remove_dir_all(&source_path);
+
+        assert_eq!(
+            rust_core_dependency_for_path(&source_path),
+            rust_string(env!("CARGO_PKG_VERSION"))
+        );
     }
 
     #[test]

--- a/crates/fabric-cli/templates/rust/Cargo.toml.tmpl
+++ b/crates/fabric-cli/templates/rust/Cargo.toml.tmpl
@@ -6,6 +6,8 @@ name = "{{PACKAGE}}-rust"
 version = "0.1.0"
 edition = "2024"
 
+[workspace]
+
 [dependencies]
 nemo-fabric-core = {{NEMO_FABRIC_CORE_DEPENDENCY}}
 serde_json = "1"

--- a/docs/experimentation/cli.mdx
+++ b/docs/experimentation/cli.mdx
@@ -214,7 +214,11 @@ cargo run -- "Review the workspace"
 ```
 
 The Rust scaffold constructs `FabricConfig` and calls `fabric-core` directly.
-Neither scaffold is loaded back into the central CLI.
+When the CLI is built from a source checkout, the generated manifest uses an
+absolute path to that checkout's `crates/fabric-core`. Keep the checkout
+available, or replace the path dependency with a compatible published version
+before moving the scaffold. Neither scaffold is loaded back into the central
+CLI.
 
 ## CLI Boundaries
 

--- a/docs/getting-started/install.mdx
+++ b/docs/getting-started/install.mdx
@@ -122,5 +122,5 @@ uv sync --all-groups --all-extras
 Then run the build command with the `no_uv=true` flag to avoid re-installing the dependencies:
 
 ```bash
-just build-all no_uv=true
+just no_uv=true build-all
 ```

--- a/docs/integrations/harness/codex.mdx
+++ b/docs/integrations/harness/codex.mdx
@@ -40,6 +40,9 @@ Use normalized NeMo Fabric fields so the same capability configuration can be
 planned before the adapter starts:
 
 ```python
+from examples.code_review_agent import codex_config
+
+config = codex_config()
 config.add_skill_path("./skills/code-review")
 config.add_mcp_server(
     "repo",
@@ -83,6 +86,9 @@ To override the SDK-selected app-server intentionally, set an absolute path or
 a path relative to the NeMo Fabric config root in `harness.settings.codex_bin`:
 
 ```python
+from examples.code_review_agent import codex_config
+
+config = codex_config()
 config.harness.settings["codex_bin"] = "/path/to/codex"
 ```
 
@@ -157,12 +163,6 @@ dependency and does not install the CLI. NeMo Fabric owns sidecar supervision an
 runtime-scoped SDK configuration. Relay owns gateway transport behavior,
 including decoding `Content-Encoding` before it constructs managed LLM events.
 There is no NeMo Fabric compression setting.
-
-The initial NeMo Relay `0.6.0` source tag cannot recover semantic fields from
-zstd-compressed Codex SDK requests. Until a later `0.6.x` release contains the
-fix, use a build that includes
-[NeMo Relay PR #452](https://github.com/NVIDIA/NeMo-Relay/pull/452). NeMo Fabric's
-opt-in Relay E2E rejects opaque request bodies and missing token usage.
 
 ## Compare Phoenix Trace Modes
 

--- a/docs/reference/api/python-library-reference/nemo_fabric.client.md
+++ b/docs/reference/api/python-library-reference/nemo_fabric.client.md
@@ -7,6 +7,7 @@ description: "Resolve, plan, diagnose, and run agents with NVIDIA NeMo Fabric."
 SPDX-License-Identifier: Apache-2.0 -->
 
 # <kbd>module</kbd> `nemo_fabric.client`
+
 Native Python client for resolving and running NeMo Fabric agents.
 
 
@@ -15,6 +16,7 @@ Native Python client for resolving and running NeMo Fabric agents.
 
 
 ## <kbd>class</kbd> `Fabric`
+
 Primary Python entrypoint for NeMo Fabric.
 
 Every lifecycle method accepts a complete, typed ``FabricConfig`` plus an optional ``base_dir`` used to resolve relative paths. Compose variants in Python before calling the SDK. The ``doctor()``, ``plan()``, and ``run()`` results are typed, read-only mapping models. ``start_runtime()`` returns an active ``Runtime`` handle.
@@ -32,10 +34,11 @@ See the Getting Started overview for runnable single-invocation, typed-config, a
 ### <kbd>method</kbd> `doctor`
 
 ```python
-doctor(
-    config: 'FabricConfig',
-    base_dir: 'str | PathLike[str] | None' = None
-) → DoctorReport
+async def doctor(
+    config: FabricConfig,
+    *,
+    base_dir: str | os.PathLike[str] | None = None,
+) -> DoctorReport
 ```
 
 Diagnose a planned agent without starting its runtime.
@@ -67,10 +70,11 @@ Doctor checks the resolved adapter, capability mappings, and declared environmen
 ### <kbd>method</kbd> `plan`
 
 ```python
-plan(
-    config: 'FabricConfig',
-    base_dir: 'str | PathLike[str] | None' = None
-) → RunPlan
+def plan(
+    config: FabricConfig,
+    *,
+    base_dir: str | os.PathLike[str] | None = None,
+) -> RunPlan
 ```
 
 Resolve a complete typed configuration into an immutable execution plan.
@@ -102,12 +106,13 @@ Planning resolves the selected adapter and reports optional runtime capabilities
 ### <kbd>method</kbd> `run`
 
 ```python
-run(
-    config: 'FabricConfig',
-    base_dir: 'str | PathLike[str] | None' = None,
-    input: 'Any' = None,
-    request: 'RunRequest | None' = None
-) → RunResult
+async def run(
+    config: FabricConfig,
+    *,
+    base_dir: str | os.PathLike[str] | None = None,
+    input: Any = None,
+    request: RunRequest | None = None,
+) -> RunResult
 ```
 
 Execute one complete start, invoke, and stop lifecycle.
@@ -142,12 +147,13 @@ Execute one complete start, invoke, and stop lifecycle.
 ### <kbd>method</kbd> `start_runtime`
 
 ```python
-start_runtime(
-    config: 'FabricConfig',
-    base_dir: 'str | PathLike[str] | None' = None,
-    overrides: 'Mapping[str, Any] | None' = None,
-    streaming: 'bool' = False
-) → Runtime
+async def start_runtime(
+    config: FabricConfig,
+    *,
+    base_dir: str | os.PathLike[str] | None = None,
+    overrides: Mapping[str, Any] | None = None,
+    streaming: bool = False,
+) -> Runtime
 ```
 
 Start a stateful runtime for one or more ordered invocations.

--- a/docs/reference/api/python-library-reference/nemo_fabric.errors.md
+++ b/docs/reference/api/python-library-reference/nemo_fabric.errors.md
@@ -7,6 +7,7 @@ description: "Structured exception hierarchy for config, capability, state, and 
 SPDX-License-Identifier: Apache-2.0 -->
 
 # <kbd>module</kbd> `nemo_fabric.errors`
+
 Public exception hierarchy for the NeMo Fabric Python SDK.
 
 
@@ -15,6 +16,7 @@ Public exception hierarchy for the NeMo Fabric Python SDK.
 
 
 ## <kbd>class</kbd> `FabricError`
+
 Base class for structured SDK-level NeMo Fabric errors.
 
 Catch this type to handle any SDK failure while preserving machine-readable stage, code, retryability, and detail fields.
@@ -29,16 +31,22 @@ Catch this type to handle any SDK failure while preserving machine-readable stag
  - <b>`details`</b>:  Detached structured error details.
 
 
+
+### Inheritance
+
+Direct base: `RuntimeError`.
+
 ### <kbd>method</kbd> `__init__`
 
 ```python
-__init__(
-    message: 'str',
-    stage: 'str | None' = None,
-    code: 'str | None' = None,
-    retryable: 'bool' = False,
-    details: 'Mapping[str, Any] | None' = None
-) → None
+def __init__(
+    message: str,
+    *,
+    stage: str | None = None,
+    code: str | None = None,
+    retryable: bool = False,
+    details: Mapping[str, Any] | None = None,
+) -> None
 ```
 
 Initialize a structured NeMo Fabric exception.
@@ -61,19 +69,26 @@ Initialize a structured NeMo Fabric exception.
 
 
 ## <kbd>class</kbd> `FabricConfigError`
+
 Invalid SDK input, request shape, factory, or resolved config.
 
+
+
+### Inheritance
+
+Direct base: `FabricError`.
 
 ### <kbd>method</kbd> `__init__`
 
 ```python
-__init__(
-    message: 'str',
-    stage: 'str | None' = None,
-    code: 'str | None' = None,
-    retryable: 'bool' = False,
-    details: 'Mapping[str, Any] | None' = None
-) → None
+def __init__(
+    message: str,
+    *,
+    stage: str | None = None,
+    code: str | None = None,
+    retryable: bool = False,
+    details: Mapping[str, Any] | None = None,
+) -> None
 ```
 
 Initialize a structured NeMo Fabric exception.
@@ -96,19 +111,26 @@ Initialize a structured NeMo Fabric exception.
 
 
 ## <kbd>class</kbd> `FabricRuntimeError`
+
 Failure while starting, invoking, stopping, or otherwise driving a runtime.
 
+
+
+### Inheritance
+
+Direct base: `FabricError`.
 
 ### <kbd>method</kbd> `__init__`
 
 ```python
-__init__(
-    message: 'str',
-    stage: 'str | None' = None,
-    code: 'str | None' = None,
-    retryable: 'bool' = False,
-    details: 'Mapping[str, Any] | None' = None
-) → None
+def __init__(
+    message: str,
+    *,
+    stage: str | None = None,
+    code: str | None = None,
+    retryable: bool = False,
+    details: Mapping[str, Any] | None = None,
+) -> None
 ```
 
 Initialize a structured NeMo Fabric exception.
@@ -131,19 +153,26 @@ Initialize a structured NeMo Fabric exception.
 
 
 ## <kbd>class</kbd> `FabricStateError`
+
 Operation rejected because a local runtime is in the wrong state.
 
+
+
+### Inheritance
+
+Direct base: `FabricRuntimeError`.
 
 ### <kbd>method</kbd> `__init__`
 
 ```python
-__init__(
-    message: 'str',
-    stage: 'str | None' = None,
-    code: 'str | None' = None,
-    retryable: 'bool' = False,
-    details: 'Mapping[str, Any] | None' = None
-) → None
+def __init__(
+    message: str,
+    *,
+    stage: str | None = None,
+    code: str | None = None,
+    retryable: bool = False,
+    details: Mapping[str, Any] | None = None,
+) -> None
 ```
 
 Initialize a structured NeMo Fabric exception.
@@ -166,19 +195,26 @@ Initialize a structured NeMo Fabric exception.
 
 
 ## <kbd>class</kbd> `FabricCapabilityError`
+
 Operation rejected by resolved runtime capabilities or implementation status.
 
+
+
+### Inheritance
+
+Direct base: `FabricRuntimeError`.
 
 ### <kbd>method</kbd> `__init__`
 
 ```python
-__init__(
-    message: 'str',
-    stage: 'str | None' = None,
-    code: 'str | None' = None,
-    retryable: 'bool' = False,
-    details: 'Mapping[str, Any] | None' = None
-) → None
+def __init__(
+    message: str,
+    *,
+    stage: str | None = None,
+    code: str | None = None,
+    retryable: bool = False,
+    details: Mapping[str, Any] | None = None,
+) -> None
 ```
 
 Initialize a structured NeMo Fabric exception.
@@ -201,19 +237,26 @@ Initialize a structured NeMo Fabric exception.
 
 
 ## <kbd>class</kbd> `FabricNativeUnavailableError`
+
 SDK call requires the PyO3 extension, but it is not installed or importable.
 
+
+
+### Inheritance
+
+Direct base: `FabricRuntimeError`.
 
 ### <kbd>method</kbd> `__init__`
 
 ```python
-__init__(
-    message: 'str',
-    stage: 'str | None' = None,
-    code: 'str | None' = None,
-    retryable: 'bool' = False,
-    details: 'Mapping[str, Any] | None' = None
-) → None
+def __init__(
+    message: str,
+    *,
+    stage: str | None = None,
+    code: str | None = None,
+    retryable: bool = False,
+    details: Mapping[str, Any] | None = None,
+) -> None
 ```
 
 Initialize a structured NeMo Fabric exception.

--- a/docs/reference/api/python-library-reference/nemo_fabric.models.md
+++ b/docs/reference/api/python-library-reference/nemo_fabric.models.md
@@ -7,6 +7,7 @@ description: "Pydantic authoring models for NVIDIA NeMo Fabric config and reques
 SPDX-License-Identifier: Apache-2.0 -->
 
 # <kbd>module</kbd> `nemo_fabric.models`
+
 Pydantic SDK models for NeMo Fabric configuration and requests.
 
 The Rust core remains the source of truth for persisted schema snapshots. These models provide the Python SDK's typed authoring surface and intentionally keep extension fields so consumers can carry adapter- or application-owned data without waiting for a schema release.
@@ -17,6 +18,7 @@ The Rust core remains the source of truth for persisted schema snapshots. These 
 
 
 ## <kbd>class</kbd> `FabricBaseModel`
+
 Base class for SDK-facing Pydantic models.
 
 
@@ -56,7 +58,7 @@ Returns the set of fields that have been explicitly set on this model instance.
 ### <kbd>classmethod</kbd> `from_mapping`
 
 ```python
-from_mapping(value: 'Mapping[str, Any]') → Self
+def from_mapping(value: Mapping[str, Any]) -> Self
 ```
 
 Validate a mapping using this Pydantic model.
@@ -67,7 +69,7 @@ Validate a mapping using this Pydantic model.
 ### <kbd>method</kbd> `to_mapping`
 
 ```python
-to_mapping() → dict[str, Any]
+def to_mapping() -> dict[str, Any]
 ```
 
 Return a detached JSON-compatible mapping for Rust/core calls.
@@ -77,8 +79,19 @@ Return a detached JSON-compatible mapping for Rust/core calls.
 
 
 ## <kbd>class</kbd> `MetadataConfig`
+
 Human-readable agent identity.
 
+
+
+### Fields
+
+The model defines the following fields:
+
+| Field | Type | Required | Default | Constraints | Description |
+| --- | --- | --- | --- | --- | --- |
+| `name` | `str` | Yes | — | `MinLen(min_length=1)` | — |
+| `description` | `str \| None` | No | `None` | — | — |
 
 ---
 
@@ -116,7 +129,7 @@ Returns the set of fields that have been explicitly set on this model instance.
 ### <kbd>classmethod</kbd> `from_mapping`
 
 ```python
-from_mapping(value: 'Mapping[str, Any]') → Self
+def from_mapping(value: Mapping[str, Any]) -> Self
 ```
 
 Validate a mapping using this Pydantic model.
@@ -127,7 +140,7 @@ Validate a mapping using this Pydantic model.
 ### <kbd>method</kbd> `to_mapping`
 
 ```python
-to_mapping() → dict[str, Any]
+def to_mapping() -> dict[str, Any]
 ```
 
 Return a detached JSON-compatible mapping for Rust/core calls.
@@ -137,8 +150,20 @@ Return a detached JSON-compatible mapping for Rust/core calls.
 
 
 ## <kbd>class</kbd> `HarnessConfig`
+
 Harness adapter selection plus adapter-owned settings.
 
+
+
+### Fields
+
+The model defines the following fields:
+
+| Field | Type | Required | Default | Constraints | Description |
+| --- | --- | --- | --- | --- | --- |
+| `adapter_id` | `str` | Yes | — | `MinLen(min_length=1)` | — |
+| `resolution` | `Literal['preinstalled', 'image_provided', 'pip_uv', 'npm', 'source', 'service', 'native_plugin'] \| None` | No | `None` | — | — |
+| `settings` | `dict[str, Any]` | No | `dict()` | — | — |
 
 ---
 
@@ -176,7 +201,7 @@ Returns the set of fields that have been explicitly set on this model instance.
 ### <kbd>classmethod</kbd> `from_mapping`
 
 ```python
-from_mapping(value: 'Mapping[str, Any]') → Self
+def from_mapping(value: Mapping[str, Any]) -> Self
 ```
 
 Validate a mapping using this Pydantic model.
@@ -187,7 +212,7 @@ Validate a mapping using this Pydantic model.
 ### <kbd>method</kbd> `to_mapping`
 
 ```python
-to_mapping() → dict[str, Any]
+def to_mapping() -> dict[str, Any]
 ```
 
 Return a detached JSON-compatible mapping for Rust/core calls.
@@ -197,8 +222,20 @@ Return a detached JSON-compatible mapping for Rust/core calls.
 
 
 ## <kbd>class</kbd> `RuntimeConfig`
+
 Runtime input/output contract.
 
+
+
+### Fields
+
+The model defines the following fields:
+
+| Field | Type | Required | Default | Constraints | Description |
+| --- | --- | --- | --- | --- | --- |
+| `input_schema` | `str \| None` | No | `None` | — | — |
+| `output_schema` | `str \| None` | No | `None` | — | — |
+| `artifacts` | `str \| Path \| None` | No | `None` | — | — |
 
 ---
 
@@ -236,7 +273,7 @@ Returns the set of fields that have been explicitly set on this model instance.
 ### <kbd>classmethod</kbd> `from_mapping`
 
 ```python
-from_mapping(value: 'Mapping[str, Any]') → Self
+def from_mapping(value: Mapping[str, Any]) -> Self
 ```
 
 Validate a mapping using this Pydantic model.
@@ -247,7 +284,7 @@ Validate a mapping using this Pydantic model.
 ### <kbd>method</kbd> `to_mapping`
 
 ```python
-to_mapping() → dict[str, Any]
+def to_mapping() -> dict[str, Any]
 ```
 
 Return a detached JSON-compatible mapping for Rust/core calls.
@@ -257,10 +294,27 @@ Return a detached JSON-compatible mapping for Rust/core calls.
 
 
 ## <kbd>class</kbd> `EnvironmentConfig`
+
 Execution environment configuration supplied by the consumer.
 
 ``provider`` selects the environment implementation. ``workspace`` is the path visible to the harness, while ``artifacts`` is the provider-specific output location. ``settings`` configures the selected provider; ``connection`` describes how NeMo Fabric reaches an existing environment; and ``metadata`` carries consumer-owned values that NeMo Fabric does not interpret. ``ownership`` identifies who tears the environment down, and ``control_location`` identifies whether NeMo Fabric control code runs inside or outside it.
 
+
+
+### Fields
+
+The model defines the following fields:
+
+| Field | Type | Required | Default | Constraints | Description |
+| --- | --- | --- | --- | --- | --- |
+| `provider` | `str` | No | `'local'` | `MinLen(min_length=1)` | Environment provider, such as local, docker, opensandbox, or k8s. |
+| `workspace` | `str \| Path \| None` | No | `None` | — | Workspace path visible to the harness. |
+| `artifacts` | `str \| Path \| None` | No | `None` | — | Environment-specific artifact path. |
+| `settings` | `dict[str, Any]` | No | `dict()` | — | Provider-specific configuration interpreted by the environment provider. |
+| `metadata` | `dict[str, Any]` | No | `dict()` | — | Consumer-owned environment metadata passed through without NeMo Fabric semantics. |
+| `connection` | `dict[str, Any]` | No | `dict()` | — | Connection data for an existing environment, such as URL, namespace, or credential reference. |
+| `ownership` | `Literal['caller_owned', 'fabric_owned']` | No | `'caller_owned'` | — | Whether the caller or NeMo Fabric owns environment teardown. |
+| `control_location` | `Literal['external_control', 'in_env_control']` | No | `'in_env_control'` | — | Whether NeMo Fabric control code runs outside or inside the environment. |
 
 ---
 
@@ -298,7 +352,7 @@ Returns the set of fields that have been explicitly set on this model instance.
 ### <kbd>classmethod</kbd> `from_mapping`
 
 ```python
-from_mapping(value: 'Mapping[str, Any]') → Self
+def from_mapping(value: Mapping[str, Any]) -> Self
 ```
 
 Validate a mapping using this Pydantic model.
@@ -309,7 +363,7 @@ Validate a mapping using this Pydantic model.
 ### <kbd>method</kbd> `to_mapping`
 
 ```python
-to_mapping() → dict[str, Any]
+def to_mapping() -> dict[str, Any]
 ```
 
 Return a detached JSON-compatible mapping for Rust/core calls.
@@ -319,8 +373,22 @@ Return a detached JSON-compatible mapping for Rust/core calls.
 
 
 ## <kbd>class</kbd> `ModelConfig`
+
 Model alias configuration.
 
+
+
+### Fields
+
+The model defines the following fields:
+
+| Field | Type | Required | Default | Constraints | Description |
+| --- | --- | --- | --- | --- | --- |
+| `provider` | `str` | Yes | — | `MinLen(min_length=1)` | — |
+| `model` | `str` | Yes | — | `MinLen(min_length=1)` | — |
+| `api_key_env` | `str \| None` | No | `None` | — | — |
+| `temperature` | `float \| None` | No | `None` | — | — |
+| `settings` | `dict[str, Any]` | No | `dict()` | — | — |
 
 ---
 
@@ -358,7 +426,7 @@ Returns the set of fields that have been explicitly set on this model instance.
 ### <kbd>classmethod</kbd> `from_mapping`
 
 ```python
-from_mapping(value: 'Mapping[str, Any]') → Self
+def from_mapping(value: Mapping[str, Any]) -> Self
 ```
 
 Validate a mapping using this Pydantic model.
@@ -369,7 +437,7 @@ Validate a mapping using this Pydantic model.
 ### <kbd>method</kbd> `to_mapping`
 
 ```python
-to_mapping() → dict[str, Any]
+def to_mapping() -> dict[str, Any]
 ```
 
 Return a detached JSON-compatible mapping for Rust/core calls.
@@ -379,8 +447,18 @@ Return a detached JSON-compatible mapping for Rust/core calls.
 
 
 ## <kbd>class</kbd> `SkillConfig`
+
 Skill capability configuration.
 
+
+
+### Fields
+
+The model defines the following fields:
+
+| Field | Type | Required | Default | Constraints | Description |
+| --- | --- | --- | --- | --- | --- |
+| `paths` | `list[str \| Path]` | No | `list()` | — | — |
 
 ---
 
@@ -418,7 +496,7 @@ Returns the set of fields that have been explicitly set on this model instance.
 ### <kbd>method</kbd> `add_path`
 
 ```python
-add_path(path: 'str | Path') → Self
+def add_path(path: str | Path) -> Self
 ```
 
 Add a skill path if absent.
@@ -429,7 +507,7 @@ Add a skill path if absent.
 ### <kbd>classmethod</kbd> `from_mapping`
 
 ```python
-from_mapping(value: 'Mapping[str, Any]') → Self
+def from_mapping(value: Mapping[str, Any]) -> Self
 ```
 
 Validate a mapping using this Pydantic model.
@@ -440,7 +518,7 @@ Validate a mapping using this Pydantic model.
 ### <kbd>method</kbd> `remove_path`
 
 ```python
-remove_path(path: 'str | Path') → Self
+def remove_path(path: str | Path) -> Self
 ```
 
 Remove a skill path if present.
@@ -451,7 +529,7 @@ Remove a skill path if present.
 ### <kbd>method</kbd> `to_mapping`
 
 ```python
-to_mapping() → dict[str, Any]
+def to_mapping() -> dict[str, Any]
 ```
 
 Return a detached JSON-compatible mapping for Rust/core calls.
@@ -461,8 +539,20 @@ Return a detached JSON-compatible mapping for Rust/core calls.
 
 
 ## <kbd>class</kbd> `McpServerConfig`
+
 MCP server configuration.
 
+
+
+### Fields
+
+The model defines the following fields:
+
+| Field | Type | Required | Default | Constraints | Description |
+| --- | --- | --- | --- | --- | --- |
+| `transport` | `str` | Yes | — | `MinLen(min_length=1)` | — |
+| `url` | `str` | Yes | — | `MinLen(min_length=1)` | — |
+| `exposure` | `Literal['harness_native', 'fabric_managed']` | No | `'harness_native'` | — | — |
 
 ---
 
@@ -500,7 +590,7 @@ Returns the set of fields that have been explicitly set on this model instance.
 ### <kbd>classmethod</kbd> `from_mapping`
 
 ```python
-from_mapping(value: 'Mapping[str, Any]') → Self
+def from_mapping(value: Mapping[str, Any]) -> Self
 ```
 
 Validate a mapping using this Pydantic model.
@@ -511,7 +601,7 @@ Validate a mapping using this Pydantic model.
 ### <kbd>method</kbd> `to_mapping`
 
 ```python
-to_mapping() → dict[str, Any]
+def to_mapping() -> dict[str, Any]
 ```
 
 Return a detached JSON-compatible mapping for Rust/core calls.
@@ -521,8 +611,18 @@ Return a detached JSON-compatible mapping for Rust/core calls.
 
 
 ## <kbd>class</kbd> `McpConfig`
+
 MCP capability configuration.
 
+
+
+### Fields
+
+The model defines the following fields:
+
+| Field | Type | Required | Default | Constraints | Description |
+| --- | --- | --- | --- | --- | --- |
+| `servers` | `dict[str, McpServerConfig]` | No | `dict()` | — | — |
 
 ---
 
@@ -560,13 +660,14 @@ Returns the set of fields that have been explicitly set on this model instance.
 ### <kbd>method</kbd> `add_server`
 
 ```python
-add_server(
-    name: 'str',
-    transport: 'str',
-    url: 'str',
-    exposure: "Literal['harness_native', 'fabric_managed']" = 'harness_native',
-    extra_fields: 'Mapping[str, Any] | None' = None
-) → Self
+def add_server(
+    name: str,
+    *,
+    transport: str,
+    url: str,
+    exposure: Literal['harness_native', 'fabric_managed'] = 'harness_native',
+    extra_fields: Mapping[str, Any] | None = None,
+) -> Self
 ```
 
 Add or replace a named MCP server.
@@ -577,7 +678,7 @@ Add or replace a named MCP server.
 ### <kbd>classmethod</kbd> `from_mapping`
 
 ```python
-from_mapping(value: 'Mapping[str, Any]') → Self
+def from_mapping(value: Mapping[str, Any]) -> Self
 ```
 
 Validate a mapping using this Pydantic model.
@@ -588,7 +689,7 @@ Validate a mapping using this Pydantic model.
 ### <kbd>method</kbd> `remove_server`
 
 ```python
-remove_server(name: 'str') → Self
+def remove_server(name: str) -> Self
 ```
 
 Remove a named MCP server if present.
@@ -599,7 +700,7 @@ Remove a named MCP server if present.
 ### <kbd>method</kbd> `to_mapping`
 
 ```python
-to_mapping() → dict[str, Any]
+def to_mapping() -> dict[str, Any]
 ```
 
 Return a detached JSON-compatible mapping for Rust/core calls.
@@ -609,8 +710,20 @@ Return a detached JSON-compatible mapping for Rust/core calls.
 
 
 ## <kbd>class</kbd> `RelayConfigPolicy`
+
 NVIDIA NeMo Relay config validation policy.
 
+
+
+### Fields
+
+The model defines the following fields:
+
+| Field | Type | Required | Default | Constraints | Description |
+| --- | --- | --- | --- | --- | --- |
+| `unknown_component` | `Literal['ignore', 'warn', 'error']` | No | `'warn'` | — | — |
+| `unknown_field` | `Literal['ignore', 'warn', 'error']` | No | `'warn'` | — | — |
+| `unsupported_value` | `Literal['ignore', 'warn', 'error']` | No | `'error'` | — | — |
 
 ---
 
@@ -648,7 +761,7 @@ Returns the set of fields that have been explicitly set on this model instance.
 ### <kbd>classmethod</kbd> `from_mapping`
 
 ```python
-from_mapping(value: 'Mapping[str, Any]') → Self
+def from_mapping(value: Mapping[str, Any]) -> Self
 ```
 
 Validate a mapping using this Pydantic model.
@@ -659,7 +772,7 @@ Validate a mapping using this Pydantic model.
 ### <kbd>method</kbd> `to_mapping`
 
 ```python
-to_mapping() → dict[str, Any]
+def to_mapping() -> dict[str, Any]
 ```
 
 Return a detached JSON-compatible mapping for Rust/core calls.
@@ -673,6 +786,18 @@ Return a detached JSON-compatible mapping for Rust/core calls.
 NeMo Relay ATOF file sink configuration.
 
 
+
+### Fields
+
+The model defines the following fields:
+
+| Field | Type | Required | Default | Constraints | Description |
+| --- | --- | --- | --- | --- | --- |
+| `type` | `Literal['file']` | No | `'file'` | — | — |
+| `output_directory` | `str \| Path \| None` | No | `None` | — | — |
+| `filename` | `str \| None` | No | `None` | — | — |
+| `mode` | `Literal['append', 'overwrite']` | No | `'append'` | — | — |
+
 ---
 
 ### <kbd>property</kbd> extra_fields
@@ -709,7 +834,7 @@ Returns the set of fields that have been explicitly set on this model instance.
 ### <kbd>classmethod</kbd> `from_mapping`
 
 ```python
-from_mapping(value: 'Mapping[str, Any]') → Self
+def from_mapping(value: Mapping[str, Any]) -> Self
 ```
 
 Validate a mapping using this Pydantic model.
@@ -720,7 +845,7 @@ Validate a mapping using this Pydantic model.
 ### <kbd>method</kbd> `to_mapping`
 
 ```python
-to_mapping() → dict[str, Any]
+def to_mapping() -> dict[str, Any]
 ```
 
 Return a detached JSON-compatible mapping for Rust/core calls.
@@ -734,6 +859,22 @@ Return a detached JSON-compatible mapping for Rust/core calls.
 NeMo Relay ATOF stream sink configuration.
 
 
+
+### Fields
+
+The model defines the following fields:
+
+| Field | Type | Required | Default | Constraints | Description |
+| --- | --- | --- | --- | --- | --- |
+| `type` | `Literal['stream']` | No | `'stream'` | — | — |
+| `url` | `str` | Yes | — | — | — |
+| `transport` | `Literal['http_post', 'websocket', 'ndjson']` | No | `'http_post'` | — | — |
+| `headers` | `dict[str, str]` | No | `dict()` | — | — |
+| `header_env` | `dict[str, str]` | No | `dict()` | — | — |
+| `timeout_millis` | `int` | No | `3000` | — | — |
+| `field_name_policy` | `Literal['preserve', 'replace_dots']` | No | `'preserve'` | — | — |
+| `name` | `str \| None` | No | `None` | — | — |
+
 ---
 
 ### <kbd>property</kbd> extra_fields
@@ -770,7 +911,7 @@ Returns the set of fields that have been explicitly set on this model instance.
 ### <kbd>classmethod</kbd> `from_mapping`
 
 ```python
-from_mapping(value: 'Mapping[str, Any]') → Self
+def from_mapping(value: Mapping[str, Any]) -> Self
 ```
 
 Validate a mapping using this Pydantic model.
@@ -781,7 +922,7 @@ Validate a mapping using this Pydantic model.
 ### <kbd>method</kbd> `to_mapping`
 
 ```python
-to_mapping() → dict[str, Any]
+def to_mapping() -> dict[str, Any]
 ```
 
 Return a detached JSON-compatible mapping for Rust/core calls.
@@ -791,8 +932,19 @@ Return a detached JSON-compatible mapping for Rust/core calls.
 
 
 ## <kbd>class</kbd> `RelayAtofConfig`
+
 NeMo Relay ATOF export configuration.
 
+
+
+### Fields
+
+The model defines the following fields:
+
+| Field | Type | Required | Default | Constraints | Description |
+| --- | --- | --- | --- | --- | --- |
+| `enabled` | `bool` | No | `False` | — | — |
+| `sinks` | `list[Annotated[RelayAtofFileSinkConfig \| RelayAtofStreamSinkConfig, Field(discriminator='type')] \| dict[str, Any]] \| None` | No | `None` | — | — |
 
 ---
 
@@ -830,7 +982,7 @@ Returns the set of fields that have been explicitly set on this model instance.
 ### <kbd>classmethod</kbd> `from_mapping`
 
 ```python
-from_mapping(value: 'Mapping[str, Any]') → Self
+def from_mapping(value: Mapping[str, Any]) -> Self
 ```
 
 Validate a mapping using this Pydantic model.
@@ -841,7 +993,7 @@ Validate a mapping using this Pydantic model.
 ### <kbd>method</kbd> `to_mapping`
 
 ```python
-to_mapping() → dict[str, Any]
+def to_mapping() -> dict[str, Any]
 ```
 
 Return a detached JSON-compatible mapping for Rust/core calls.
@@ -851,8 +1003,26 @@ Return a detached JSON-compatible mapping for Rust/core calls.
 
 
 ## <kbd>class</kbd> `RelayS3StorageConfig`
+
 NeMo Relay ATIF S3 storage configuration.
 
+
+
+### Fields
+
+The model defines the following fields:
+
+| Field | Type | Required | Default | Constraints | Description |
+| --- | --- | --- | --- | --- | --- |
+| `type` | `Literal['s3']` | No | `'s3'` | — | — |
+| `bucket` | `str` | No | `''` | — | — |
+| `key_prefix` | `str \| None` | No | `None` | — | — |
+| `access_key_id` | `str \| None` | No | `None` | — | — |
+| `secret_access_key_var` | `str \| None` | No | `None` | — | — |
+| `session_token_var` | `str \| None` | No | `None` | — | — |
+| `region` | `str \| None` | No | `None` | — | — |
+| `endpoint_url` | `str \| None` | No | `None` | — | — |
+| `allow_http` | `bool \| None` | No | `None` | — | — |
 
 ---
 
@@ -890,7 +1060,7 @@ Returns the set of fields that have been explicitly set on this model instance.
 ### <kbd>classmethod</kbd> `from_mapping`
 
 ```python
-from_mapping(value: 'Mapping[str, Any]') → Self
+def from_mapping(value: Mapping[str, Any]) -> Self
 ```
 
 Validate a mapping using this Pydantic model.
@@ -901,7 +1071,7 @@ Validate a mapping using this Pydantic model.
 ### <kbd>method</kbd> `to_mapping`
 
 ```python
-to_mapping() → dict[str, Any]
+def to_mapping() -> dict[str, Any]
 ```
 
 Return a detached JSON-compatible mapping for Rust/core calls.
@@ -911,8 +1081,22 @@ Return a detached JSON-compatible mapping for Rust/core calls.
 
 
 ## <kbd>class</kbd> `RelayHttpStorageConfig`
+
 NeMo Relay ATIF HTTP storage configuration.
 
+
+
+### Fields
+
+The model defines the following fields:
+
+| Field | Type | Required | Default | Constraints | Description |
+| --- | --- | --- | --- | --- | --- |
+| `type` | `Literal['http']` | No | `'http'` | — | — |
+| `endpoint` | `str` | No | `''` | — | — |
+| `headers` | `dict[str, str]` | No | `dict()` | — | — |
+| `header_env` | `dict[str, str]` | No | `dict()` | — | — |
+| `timeout_millis` | `int` | No | `3000` | — | — |
 
 ---
 
@@ -950,7 +1134,7 @@ Returns the set of fields that have been explicitly set on this model instance.
 ### <kbd>classmethod</kbd> `from_mapping`
 
 ```python
-from_mapping(value: 'Mapping[str, Any]') → Self
+def from_mapping(value: Mapping[str, Any]) -> Self
 ```
 
 Validate a mapping using this Pydantic model.
@@ -961,7 +1145,7 @@ Validate a mapping using this Pydantic model.
 ### <kbd>method</kbd> `to_mapping`
 
 ```python
-to_mapping() → dict[str, Any]
+def to_mapping() -> dict[str, Any]
 ```
 
 Return a detached JSON-compatible mapping for Rust/core calls.
@@ -971,8 +1155,26 @@ Return a detached JSON-compatible mapping for Rust/core calls.
 
 
 ## <kbd>class</kbd> `RelayAtifConfig`
+
 NeMo Relay ATIF export configuration.
 
+
+
+### Fields
+
+The model defines the following fields:
+
+| Field | Type | Required | Default | Constraints | Description |
+| --- | --- | --- | --- | --- | --- |
+| `enabled` | `bool` | No | `False` | — | — |
+| `agent_name` | `str` | No | `'NeMo Relay'` | — | — |
+| `agent_version` | `str \| None` | No | `None` | — | — |
+| `model_name` | `str` | No | `'unknown'` | — | — |
+| `tool_definitions` | `list[dict[str, Any]] \| None` | No | `None` | — | — |
+| `extra` | `dict[str, Any] \| None` | No | `None` | — | — |
+| `output_directory` | `str \| Path \| None` | No | `None` | — | — |
+| `filename_template` | `str` | No | `'nemo-relay-atif-{session_id}.json'` | — | — |
+| `storage` | `list[Annotated[RelayS3StorageConfig \| RelayHttpStorageConfig, Field(discriminator='type')] \| dict[str, Any]] \| None` | No | `None` | — | — |
 
 ---
 
@@ -1010,7 +1212,7 @@ Returns the set of fields that have been explicitly set on this model instance.
 ### <kbd>classmethod</kbd> `from_mapping`
 
 ```python
-from_mapping(value: 'Mapping[str, Any]') → Self
+def from_mapping(value: Mapping[str, Any]) -> Self
 ```
 
 Validate a mapping using this Pydantic model.
@@ -1021,7 +1223,7 @@ Validate a mapping using this Pydantic model.
 ### <kbd>method</kbd> `to_mapping`
 
 ```python
-to_mapping() → dict[str, Any]
+def to_mapping() -> dict[str, Any]
 ```
 
 Return a detached JSON-compatible mapping for Rust/core calls.
@@ -1031,8 +1233,27 @@ Return a detached JSON-compatible mapping for Rust/core calls.
 
 
 ## <kbd>class</kbd> `RelayOtlpConfig`
+
 NeMo Relay OTLP export configuration for OpenTelemetry/OpenInference.
 
+
+
+### Fields
+
+The model defines the following fields:
+
+| Field | Type | Required | Default | Constraints | Description |
+| --- | --- | --- | --- | --- | --- |
+| `enabled` | `bool` | No | `False` | — | — |
+| `transport` | `Literal['http_binary', 'grpc']` | No | `'http_binary'` | — | — |
+| `endpoint` | `str \| None` | No | `None` | — | — |
+| `headers` | `dict[str, str]` | No | `dict()` | — | — |
+| `resource_attributes` | `dict[str, str]` | No | `dict()` | — | — |
+| `service_name` | `str` | No | `'nemo-relay'` | — | — |
+| `service_namespace` | `str \| None` | No | `None` | — | — |
+| `service_version` | `str \| None` | No | `None` | — | — |
+| `instrumentation_scope` | `str \| None` | No | `None` | — | — |
+| `timeout_millis` | `int` | No | `3000` | — | — |
 
 ---
 
@@ -1070,7 +1291,7 @@ Returns the set of fields that have been explicitly set on this model instance.
 ### <kbd>classmethod</kbd> `from_mapping`
 
 ```python
-from_mapping(value: 'Mapping[str, Any]') → Self
+def from_mapping(value: Mapping[str, Any]) -> Self
 ```
 
 Validate a mapping using this Pydantic model.
@@ -1081,7 +1302,7 @@ Validate a mapping using this Pydantic model.
 ### <kbd>method</kbd> `to_mapping`
 
 ```python
-to_mapping() → dict[str, Any]
+def to_mapping() -> dict[str, Any]
 ```
 
 Return a detached JSON-compatible mapping for Rust/core calls.
@@ -1091,8 +1312,23 @@ Return a detached JSON-compatible mapping for Rust/core calls.
 
 
 ## <kbd>class</kbd> `RelayObservabilityConfig`
+
 NeMo Relay observability component configuration.
 
+
+
+### Fields
+
+The model defines the following fields:
+
+| Field | Type | Required | Default | Constraints | Description |
+| --- | --- | --- | --- | --- | --- |
+| `version` | `int` | No | `2` | — | — |
+| `atof` | `RelayAtofConfig \| dict[str, Any] \| None` | No | `None` | — | — |
+| `atif` | `RelayAtifConfig \| dict[str, Any] \| None` | No | `None` | — | — |
+| `opentelemetry` | `RelayOtlpConfig \| dict[str, Any] \| None` | No | `None` | — | — |
+| `openinference` | `RelayOtlpConfig \| dict[str, Any] \| None` | No | `None` | — | — |
+| `policy` | `RelayConfigPolicy \| dict[str, Any] \| None` | No | `None` | — | — |
 
 ---
 
@@ -1130,7 +1366,7 @@ Returns the set of fields that have been explicitly set on this model instance.
 ### <kbd>classmethod</kbd> `from_mapping`
 
 ```python
-from_mapping(value: 'Mapping[str, Any]') → Self
+def from_mapping(value: Mapping[str, Any]) -> Self
 ```
 
 Validate a mapping using this Pydantic model.
@@ -1141,7 +1377,7 @@ Validate a mapping using this Pydantic model.
 ### <kbd>method</kbd> `to_mapping`
 
 ```python
-to_mapping() → dict[str, Any]
+def to_mapping() -> dict[str, Any]
 ```
 
 Return a detached JSON-compatible mapping for Rust/core calls.
@@ -1151,8 +1387,20 @@ Return a detached JSON-compatible mapping for Rust/core calls.
 
 
 ## <kbd>class</kbd> `RelayComponentConfig`
+
 Generic NeMo Relay plugin component configuration.
 
+
+
+### Fields
+
+The model defines the following fields:
+
+| Field | Type | Required | Default | Constraints | Description |
+| --- | --- | --- | --- | --- | --- |
+| `kind` | `str` | Yes | — | `MinLen(min_length=1)` | — |
+| `enabled` | `bool` | No | `True` | — | — |
+| `config` | `dict[str, Any]` | No | `dict()` | — | — |
 
 ---
 
@@ -1190,7 +1438,7 @@ Returns the set of fields that have been explicitly set on this model instance.
 ### <kbd>classmethod</kbd> `from_mapping`
 
 ```python
-from_mapping(value: 'Mapping[str, Any]') → Self
+def from_mapping(value: Mapping[str, Any]) -> Self
 ```
 
 Validate a mapping using this Pydantic model.
@@ -1201,7 +1449,7 @@ Validate a mapping using this Pydantic model.
 ### <kbd>method</kbd> `to_mapping`
 
 ```python
-to_mapping() → dict[str, Any]
+def to_mapping() -> dict[str, Any]
 ```
 
 Return a detached JSON-compatible mapping for Rust/core calls.
@@ -1211,8 +1459,22 @@ Return a detached JSON-compatible mapping for Rust/core calls.
 
 
 ## <kbd>class</kbd> `RelayConfig`
+
 First-class NeMo Relay integration configuration.
 
+
+
+### Fields
+
+The model defines the following fields:
+
+| Field | Type | Required | Default | Constraints | Description |
+| --- | --- | --- | --- | --- | --- |
+| `project` | `str \| None` | No | `None` | — | — |
+| `output_dir` | `str \| Path \| None` | No | `None` | — | — |
+| `observability` | `RelayObservabilityConfig \| dict[str, Any] \| None` | No | `None` | — | — |
+| `components` | `list[RelayComponentConfig \| dict[str, Any]]` | No | `list()` | — | — |
+| `policy` | `RelayConfigPolicy \| dict[str, Any] \| None` | No | `None` | — | — |
 
 ---
 
@@ -1250,7 +1512,7 @@ Returns the set of fields that have been explicitly set on this model instance.
 ### <kbd>classmethod</kbd> `from_mapping`
 
 ```python
-from_mapping(value: 'Mapping[str, Any]') → Self
+def from_mapping(value: Mapping[str, Any]) -> Self
 ```
 
 Validate a mapping using this Pydantic model.
@@ -1261,7 +1523,7 @@ Validate a mapping using this Pydantic model.
 ### <kbd>method</kbd> `to_mapping`
 
 ```python
-to_mapping() → dict[str, Any]
+def to_mapping() -> dict[str, Any]
 ```
 
 Return a detached JSON-compatible mapping for Rust/core calls.
@@ -1271,8 +1533,18 @@ Return a detached JSON-compatible mapping for Rust/core calls.
 
 
 ## <kbd>class</kbd> `TelemetryProviderConfig`
+
 Provider-specific telemetry configuration.
 
+
+
+### Fields
+
+The model defines the following fields:
+
+| Field | Type | Required | Default | Constraints | Description |
+| --- | --- | --- | --- | --- | --- |
+| `config` | `dict[str, Any] \| None` | No | `None` | — | — |
 
 ---
 
@@ -1310,7 +1582,7 @@ Returns the set of fields that have been explicitly set on this model instance.
 ### <kbd>classmethod</kbd> `from_mapping`
 
 ```python
-from_mapping(value: 'Mapping[str, Any]') → Self
+def from_mapping(value: Mapping[str, Any]) -> Self
 ```
 
 Validate a mapping using this Pydantic model.
@@ -1321,7 +1593,7 @@ Validate a mapping using this Pydantic model.
 ### <kbd>method</kbd> `to_mapping`
 
 ```python
-to_mapping() → dict[str, Any]
+def to_mapping() -> dict[str, Any]
 ```
 
 Return a detached JSON-compatible mapping for Rust/core calls.
@@ -1331,8 +1603,18 @@ Return a detached JSON-compatible mapping for Rust/core calls.
 
 
 ## <kbd>class</kbd> `TelemetryConfig`
+
 Telemetry configuration.
 
+
+
+### Fields
+
+The model defines the following fields:
+
+| Field | Type | Required | Default | Constraints | Description |
+| --- | --- | --- | --- | --- | --- |
+| `providers` | `dict[Literal['relay', 'native'], TelemetryProviderConfig \| dict[str, Any]]` | No | `dict()` | — | — |
 
 ---
 
@@ -1370,7 +1652,7 @@ Returns the set of fields that have been explicitly set on this model instance.
 ### <kbd>method</kbd> `enable_native`
 
 ```python
-enable_native(config: 'Mapping[str, Any] | None' = None) → Self
+def enable_native(*, config: Mapping[str, Any] | None = None) -> Self
 ```
 
 Let the selected adapter handle telemetry natively.
@@ -1381,7 +1663,7 @@ Let the selected adapter handle telemetry natively.
 ### <kbd>method</kbd> `enable_relay`
 
 ```python
-enable_relay() → Self
+def enable_relay() -> Self
 ```
 
 Enable NeMo Relay telemetry for subsequently started runtimes.
@@ -1392,7 +1674,7 @@ Enable NeMo Relay telemetry for subsequently started runtimes.
 ### <kbd>classmethod</kbd> `from_mapping`
 
 ```python
-from_mapping(value: 'Mapping[str, Any]') → Self
+def from_mapping(value: Mapping[str, Any]) -> Self
 ```
 
 Validate a mapping using this Pydantic model.
@@ -1403,7 +1685,7 @@ Validate a mapping using this Pydantic model.
 ### <kbd>method</kbd> `remove_provider`
 
 ```python
-remove_provider(provider: "Literal['relay', 'native']") → Self
+def remove_provider(provider: Literal['relay', 'native']) -> Self
 ```
 
 Remove a configured telemetry provider.
@@ -1414,7 +1696,7 @@ Remove a configured telemetry provider.
 ### <kbd>method</kbd> `to_mapping`
 
 ```python
-to_mapping() → dict[str, Any]
+def to_mapping() -> dict[str, Any]
 ```
 
 Return a detached JSON-compatible mapping for Rust/core calls.
@@ -1427,6 +1709,15 @@ Return a detached JSON-compatible mapping for Rust/core calls.
 
 Harness-neutral tool capability configuration.
 
+
+
+### Fields
+
+The model defines the following fields:
+
+| Field | Type | Required | Default | Constraints | Description |
+| --- | --- | --- | --- | --- | --- |
+| `blocked` | `list[str]` | No | `list()` | — | — |
 
 ---
 
@@ -1464,7 +1755,7 @@ Returns the set of fields that have been explicitly set on this model instance.
 ### <kbd>classmethod</kbd> `from_mapping`
 
 ```python
-from_mapping(value: 'Mapping[str, Any]') → Self
+def from_mapping(value: Mapping[str, Any]) -> Self
 ```
 
 Validate a mapping using this Pydantic model.
@@ -1475,7 +1766,7 @@ Validate a mapping using this Pydantic model.
 ### <kbd>method</kbd> `to_mapping`
 
 ```python
-to_mapping() → dict[str, Any]
+def to_mapping() -> dict[str, Any]
 ```
 
 Return a detached JSON-compatible mapping for Rust/core calls.
@@ -1485,8 +1776,28 @@ Return a detached JSON-compatible mapping for Rust/core calls.
 
 
 ## <kbd>class</kbd> `FabricConfig`
+
 SDK-facing typed NeMo Fabric agent configuration.
 
+
+
+### Fields
+
+The model defines the following fields:
+
+| Field | Type | Required | Default | Constraints | Description |
+| --- | --- | --- | --- | --- | --- |
+| `schema_version` | `str` | No | `'fabric.agent/v1alpha1'` | — | — |
+| `metadata` | `MetadataConfig` | Yes | — | — | — |
+| `harness` | `HarnessConfig` | Yes | — | — | — |
+| `runtime` | `RuntimeConfig` | No | `RuntimeConfig()` | — | — |
+| `environment` | `EnvironmentConfig \| None` | No | `None` | — | — |
+| `models` | `dict[str, ModelConfig \| dict[str, Any]]` | No | `dict()` | — | — |
+| `mcp` | `McpConfig \| None` | No | `None` | — | — |
+| `skills` | `SkillConfig \| None` | No | `None` | — | — |
+| `telemetry` | `TelemetryConfig \| None` | No | `None` | — | — |
+| `relay` | `RelayConfig \| dict[str, Any] \| None` | No | `None` | — | — |
+| `tools` | `ToolsConfig \| dict[str, Any] \| None` | No | `None` | — | — |
 
 ---
 
@@ -1524,13 +1835,14 @@ Returns the set of fields that have been explicitly set on this model instance.
 ### <kbd>method</kbd> `add_mcp_server`
 
 ```python
-add_mcp_server(
-    name: 'str',
-    transport: 'str',
-    url: 'str',
-    exposure: "Literal['harness_native', 'fabric_managed']" = 'harness_native',
-    extra_fields: 'Mapping[str, Any] | None' = None
-) → Self
+def add_mcp_server(
+    name: str,
+    *,
+    transport: str,
+    url: str,
+    exposure: Literal['harness_native', 'fabric_managed'] = 'harness_native',
+    extra_fields: Mapping[str, Any] | None = None,
+) -> Self
 ```
 
 Add or replace a named MCP server and return this config.
@@ -1541,7 +1853,7 @@ Add or replace a named MCP server and return this config.
 ### <kbd>method</kbd> `add_skill_path`
 
 ```python
-add_skill_path(path: 'str | Path') → Self
+def add_skill_path(path: str | Path) -> Self
 ```
 
 Add a skill path and return this config.
@@ -1552,7 +1864,7 @@ Add a skill path and return this config.
 ### <kbd>method</kbd> `block_tools`
 
 ```python
-block_tools(*tools: 'str') → Self
+def block_tools(*tools: str) -> Self
 ```
 
 Block adapter-native tool names or toolsets and return this config.
@@ -1563,13 +1875,14 @@ Block adapter-native tool names or toolsets and return this config.
 ### <kbd>method</kbd> `enable_relay`
 
 ```python
-enable_relay(
-    project: 'str | None' = None,
-    output_dir: 'str | Path | None' = None,
-    observability: 'RelayObservabilityConfig | Mapping[str, Any] | None' = None,
-    components: 'Sequence[RelayComponentConfig | Mapping[str, Any]] | None' = None,
-    policy: 'RelayConfigPolicy | Mapping[str, Any] | None' = None
-) → Self
+def enable_relay(
+    *,
+    project: str | None = None,
+    output_dir: str | Path | None = None,
+    observability: RelayObservabilityConfig | Mapping[str, Any] | None = None,
+    components: Sequence[RelayComponentConfig | Mapping[str, Any]] | None = None,
+    policy: RelayConfigPolicy | Mapping[str, Any] | None = None,
+) -> Self
 ```
 
 Enable NeMo Relay telemetry and return this config.
@@ -1580,7 +1893,7 @@ Enable NeMo Relay telemetry and return this config.
 ### <kbd>classmethod</kbd> `from_mapping`
 
 ```python
-from_mapping(value: 'Mapping[str, Any]') → Self
+def from_mapping(value: Mapping[str, Any]) -> Self
 ```
 
 Validate the public agent config mapping shape.
@@ -1591,7 +1904,7 @@ Validate the public agent config mapping shape.
 ### <kbd>method</kbd> `remove_mcp_server`
 
 ```python
-remove_mcp_server(name: 'str') → Self
+def remove_mcp_server(name: str) -> Self
 ```
 
 Remove a named MCP server and return this config.
@@ -1602,7 +1915,7 @@ Remove a named MCP server and return this config.
 ### <kbd>method</kbd> `remove_skill_path`
 
 ```python
-remove_skill_path(path: 'str | Path') → Self
+def remove_skill_path(path: str | Path) -> Self
 ```
 
 Remove a skill path and return this config.
@@ -1613,7 +1926,7 @@ Remove a skill path and return this config.
 ### <kbd>method</kbd> `to_mapping`
 
 ```python
-to_mapping() → dict[str, Any]
+def to_mapping() -> dict[str, Any]
 ```
 
 Return a detached mapping matching the Rust ``FabricConfig`` schema.
@@ -1623,8 +1936,21 @@ Return a detached mapping matching the Rust ``FabricConfig`` schema.
 
 
 ## <kbd>class</kbd> `RunRequest`
+
 One validated NeMo Fabric invocation request.
 
+
+
+### Fields
+
+The model defines the following fields:
+
+| Field | Type | Required | Default | Constraints | Description |
+| --- | --- | --- | --- | --- | --- |
+| `input` | `Any` | No | `''` | — | — |
+| `request_id` | `str` | No | `<generated>` | `MinLen(min_length=1)` | — |
+| `context` | `dict[str, Any]` | No | `dict()` | — | — |
+| `overrides` | `dict[str, Any] \| None` | No | `None` | — | — |
 
 ---
 
@@ -1662,7 +1988,7 @@ Returns the set of fields that have been explicitly set on this model instance.
 ### <kbd>classmethod</kbd> `from_mapping`
 
 ```python
-from_mapping(value: 'Mapping[str, Any]') → Self
+def from_mapping(value: Mapping[str, Any]) -> Self
 ```
 
 Validate a mapping using this Pydantic model.
@@ -1673,7 +1999,7 @@ Validate a mapping using this Pydantic model.
 ### <kbd>method</kbd> `to_mapping`
 
 ```python
-to_mapping() → dict[str, Any]
+def to_mapping() -> dict[str, Any]
 ```
 
 Return a detached request mapping for the Rust runtime.

--- a/docs/reference/api/python-library-reference/nemo_fabric.runtime.md
+++ b/docs/reference/api/python-library-reference/nemo_fabric.runtime.md
@@ -7,6 +7,7 @@ description: "Drive stateful multi-turn execution through the Runtime API."
 SPDX-License-Identifier: Apache-2.0 -->
 
 # <kbd>module</kbd> `nemo_fabric.runtime`
+
 Runtime lifecycle support for the NVIDIA NeMo Fabric Python SDK.
 
 
@@ -15,6 +16,7 @@ Runtime lifecycle support for the NVIDIA NeMo Fabric Python SDK.
 
 
 ## <kbd>class</kbd> `RuntimeStatus`
+
 Lifecycle state of a runtime.
 
 ``ACTIVE`` accepts invocations, ``STOPPED`` has released its runtime, and ``FAILED`` records a lifecycle failure that prevents further invocations but still permits cleanup.
@@ -23,10 +25,26 @@ Lifecycle state of a runtime.
 
 
 
+
+### Inheritance
+
+Direct bases: `str`, `Enum`.
+
+### Values
+
+The enum defines the following values:
+
+| Name | Value |
+| --- | --- |
+| `ACTIVE` | `active` |
+| `STOPPED` | `stopped` |
+| `FAILED` | `failed` |
+
 ---
 
 
 ## <kbd>class</kbd> `Runtime`
+
 One logical, stateful harness execution.
 
 Create runtimes with ``Fabric.start_runtime()`` rather than calling the constructor. A runtime serializes invocations and preserves adapter-owned harness state across turns. Use it as an asynchronous context manager to stop the runtime on exit.
@@ -78,7 +96,7 @@ Return whether NVIDIA NeMo Relay ATOF streaming is enabled.
 ### <kbd>method</kbd> `invoke`
 
 ```python
-invoke(input: 'Any' = None, request: 'RunRequest | None' = None) → RunResult
+async def invoke(*, input: Any = None, request: RunRequest | None = None) -> RunResult
 ```
 
 Run one turn on this runtime.
@@ -112,10 +130,11 @@ Run one turn on this runtime.
 ### <kbd>method</kbd> `invoke_stream`
 
 ```python
-invoke_stream(
-    input: 'Any' = None,
-    request: 'RunRequest | None' = None
-) → InvokeStream
+def invoke_stream(
+    *,
+    input: Any = None,
+    request: RunRequest | None = None,
+) -> InvokeStream
 ```
 
 Start one turn and stream raw NeMo Relay ATOF records as they arrive.
@@ -136,7 +155,7 @@ Start one turn and stream raw NeMo Relay ATOF records as they arrive.
 ### <kbd>method</kbd> `stop`
 
 ```python
-stop() → None
+async def stop() -> None
 ```
 
 Destroy an idle runtime exactly once.

--- a/docs/reference/api/python-library-reference/nemo_fabric.streaming.md
+++ b/docs/reference/api/python-library-reference/nemo_fabric.streaming.md
@@ -7,6 +7,7 @@ description: "Consume raw NVIDIA NeMo Relay ATOF records and terminal invocation
 SPDX-License-Identifier: Apache-2.0 -->
 
 # <kbd>module</kbd> `nemo_fabric.streaming`
+
 NeMo Relay streaming support for the NVIDIA NeMo Fabric Python SDK.
 
 
@@ -15,6 +16,7 @@ NeMo Relay streaming support for the NVIDIA NeMo Fabric Python SDK.
 
 
 ## <kbd>class</kbd> `InvokeStream`
+
 Async iterator of raw ATOF records for one runtime invocation.
 
 Consume the final normalized result separately with :meth:`result`. If iteration stops early, call :meth:`aclose` before starting another turn.
@@ -28,7 +30,7 @@ Consume the final normalized result separately with :meth:`result`. If iteration
 ### <kbd>method</kbd> `aclose`
 
 ```python
-async def aclose() → None
+async def aclose() -> None
 ```
 
 Stop iteration and drain this turn without cancelling the invocation.
@@ -39,7 +41,7 @@ Stop iteration and drain this turn without cancelling the invocation.
 ### <kbd>method</kbd> `result`
 
 ```python
-async def result() → RunResult
+async def result() -> RunResult
 ```
 
 Return the terminal normalized result without adding it to the stream.

--- a/docs/reference/api/python-library-reference/nemo_fabric.types.md
+++ b/docs/reference/api/python-library-reference/nemo_fabric.types.md
@@ -7,6 +7,7 @@ description: "Typed config, request, plan, result, artifact, telemetry, and runt
 SPDX-License-Identifier: Apache-2.0 -->
 
 # <kbd>module</kbd> `nemo_fabric.types`
+
 Public data contracts for the NeMo Fabric Python SDK.
 
 
@@ -15,6 +16,7 @@ Public data contracts for the NeMo Fabric Python SDK.
 
 
 ## <kbd>class</kbd> `AdapterInfo`
+
 Resolved adapter identity attached to a run plan.
 
 
@@ -27,10 +29,22 @@ Resolved adapter identity attached to a run plan.
  - <b>`metadata`</b>:  Adapter-specific, JSON-compatible metadata.
 
 
+
+### Fields
+
+The mapping exposes the following typed fields:
+
+| Field | Type |
+| --- | --- |
+| `adapter_id` | `str` |
+| `harness` | `str` |
+| `adapter_kind` | `str` |
+| `metadata` | `Mapping[str, Any]` |
+
 ### <kbd>method</kbd> `__init__`
 
 ```python
-__init__(mapping: 'Mapping[str, Any]') → None
+def __init__(mapping: Mapping[str, Any]) -> None
 ```
 
 
@@ -52,7 +66,7 @@ Return an immutable view of preserved extension fields.
 ### <kbd>classmethod</kbd> `from_mapping`
 
 ```python
-from_mapping(mapping: 'Mapping[str, Any]') → 'FabricMapping'
+def from_mapping(mapping: Mapping[str, Any]) -> Self
 ```
 
 Validate and copy a mapping into the requested typed model.
@@ -63,7 +77,7 @@ Validate and copy a mapping into the requested typed model.
 ### <kbd>method</kbd> `to_dict`
 
 ```python
-to_dict() → dict[str, Any]
+def to_dict() -> dict[str, Any]
 ```
 
 Return the same detached representation as ``to_mapping()``.
@@ -74,7 +88,7 @@ Return the same detached representation as ``to_mapping()``.
 ### <kbd>method</kbd> `to_mapping`
 
 ```python
-to_mapping() → dict[str, Any]
+def to_mapping() -> dict[str, Any]
 ```
 
 Return a detached, JSON-compatible mapping for serialization.
@@ -84,6 +98,7 @@ Return a detached, JSON-compatible mapping for serialization.
 
 
 ## <kbd>class</kbd> `RuntimeCapabilities`
+
 Operations declared by the resolved runtime and adapter.
 
 Capabilities describe what the selected runtime can support; callers should still expect a capability-specific error when a transport is modeled but not implemented.
@@ -99,10 +114,23 @@ Capabilities describe what the selected runtime can support; callers should stil
  - <b>`metadata`</b>:  Additional capability details.
 
 
+
+### Fields
+
+The mapping exposes the following typed fields:
+
+| Field | Type |
+| --- | --- |
+| `service` | `bool` |
+| `streaming` | `bool` |
+| `updates` | `bool` |
+| `cancellation` | `bool` |
+| `metadata` | `Mapping[str, Any]` |
+
 ### <kbd>method</kbd> `__init__`
 
 ```python
-__init__(mapping: 'Mapping[str, Any]') → None
+def __init__(mapping: Mapping[str, Any]) -> None
 ```
 
 
@@ -124,7 +152,7 @@ Return an immutable view of preserved extension fields.
 ### <kbd>classmethod</kbd> `from_mapping`
 
 ```python
-from_mapping(mapping: 'Mapping[str, Any]') → 'FabricMapping'
+def from_mapping(mapping: Mapping[str, Any]) -> Self
 ```
 
 Validate and copy a mapping into the requested typed model.
@@ -135,7 +163,7 @@ Validate and copy a mapping into the requested typed model.
 ### <kbd>method</kbd> `to_dict`
 
 ```python
-to_dict() → dict[str, Any]
+def to_dict() -> dict[str, Any]
 ```
 
 Return the same detached representation as ``to_mapping()``.
@@ -146,7 +174,7 @@ Return the same detached representation as ``to_mapping()``.
 ### <kbd>method</kbd> `to_mapping`
 
 ```python
-to_mapping() → dict[str, Any]
+def to_mapping() -> dict[str, Any]
 ```
 
 Return a detached, JSON-compatible mapping for serialization.
@@ -156,6 +184,7 @@ Return a detached, JSON-compatible mapping for serialization.
 
 
 ## <kbd>class</kbd> `RunPlan`
+
 Immutable execution plan produced before a runtime is started.
 
 
@@ -169,10 +198,23 @@ Immutable execution plan produced before a runtime is started.
  - <b>`capabilities`</b>:  Operations declared by the resolved runtime.
 
 
+
+### Fields
+
+The mapping exposes the following typed fields:
+
+| Field | Type |
+| --- | --- |
+| `agent_name` | `str` |
+| `base_dir` | `Path` |
+| `config` | `_FabricConfigSnapshot` |
+| `adapter` | `AdapterInfo` |
+| `capabilities` | `RuntimeCapabilities` |
+
 ### <kbd>method</kbd> `__init__`
 
 ```python
-__init__(mapping: 'Mapping[str, Any]') → None
+def __init__(mapping: Mapping[str, Any]) -> None
 ```
 
 
@@ -194,7 +236,7 @@ Return an immutable view of preserved extension fields.
 ### <kbd>classmethod</kbd> `from_mapping`
 
 ```python
-from_mapping(mapping: 'Mapping[str, Any]') → 'FabricMapping'
+def from_mapping(mapping: Mapping[str, Any]) -> Self
 ```
 
 Validate and copy a mapping into the requested typed model.
@@ -205,7 +247,7 @@ Validate and copy a mapping into the requested typed model.
 ### <kbd>method</kbd> `to_dict`
 
 ```python
-to_dict() → dict[str, Any]
+def to_dict() -> dict[str, Any]
 ```
 
 Return the same detached representation as ``to_mapping()``.
@@ -216,7 +258,7 @@ Return the same detached representation as ``to_mapping()``.
 ### <kbd>method</kbd> `to_mapping`
 
 ```python
-to_mapping() → dict[str, Any]
+def to_mapping() -> dict[str, Any]
 ```
 
 Return a detached, JSON-compatible mapping for serialization.
@@ -226,6 +268,7 @@ Return a detached, JSON-compatible mapping for serialization.
 
 
 ## <kbd>class</kbd> `DoctorCheck`
+
 One diagnostic check in a ``DoctorReport``.
 
 
@@ -238,10 +281,22 @@ One diagnostic check in a ``DoctorReport``.
  - <b>`metadata`</b>:  Structured check details.
 
 
+
+### Fields
+
+The mapping exposes the following typed fields:
+
+| Field | Type |
+| --- | --- |
+| `name` | `str` |
+| `status` | `str` |
+| `message` | `str` |
+| `metadata` | `Mapping[str, Any]` |
+
 ### <kbd>method</kbd> `__init__`
 
 ```python
-__init__(mapping: 'Mapping[str, Any]') → None
+def __init__(mapping: Mapping[str, Any]) -> None
 ```
 
 
@@ -263,7 +318,7 @@ Return an immutable view of preserved extension fields.
 ### <kbd>classmethod</kbd> `from_mapping`
 
 ```python
-from_mapping(mapping: 'Mapping[str, Any]') → 'FabricMapping'
+def from_mapping(mapping: Mapping[str, Any]) -> Self
 ```
 
 Validate and copy a mapping into the requested typed model.
@@ -274,7 +329,7 @@ Validate and copy a mapping into the requested typed model.
 ### <kbd>method</kbd> `to_dict`
 
 ```python
-to_dict() → dict[str, Any]
+def to_dict() -> dict[str, Any]
 ```
 
 Return the same detached representation as ``to_mapping()``.
@@ -285,7 +340,7 @@ Return the same detached representation as ``to_mapping()``.
 ### <kbd>method</kbd> `to_mapping`
 
 ```python
-to_mapping() → dict[str, Any]
+def to_mapping() -> dict[str, Any]
 ```
 
 Return a detached, JSON-compatible mapping for serialization.
@@ -295,6 +350,7 @@ Return a detached, JSON-compatible mapping for serialization.
 
 
 ## <kbd>class</kbd> `DoctorReport`
+
 Aggregate preflight diagnostics for a resolved run plan.
 
 
@@ -306,10 +362,21 @@ Aggregate preflight diagnostics for a resolved run plan.
  - <b>`checks`</b>:  Ordered ``DoctorCheck`` results.
 
 
+
+### Fields
+
+The mapping exposes the following typed fields:
+
+| Field | Type |
+| --- | --- |
+| `agent_name` | `str` |
+| `status` | `str` |
+| `checks` | `Sequence[DoctorCheck]` |
+
 ### <kbd>method</kbd> `__init__`
 
 ```python
-__init__(mapping: 'Mapping[str, Any]') → None
+def __init__(mapping: Mapping[str, Any]) -> None
 ```
 
 
@@ -331,7 +398,7 @@ Return an immutable view of preserved extension fields.
 ### <kbd>classmethod</kbd> `from_mapping`
 
 ```python
-from_mapping(mapping: 'Mapping[str, Any]') → 'FabricMapping'
+def from_mapping(mapping: Mapping[str, Any]) -> Self
 ```
 
 Validate and copy a mapping into the requested typed model.
@@ -342,7 +409,7 @@ Validate and copy a mapping into the requested typed model.
 ### <kbd>method</kbd> `to_dict`
 
 ```python
-to_dict() → dict[str, Any]
+def to_dict() -> dict[str, Any]
 ```
 
 Return the same detached representation as ``to_mapping()``.
@@ -353,7 +420,7 @@ Return the same detached representation as ``to_mapping()``.
 ### <kbd>method</kbd> `to_mapping`
 
 ```python
-to_mapping() → dict[str, Any]
+def to_mapping() -> dict[str, Any]
 ```
 
 Return a detached, JSON-compatible mapping for serialization.
@@ -363,6 +430,7 @@ Return a detached, JSON-compatible mapping for serialization.
 
 
 ## <kbd>class</kbd> `ErrorInfo`
+
 Structured failure returned inside a normalized ``RunResult``.
 
 
@@ -376,10 +444,23 @@ Structured failure returned inside a normalized ``RunResult``.
  - <b>`metadata`</b>:  Adapter- or runtime-specific details.
 
 
+
+### Fields
+
+The mapping exposes the following typed fields:
+
+| Field | Type |
+| --- | --- |
+| `stage` | `str` |
+| `code` | `str` |
+| `message` | `str` |
+| `retryable` | `bool` |
+| `metadata` | `Mapping[str, Any]` |
+
 ### <kbd>method</kbd> `__init__`
 
 ```python
-__init__(mapping: 'Mapping[str, Any]') → None
+def __init__(mapping: Mapping[str, Any]) -> None
 ```
 
 
@@ -401,7 +482,7 @@ Return an immutable view of preserved extension fields.
 ### <kbd>classmethod</kbd> `from_mapping`
 
 ```python
-from_mapping(mapping: 'Mapping[str, Any]') → 'FabricMapping'
+def from_mapping(mapping: Mapping[str, Any]) -> Self
 ```
 
 Validate and copy a mapping into the requested typed model.
@@ -412,7 +493,7 @@ Validate and copy a mapping into the requested typed model.
 ### <kbd>method</kbd> `to_dict`
 
 ```python
-to_dict() → dict[str, Any]
+def to_dict() -> dict[str, Any]
 ```
 
 Return the same detached representation as ``to_mapping()``.
@@ -423,7 +504,7 @@ Return the same detached representation as ``to_mapping()``.
 ### <kbd>method</kbd> `to_mapping`
 
 ```python
-to_mapping() → dict[str, Any]
+def to_mapping() -> dict[str, Any]
 ```
 
 Return a detached, JSON-compatible mapping for serialization.
@@ -433,6 +514,7 @@ Return a detached, JSON-compatible mapping for serialization.
 
 
 ## <kbd>class</kbd> `ArtifactRef`
+
 Reference to one artifact produced by a run.
 
 
@@ -446,10 +528,23 @@ Reference to one artifact produced by a run.
  - <b>`metadata`</b>:  Artifact-specific details.
 
 
+
+### Fields
+
+The mapping exposes the following typed fields:
+
+| Field | Type |
+| --- | --- |
+| `name` | `str` |
+| `kind` | `str` |
+| `path` | `Path` |
+| `media_type` | `str \| None` |
+| `metadata` | `Mapping[str, Any]` |
+
 ### <kbd>method</kbd> `__init__`
 
 ```python
-__init__(mapping: 'Mapping[str, Any]') → None
+def __init__(mapping: Mapping[str, Any]) -> None
 ```
 
 
@@ -471,7 +566,7 @@ Return an immutable view of preserved extension fields.
 ### <kbd>classmethod</kbd> `from_mapping`
 
 ```python
-from_mapping(mapping: 'Mapping[str, Any]') → 'FabricMapping'
+def from_mapping(mapping: Mapping[str, Any]) -> Self
 ```
 
 Validate and copy a mapping into the requested typed model.
@@ -482,7 +577,7 @@ Validate and copy a mapping into the requested typed model.
 ### <kbd>method</kbd> `to_dict`
 
 ```python
-to_dict() → dict[str, Any]
+def to_dict() -> dict[str, Any]
 ```
 
 Return the same detached representation as ``to_mapping()``.
@@ -493,7 +588,7 @@ Return the same detached representation as ``to_mapping()``.
 ### <kbd>method</kbd> `to_mapping`
 
 ```python
-to_mapping() → dict[str, Any]
+def to_mapping() -> dict[str, Any]
 ```
 
 Return a detached, JSON-compatible mapping for serialization.
@@ -503,6 +598,7 @@ Return a detached, JSON-compatible mapping for serialization.
 
 
 ## <kbd>class</kbd> `ArtifactManifest`
+
 Normalized collection of artifacts produced by a run.
 
 
@@ -513,10 +609,20 @@ Normalized collection of artifacts produced by a run.
  - <b>`artifacts`</b>:  Ordered ``ArtifactRef`` entries.
 
 
+
+### Fields
+
+The mapping exposes the following typed fields:
+
+| Field | Type |
+| --- | --- |
+| `root` | `Path \| None` |
+| `artifacts` | `Sequence[ArtifactRef]` |
+
 ### <kbd>method</kbd> `__init__`
 
 ```python
-__init__(mapping: 'Mapping[str, Any]') → None
+def __init__(mapping: Mapping[str, Any]) -> None
 ```
 
 
@@ -538,7 +644,7 @@ Return an immutable view of preserved extension fields.
 ### <kbd>classmethod</kbd> `from_mapping`
 
 ```python
-from_mapping(mapping: 'Mapping[str, Any]') → 'FabricMapping'
+def from_mapping(mapping: Mapping[str, Any]) -> Self
 ```
 
 Validate and copy a mapping into the requested typed model.
@@ -549,7 +655,7 @@ Validate and copy a mapping into the requested typed model.
 ### <kbd>method</kbd> `to_dict`
 
 ```python
-to_dict() → dict[str, Any]
+def to_dict() -> dict[str, Any]
 ```
 
 Return the same detached representation as ``to_mapping()``.
@@ -560,7 +666,7 @@ Return the same detached representation as ``to_mapping()``.
 ### <kbd>method</kbd> `to_mapping`
 
 ```python
-to_mapping() → dict[str, Any]
+def to_mapping() -> dict[str, Any]
 ```
 
 Return a detached, JSON-compatible mapping for serialization.
@@ -570,6 +676,7 @@ Return a detached, JSON-compatible mapping for serialization.
 
 
 ## <kbd>class</kbd> `TelemetryRef`
+
 Reference to external or persisted telemetry for a run.
 
 
@@ -583,10 +690,23 @@ Reference to external or persisted telemetry for a run.
  - <b>`metadata`</b>:  Provider-specific details.
 
 
+
+### Fields
+
+The mapping exposes the following typed fields:
+
+| Field | Type |
+| --- | --- |
+| `provider` | `str` |
+| `kind` | `str` |
+| `uri` | `str \| None` |
+| `trace_id` | `str \| None` |
+| `metadata` | `Mapping[str, Any]` |
+
 ### <kbd>method</kbd> `__init__`
 
 ```python
-__init__(mapping: 'Mapping[str, Any]') → None
+def __init__(mapping: Mapping[str, Any]) -> None
 ```
 
 
@@ -608,7 +728,7 @@ Return an immutable view of preserved extension fields.
 ### <kbd>classmethod</kbd> `from_mapping`
 
 ```python
-from_mapping(mapping: 'Mapping[str, Any]') → 'FabricMapping'
+def from_mapping(mapping: Mapping[str, Any]) -> Self
 ```
 
 Validate and copy a mapping into the requested typed model.
@@ -619,7 +739,7 @@ Validate and copy a mapping into the requested typed model.
 ### <kbd>method</kbd> `to_dict`
 
 ```python
-to_dict() → dict[str, Any]
+def to_dict() -> dict[str, Any]
 ```
 
 Return the same detached representation as ``to_mapping()``.
@@ -630,7 +750,7 @@ Return the same detached representation as ``to_mapping()``.
 ### <kbd>method</kbd> `to_mapping`
 
 ```python
-to_mapping() → dict[str, Any]
+def to_mapping() -> dict[str, Any]
 ```
 
 Return a detached, JSON-compatible mapping for serialization.
@@ -640,6 +760,7 @@ Return a detached, JSON-compatible mapping for serialization.
 
 
 ## <kbd>class</kbd> `FabricEvent`
+
 One normalized lifecycle or invocation event.
 
 
@@ -653,10 +774,23 @@ One normalized lifecycle or invocation event.
  - <b>`metadata`</b>:  Event-specific structured details.
 
 
+
+### Fields
+
+The mapping exposes the following typed fields:
+
+| Field | Type |
+| --- | --- |
+| `event_id` | `str` |
+| `timestamp_millis` | `int` |
+| `kind` | `str` |
+| `message` | `str` |
+| `metadata` | `Mapping[str, Any]` |
+
 ### <kbd>method</kbd> `__init__`
 
 ```python
-__init__(mapping: 'Mapping[str, Any]') → None
+def __init__(mapping: Mapping[str, Any]) -> None
 ```
 
 
@@ -678,7 +812,7 @@ Return an immutable view of preserved extension fields.
 ### <kbd>classmethod</kbd> `from_mapping`
 
 ```python
-from_mapping(mapping: 'Mapping[str, Any]') → 'FabricMapping'
+def from_mapping(mapping: Mapping[str, Any]) -> Self
 ```
 
 Validate and copy a mapping into the requested typed model.
@@ -689,7 +823,7 @@ Validate and copy a mapping into the requested typed model.
 ### <kbd>method</kbd> `to_dict`
 
 ```python
-to_dict() → dict[str, Any]
+def to_dict() -> dict[str, Any]
 ```
 
 Return the same detached representation as ``to_mapping()``.
@@ -700,7 +834,7 @@ Return the same detached representation as ``to_mapping()``.
 ### <kbd>method</kbd> `to_mapping`
 
 ```python
-to_mapping() → dict[str, Any]
+def to_mapping() -> dict[str, Any]
 ```
 
 Return a detached, JSON-compatible mapping for serialization.
@@ -710,6 +844,7 @@ Return a detached, JSON-compatible mapping for serialization.
 
 
 ## <kbd>class</kbd> `RuntimeHandle`
+
 Opaque identity and binding for one started runtime.
 
 Applications should treat ``runtime_binding`` as opaque. NeMo Fabric validates the handle against the run plan before invocation or shutdown.
@@ -727,10 +862,25 @@ Applications should treat ``runtime_binding`` as opaque. NeMo Fabric validates t
  - <b>`environment`</b>:  Prepared environment snapshot.
 
 
+
+### Fields
+
+The mapping exposes the following typed fields:
+
+| Field | Type |
+| --- | --- |
+| `runtime_id` | `str` |
+| `runtime_binding` | `str` |
+| `agent_name` | `str` |
+| `harness` | `str` |
+| `adapter_kind` | `str` |
+| `adapter_id` | `str \| None` |
+| `environment` | `Mapping[str, Any]` |
+
 ### <kbd>method</kbd> `__init__`
 
 ```python
-__init__(mapping: 'Mapping[str, Any]') → None
+def __init__(mapping: Mapping[str, Any]) -> None
 ```
 
 
@@ -752,7 +902,7 @@ Return an immutable view of preserved extension fields.
 ### <kbd>classmethod</kbd> `from_mapping`
 
 ```python
-from_mapping(mapping: 'Mapping[str, Any]') → 'FabricMapping'
+def from_mapping(mapping: Mapping[str, Any]) -> Self
 ```
 
 Validate and copy a mapping into the requested typed model.
@@ -763,7 +913,7 @@ Validate and copy a mapping into the requested typed model.
 ### <kbd>method</kbd> `to_dict`
 
 ```python
-to_dict() → dict[str, Any]
+def to_dict() -> dict[str, Any]
 ```
 
 Return the same detached representation as ``to_mapping()``.
@@ -774,7 +924,7 @@ Return the same detached representation as ``to_mapping()``.
 ### <kbd>method</kbd> `to_mapping`
 
 ```python
-to_mapping() → dict[str, Any]
+def to_mapping() -> dict[str, Any]
 ```
 
 Return a detached, JSON-compatible mapping for serialization.
@@ -784,15 +934,25 @@ Return a detached, JSON-compatible mapping for serialization.
 
 
 ## <kbd>class</kbd> `RunOutput`
+
 Normalized adapter output.
 
 ``response`` is a known adapter response field whose value follows the core NeMo Fabric JSON contract. Other keys are adapter-specific extensions.
 
 
+
+### Fields
+
+The mapping exposes the following typed fields:
+
+| Field | Type |
+| --- | --- |
+| `response` | `JSONValue \| None` |
+
 ### <kbd>method</kbd> `__init__`
 
 ```python
-__init__(mapping: 'Mapping[str, Any]') → None
+def __init__(mapping: Mapping[str, Any]) -> None
 ```
 
 
@@ -820,7 +980,7 @@ Return the raw ``response`` JSON value, or ``None`` when absent.
 ### <kbd>classmethod</kbd> `from_mapping`
 
 ```python
-from_mapping(mapping: 'Mapping[str, Any]') → 'FabricMapping'
+def from_mapping(mapping: Mapping[str, Any]) -> Self
 ```
 
 Validate and copy a mapping into the requested typed model.
@@ -831,7 +991,7 @@ Validate and copy a mapping into the requested typed model.
 ### <kbd>method</kbd> `to_dict`
 
 ```python
-to_dict() → dict[str, Any]
+def to_dict() -> dict[str, Any]
 ```
 
 Return the same detached representation as ``to_mapping()``.
@@ -842,7 +1002,7 @@ Return the same detached representation as ``to_mapping()``.
 ### <kbd>method</kbd> `to_mapping`
 
 ```python
-to_mapping() → dict[str, Any]
+def to_mapping() -> dict[str, Any]
 ```
 
 Return a detached, JSON-compatible mapping for serialization.
@@ -852,6 +1012,7 @@ Return a detached, JSON-compatible mapping for serialization.
 
 
 ## <kbd>class</kbd> `RunResult`
+
 Normalized terminal result from one NeMo Fabric invocation.
 
 The model is both attribute-accessible and mapping-compatible. A harness failure can be represented by ``status`` and ``error`` without raising when the adapter successfully returns a normalized result.
@@ -876,10 +1037,32 @@ The model is both attribute-accessible and mapping-compatible. A harness failure
  - <b>`metadata`</b>:  Result-specific structured details.
 
 
+
+### Fields
+
+The mapping exposes the following typed fields:
+
+| Field | Type |
+| --- | --- |
+| `agent_name` | `str` |
+| `harness` | `str` |
+| `adapter_kind` | `str` |
+| `adapter_id` | `str` |
+| `runtime_id` | `str` |
+| `invocation_id` | `str` |
+| `request_id` | `str` |
+| `status` | `str` |
+| `output` | `RunOutput \| JSONValue` |
+| `error` | `ErrorInfo \| None` |
+| `artifacts` | `ArtifactManifest` |
+| `telemetry` | `Sequence[TelemetryRef]` |
+| `events` | `Sequence[FabricEvent]` |
+| `metadata` | `Mapping[str, Any]` |
+
 ### <kbd>method</kbd> `__init__`
 
 ```python
-__init__(mapping: 'Mapping[str, Any]') → None
+def __init__(mapping: Mapping[str, Any]) -> None
 ```
 
 
@@ -901,7 +1084,7 @@ Return an immutable view of preserved extension fields.
 ### <kbd>classmethod</kbd> `from_mapping`
 
 ```python
-from_mapping(mapping: 'Mapping[str, Any]') → 'FabricMapping'
+def from_mapping(mapping: Mapping[str, Any]) -> Self
 ```
 
 Validate and copy a mapping into the requested typed model.
@@ -912,7 +1095,7 @@ Validate and copy a mapping into the requested typed model.
 ### <kbd>method</kbd> `to_dict`
 
 ```python
-to_dict() → dict[str, Any]
+def to_dict() -> dict[str, Any]
 ```
 
 Return the same detached representation as ``to_mapping()``.
@@ -923,7 +1106,7 @@ Return the same detached representation as ``to_mapping()``.
 ### <kbd>method</kbd> `to_mapping`
 
 ```python
-to_mapping() → dict[str, Any]
+def to_mapping() -> dict[str, Any]
 ```
 
 Return a detached, JSON-compatible mapping for serialization.

--- a/docs/sdk/python.mdx
+++ b/docs/sdk/python.mdx
@@ -268,7 +268,7 @@ multiple independent runtimes.
 | API | Async | Use When | Notes |
 | --- | --- | --- | --- |
 | `Fabric.plan(config, base_dir=...)` | No | You need to inspect the selected adapter, capability mapping, and runtime capabilities before running. | Does not start a runtime. |
-| `Fabric.doctor(config, base_dir=...)` | Yes | You need preflight diagnostics for adapter availability, config support, and environment assumptions. | Checks may touch runtime dependencies. |
+| `Fabric.doctor(config, *, base_dir=...)` | Yes | You need preflight diagnostics for adapter resolution, capability routing, declared requirements, and environment assumptions. | Checks may inspect local binaries, environment variables, and files without starting a runtime. |
 | `Fabric.run(config, base_dir=..., input=...)` | Yes | You need one complete start, invoke, result, stop lifecycle. | `base_dir` is optional. Pass a `RunRequest` instead when the invocation needs IDs, context, or overrides. |
 | `Fabric.start_runtime(config, ..., streaming=False)` | Yes | You need state across multiple ordered invocations. | Returns a `Runtime`. Use `streaming=True` with NeMo Relay enabled to provision streaming. |
 | `Runtime.invoke(...)` | Yes | You need one turn on an existing runtime. | A runtime permits one active invocation at a time. |
@@ -441,8 +441,8 @@ Streaming has the following v0.1 constraints:
   warning check.
 
 Claude and Codex streaming use the NeMo Relay `nemo-relay` gateway CLI and require a
-stream-sink-capable release, version 0.6.0 or later. Follow the
-[NeMo Relay CLI installation instructions](/getting-started/install#nemo-relay-cli)
+stream-sink-capable release from `0.6.0` up to, but not including, `0.7.0`. Follow
+the [NeMo Relay CLI installation instructions](../getting-started/install.mdx#nemo-relay-cli)
 to provision it. Hermes Agent and Deep Agents use their in-process NeMo Relay
 integrations.
 
@@ -545,8 +545,9 @@ print(report.status)
 ```
 
 Use the plan to confirm adapter selection and capability routing. Use the doctor
-report to catch missing dependencies, unsupported settings, and environment
-problems before starting a runtime.
+report to catch unresolved adapter descriptors, unsupported normalized
+capabilities, missing declared requirements, and environment problems before
+starting a runtime.
 
 ## Install And Runtime Responsibilities
 
@@ -577,12 +578,17 @@ Use `harness.settings` for adapter-owned configuration that the selected adapter
 understands. Examples include Hermes Agent-specific launch options, Codex controls,
 or adapter-specific launch paths.
 
-Use `metadata` for caller-owned annotations that NeMo Fabric should preserve and echo
-back, but not interpret.
+Use `FabricConfig.metadata` for human-readable agent identity and additive
+caller-owned annotations. NeMo Fabric preserves these values in the resolved
+config but does not copy them into `RunResult.metadata`. Use `request_id` and
+`RunRequest.context` for per-invocation correlation. `RunResult.metadata`
+contains adapter-specific result details.
 
 Adapter settings are not portable by default. An adapter must explicitly read
-and implement a setting before it affects runtime behavior. Use `doctor(...)` to
-catch unsupported, ignored, or malformed adapter settings before launching a run.
+and implement a setting before it affects runtime behavior. Validate
+adapter-owned settings against the selected adapter's documentation;
+`doctor(...)` does not generically detect unsupported, ignored, or malformed
+adapter settings.
 
 ## Errors
 

--- a/python/src/nemo_fabric/types.py
+++ b/python/src/nemo_fabric/types.py
@@ -13,6 +13,7 @@ from copy import deepcopy
 from pathlib import Path
 from types import MappingProxyType
 from typing import Any
+from typing import Self
 from typing import TypeVar
 
 from pydantic import BaseModel
@@ -817,7 +818,7 @@ class FabricMapping(Mapping[str, Any]):
         object.__setattr__(self, "_data", _freeze(data))
 
     @classmethod
-    def from_mapping(cls, mapping: Mapping[str, Any]) -> "FabricMapping":
+    def from_mapping(cls, mapping: Mapping[str, Any]) -> Self:
         """Validate and copy a mapping into the requested typed model."""
 
         return cls(mapping)

--- a/scripts/docs/enhance_python_api_reference.py
+++ b/scripts/docs/enhance_python_api_reference.py
@@ -1,0 +1,327 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Add exact Python SDK contracts to the lazydocs-generated reference."""
+
+from __future__ import annotations
+
+import argparse
+import importlib
+import inspect
+import re
+from enum import Enum
+from pathlib import Path
+from typing import Any
+
+from pydantic import BaseModel
+
+MODULE_NAMES = (
+    "nemo_fabric.client",
+    "nemo_fabric.runtime",
+    "nemo_fabric.streaming",
+    "nemo_fabric.models",
+    "nemo_fabric.types",
+    "nemo_fabric.errors",
+)
+CLASS_HEADING = re.compile(r"^## <kbd>class</kbd> `([^`]+)`$")
+MEMBER_HEADING = re.compile(r"^### <kbd>(?:method|classmethod)</kbd> `([^`]+)`$")
+
+
+def _annotation_text(annotation: Any) -> str:
+    if annotation is inspect.Signature.empty:
+        return ""
+    if isinstance(annotation, str):
+        if (
+            len(annotation) >= 2
+            and annotation[0] == annotation[-1]
+            and annotation[0] in {'"', "'"}
+        ):
+            return annotation[1:-1]
+        return annotation
+    return inspect.formatannotation(annotation)
+
+
+def _parameter_text(parameter: inspect.Parameter) -> str:
+    prefix = ""
+    if parameter.kind is inspect.Parameter.VAR_POSITIONAL:
+        prefix = "*"
+    elif parameter.kind is inspect.Parameter.VAR_KEYWORD:
+        prefix = "**"
+
+    rendered = prefix + parameter.name
+    if parameter.annotation is not inspect.Parameter.empty:
+        rendered += f": {_annotation_text(parameter.annotation)}"
+    if parameter.default is not inspect.Parameter.empty:
+        rendered += f" = {parameter.default!r}"
+    return rendered
+
+
+def _signature_tokens(
+    parameters: list[inspect.Parameter],
+) -> list[str]:
+    tokens: list[str] = []
+    positional_only = [
+        index
+        for index, parameter in enumerate(parameters)
+        if parameter.kind is inspect.Parameter.POSITIONAL_ONLY
+    ]
+    last_positional_only = positional_only[-1] if positional_only else None
+    has_var_positional = False
+    added_keyword_separator = False
+
+    for index, parameter in enumerate(parameters):
+        if (
+            parameter.kind is inspect.Parameter.KEYWORD_ONLY
+            and not has_var_positional
+            and not added_keyword_separator
+        ):
+            tokens.append("*")
+            added_keyword_separator = True
+
+        tokens.append(_parameter_text(parameter))
+        if parameter.kind is inspect.Parameter.VAR_POSITIONAL:
+            has_var_positional = True
+        if index == last_positional_only:
+            tokens.append("/")
+
+    return tokens
+
+
+def _render_signature(name: str, member: Any) -> str:
+    signature = inspect.signature(member)
+    parameters = [
+        parameter
+        for parameter in signature.parameters.values()
+        if parameter.name not in {"self", "cls"}
+    ]
+    tokens = _signature_tokens(parameters)
+    prefix = "async def " if inspect.iscoroutinefunction(member) else "def "
+    returns = ""
+    if signature.return_annotation is not inspect.Signature.empty:
+        returns = f" -> {_annotation_text(signature.return_annotation)}"
+
+    compact = f"{prefix}{name}({', '.join(tokens)}){returns}"
+    if len(compact) <= 88:
+        return compact
+
+    lines = [f"{prefix}{name}("]
+    lines.extend(f"    {token}," for token in tokens)
+    lines.append(f"){returns}")
+    return "\n".join(lines)
+
+
+def _replace_signature_fences(text: str, module: Any) -> str:
+    lines = text.splitlines()
+    class_name: str | None = None
+    pending_member: str | None = None
+    output: list[str] = []
+    index = 0
+
+    while index < len(lines):
+        line = lines[index]
+        class_match = CLASS_HEADING.match(line)
+        if class_match:
+            class_name = class_match.group(1)
+            pending_member = None
+
+        member_match = MEMBER_HEADING.match(line)
+        if member_match:
+            pending_member = member_match.group(1)
+
+        if line == "```python" and class_name and pending_member:
+            closing = index + 1
+            while closing < len(lines) and lines[closing] != "```":
+                closing += 1
+            if closing == len(lines):
+                raise ValueError(
+                    f"unterminated signature fence for {class_name}.{pending_member}"
+                )
+
+            exported_class = getattr(module, class_name)
+            member = getattr(exported_class, pending_member)
+            output.extend(
+                [
+                    "```python",
+                    _render_signature(pending_member, member),
+                    "```",
+                ]
+            )
+            pending_member = None
+            index = closing + 1
+            continue
+
+        output.append(line)
+        index += 1
+
+    return "\n".join(output) + "\n"
+
+
+def _inline_code(value: str) -> str:
+    escaped = " ".join(value.splitlines()).replace("|", r"\|")
+    return f"`{escaped}`"
+
+
+def _default_factory_text(factory: Any) -> str:
+    name = getattr(factory, "__name__", type(factory).__name__)
+    if name == "<lambda>":
+        return "<generated>"
+    return f"{name}()"
+
+
+def _model_fields_table(model: type[BaseModel]) -> str:
+    if not model.model_fields:
+        return ""
+
+    annotations = inspect.get_annotations(model, eval_str=False)
+    lines = [
+        "### Fields",
+        "",
+        "The model defines the following fields:",
+        "",
+        "| Field | Type | Required | Default | Constraints | Description |",
+        "| --- | --- | --- | --- | --- | --- |",
+    ]
+    for name, field in model.model_fields.items():
+        annotation = _annotation_text(annotations.get(name, field.annotation))
+        required = "Yes" if field.is_required() else "No"
+        if field.is_required():
+            default = "—"
+        elif field.default_factory is not None:
+            default = _inline_code(_default_factory_text(field.default_factory))
+        else:
+            default = _inline_code(repr(field.default))
+        constraints = (
+            _inline_code(", ".join(repr(item) for item in field.metadata))
+            if field.metadata
+            else "—"
+        )
+        description = " ".join((field.description or "—").split()).replace("|", r"\|")
+        lines.append(
+            f"| {_inline_code(name)} | {_inline_code(annotation)} | "
+            f"{required} | {default} | {constraints} | {description} |"
+        )
+    return "\n".join(lines)
+
+
+def _typed_fields_table(exported_class: type[Any]) -> str:
+    annotations = inspect.get_annotations(exported_class, eval_str=False)
+    if not annotations:
+        return ""
+
+    lines = [
+        "### Fields",
+        "",
+        "The mapping exposes the following typed fields:",
+        "",
+        "| Field | Type |",
+        "| --- | --- |",
+    ]
+    for name, annotation in annotations.items():
+        lines.append(
+            f"| {_inline_code(name)} | {_inline_code(_annotation_text(annotation))} |"
+        )
+    return "\n".join(lines)
+
+
+def _inheritance_section(exported_class: type[Any]) -> str:
+    bases = [base.__name__ for base in exported_class.__bases__ if base is not object]
+    if not bases:
+        return ""
+
+    label = "Direct base" if len(bases) == 1 else "Direct bases"
+    rendered = ", ".join(_inline_code(base) for base in bases)
+    return "\n".join(
+        [
+            "### Inheritance",
+            "",
+            f"{label}: {rendered}.",
+        ]
+    )
+
+
+def _enum_values_table(exported_class: type[Enum]) -> str:
+    lines = [
+        "### Values",
+        "",
+        "The enum defines the following values:",
+        "",
+        "| Name | Value |",
+        "| --- | --- |",
+    ]
+    for member in exported_class:
+        lines.append(
+            f"| {_inline_code(member.name)} | {_inline_code(str(member.value))} |"
+        )
+    return "\n".join(lines)
+
+
+def _class_supplement(exported_class: type[Any]) -> str:
+    sections: list[str] = []
+    if exported_class.__module__ == "nemo_fabric.errors" or issubclass(
+        exported_class, Enum
+    ):
+        sections.append(_inheritance_section(exported_class))
+    if issubclass(exported_class, BaseModel):
+        sections.append(_model_fields_table(exported_class))
+    elif exported_class.__module__ == "nemo_fabric.types":
+        sections.append(_typed_fields_table(exported_class))
+    if issubclass(exported_class, Enum):
+        sections.append(_enum_values_table(exported_class))
+    return "\n\n".join(section for section in sections if section)
+
+
+def _insert_class_supplements(text: str, module: Any) -> str:
+    lines = text.splitlines()
+    headings: list[tuple[int, str]] = []
+    for index, line in enumerate(lines):
+        match = CLASS_HEADING.match(line)
+        if match:
+            headings.append((index, match.group(1)))
+
+    for heading_index, (start, class_name) in reversed(list(enumerate(headings))):
+        end = (
+            headings[heading_index + 1][0]
+            if heading_index + 1 < len(headings)
+            else len(lines)
+        )
+        first_member = next(
+            (
+                index
+                for index in range(start + 1, end)
+                if lines[index].startswith("### <kbd>")
+            ),
+            end,
+        )
+        insert_at = first_member
+        separators = [
+            index for index in range(start + 1, first_member) if lines[index] == "---"
+        ]
+        if separators:
+            insert_at = separators[-1]
+
+        supplement = _class_supplement(getattr(module, class_name))
+        if supplement:
+            lines[insert_at:insert_at] = ["", *supplement.splitlines(), ""]
+
+    return "\n".join(lines) + "\n"
+
+
+def enhance_reference(output_dir: Path) -> None:
+    for module_name in MODULE_NAMES:
+        module = importlib.import_module(module_name)
+        page = output_dir / f"{module_name}.md"
+        text = page.read_text(encoding="utf-8")
+        text = _replace_signature_fences(text, module)
+        text = _insert_class_supplements(text, module)
+        page.write_text(text, encoding="utf-8")
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("output_dir", type=Path)
+    args = parser.parse_args()
+    enhance_reference(args.output_dir)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/generate_api_docs.sh
+++ b/scripts/generate_api_docs.sh
@@ -40,12 +40,16 @@ perl -0pi -e 's/\A\s+//' "$out"/*.md
 # lazydocs nests properties at h4 directly under h2 class sections. Flatten
 # those headings to h3 so generated pages satisfy markdown heading order.
 perl -pi -e 's/^#### (<kbd>property<\/kbd>)/### $1/' "$out"/*.md
-# lazydocs emits some class headings without a separating blank line.
-perl -0pi -e 's/(^## <kbd>class<\/kbd> `(ToolsConfig|RelayAtofFileSinkConfig|RelayAtofStreamSinkConfig)`\n)(?!\n)/$1\n/gm' \
-  "$out/nemo_fabric.models.md"
+# lazydocs emits module and class headings without a separating blank line.
+perl -0pi -e 's/(^#{1,2} <kbd>(?:module|class)<\/kbd> `[^`]+`\n)(?!\n)/$1\n/gm' \
+  "$out"/*.md
 # lazydocs omits the async marker from generated method signatures.
 perl -0pi -e 's/(### <kbd>method<\/kbd> `(aclose|result)`\n\n```python\n)\2\(/${1}async def ${2}(/g' \
   "$out/nemo_fabric.streaming.md"
+
+# Restore signature semantics that lazydocs drops and add field-level contracts
+# for the SDK's Pydantic and immutable mapping models.
+PYTHONPATH="python/src" python scripts/docs/enhance_python_api_reference.py "$out"
 
 add_frontmatter() {
   local file="$1"

--- a/skills/integrations/consumer/nemo-fabric-integrate/references/sdk-api-inventory.md
+++ b/skills/integrations/consumer/nemo-fabric-integrate/references/sdk-api-inventory.md
@@ -11,9 +11,9 @@ independent runtimes. The generated
 [client reference](https://github.com/NVIDIA/NeMo-Fabric/blob/main/docs/reference/api/python-library-reference/nemo_fabric.client.md)
 and [runtime reference](https://github.com/NVIDIA/NeMo-Fabric/blob/main/docs/reference/api/python-library-reference/nemo_fabric.runtime.md)
 and [streaming reference](https://github.com/NVIDIA/NeMo-Fabric/blob/main/docs/reference/api/python-library-reference/nemo_fabric.streaming.md)
-document the public methods, but they omit `async` and keyword-only markers —
-this inventory records those, and the installed `nemo_fabric` package ships type
-information (`py.typed`) for exact signatures.
+document the public methods with their `async` and keyword-only markers. The
+installed `nemo_fabric` package also ships type information (`py.typed`) for
+static analysis.
 
 ## `Fabric` Methods
 
@@ -22,7 +22,7 @@ The following table lists the `Fabric` methods and when to use each.
 | Method | Async | Use When | Returns |
 | --- | --- | --- | --- |
 | `plan(config, *, base_dir=...)` | No | You need the selected adapter, capability routing, and runtime capabilities before running. | `RunPlan` |
-| `doctor(config, *, base_dir=...)` | Yes | You need preflight diagnostics for adapter availability, config support, and environment assumptions. | `DoctorReport` |
+| `doctor(config, *, base_dir=...)` | Yes | You need preflight diagnostics for adapter resolution, capability routing, declared requirements, and environment assumptions. | `DoctorReport` |
 | `run(config, *, base_dir=..., input=... \| request=...)` | Yes | You need one complete start, invoke, result, and stop cycle. | `RunResult` |
 | `start_runtime(config, *, base_dir=..., overrides=..., streaming=False)` | Yes | You need state across multiple ordered invocations. Pass `streaming=True` with NVIDIA NeMo Relay enabled to provision `invoke_stream(...)`. | `Runtime` |
 

--- a/tests/docs/test_python_api_docs.py
+++ b/tests/docs/test_python_api_docs.py
@@ -5,9 +5,24 @@
 
 from __future__ import annotations
 
+import ast
+import importlib
 import re
 from collections import defaultdict
-from inspect import getdoc, getmembers, isclass, isfunction, ismethod, getattr_static
+from enum import Enum
+from inspect import (
+    Parameter,
+    formatannotation,
+    get_annotations,
+    getdoc,
+    getmembers,
+    getattr_static,
+    isclass,
+    iscoroutinefunction,
+    isfunction,
+    ismethod,
+    signature,
+)
 from pathlib import Path
 
 import nemo_fabric
@@ -26,6 +41,21 @@ MODULE_SLUGS = {
     "nemo_fabric.types": "/reference/api/python-library-reference/types",
     "nemo_fabric.errors": "/reference/api/python-library-reference/errors",
 }
+MEMBER_SIGNATURE = re.compile(
+    r"^### <kbd>(?:method|classmethod)</kbd> `([^`]+)`\n\n"
+    r"```python\n(.*?)\n```",
+    flags=re.MULTILINE | re.DOTALL,
+)
+MODEL_FIELD_ROW = re.compile(
+    r"^\| `(?P<name>[^`]+)` \| `(?P<annotation>[^`]*)` \| "
+    r"(?P<required>Yes|No) \| (?P<default>—|`[^`]*`) \| "
+    r"(?P<constraints>—|`[^`]*`) \| (?P<description>.*?) \|$",
+    flags=re.MULTILINE,
+)
+TYPED_FIELD_ROW = re.compile(
+    r"^\| `(?P<name>[^`]+)` \| `(?P<annotation>[^`]*)` \|$",
+    flags=re.MULTILINE,
+)
 
 
 def _exported_classes_by_module() -> dict[str, set[str]]:
@@ -46,13 +76,73 @@ def _documented_classes(page: Path) -> set[str]:
     )
 
 
+def _class_section(page: Path, class_name: str) -> str:
+    marker = f"## <kbd>class</kbd> `{class_name}`"
+    section = page.read_text(encoding="utf-8").split(marker, maxsplit=1)[1]
+    return section.split("\n## <kbd>class</kbd>", maxsplit=1)[0]
+
+
+def _annotation_text(annotation: object) -> str:
+    if isinstance(annotation, str):
+        if (
+            len(annotation) >= 2
+            and annotation[0] == annotation[-1]
+            and annotation[0] in {'"', "'"}
+        ):
+            annotation = annotation[1:-1]
+        return annotation.replace("|", r"\|")
+    return formatannotation(annotation).replace("|", r"\|")
+
+
+def _default_factory_text(factory: object) -> str:
+    name = getattr(factory, "__name__", type(factory).__name__)
+    if name == "<lambda>":
+        return "<generated>"
+    return f"{name}()"
+
+
+def _definition_ast(source: str) -> str:
+    node = ast.parse(f"{source}:\n    pass\n").body[0]
+
+    def normalize_annotation(annotation: ast.expr) -> ast.expr:
+        while isinstance(annotation, ast.Constant) and isinstance(
+            annotation.value, str
+        ):
+            annotation = ast.parse(annotation.value, mode="eval").body
+        return annotation
+
+    arguments = node.args
+    for argument in (
+        *arguments.posonlyargs,
+        *arguments.args,
+        *arguments.kwonlyargs,
+    ):
+        if argument.annotation is not None:
+            argument.annotation = normalize_annotation(argument.annotation)
+    for argument in (arguments.vararg, arguments.kwarg):
+        if argument is not None and argument.annotation is not None:
+            argument.annotation = normalize_annotation(argument.annotation)
+    if node.returns is not None:
+        node.returns = normalize_annotation(node.returns)
+
+    return ast.dump(node, include_attributes=False)
+
+
+def _documented_method_names(exported_class: type[object]) -> list[str]:
+    return [
+        name
+        for name, member in getmembers(exported_class)
+        if (not name.startswith("_") or name == "__init__")
+        and (isfunction(member) or ismethod(member))
+        and getattr(member, "__module__", None) == exported_class.__module__
+        and "lazydocs: ignore" not in (getdoc(member) or "")
+    ]
+
+
 def test_python_reference_exactly_covers_exported_sdk_classes() -> None:
     exports = _exported_classes_by_module()
     expected_pages = {f"{module}.md" for module in exports}
-    actual_pages = {
-        page.name
-        for page in REFERENCE_DIR.glob("nemo_fabric.*.md")
-    }
+    actual_pages = {page.name for page in REFERENCE_DIR.glob("nemo_fabric.*.md")}
 
     assert actual_pages == expected_pages
     for module, names in exports.items():
@@ -89,7 +179,146 @@ def test_generated_reference_uses_valid_heading_order() -> None:
         assert "#### <kbd>property</kbd>" not in text, page
 
 
-def test_generated_reference_uses_markdown_spdx_comments() -> None:
+def test_generated_signatures_preserve_python_callable_semantics():
+    signature_count = 0
+    async_count = 0
+    for module_name, class_names in _exported_classes_by_module().items():
+        module = importlib.import_module(module_name)
+        page = REFERENCE_DIR / f"{module_name}.md"
+
+        for class_name in class_names:
+            exported_class = getattr(module, class_name)
+            section = _class_section(page, class_name)
+            documented_members = re.findall(
+                r"^### <kbd>(?:method|classmethod)</kbd> `([^`]+)`$",
+                section,
+                flags=re.MULTILINE,
+            )
+            assert documented_members == _documented_method_names(exported_class)
+            rendered_signatures = list(MEMBER_SIGNATURE.finditer(section))
+            assert [
+                match.group(1) for match in rendered_signatures
+            ] == documented_members
+
+            for match in rendered_signatures:
+                member_name, rendered = match.groups()
+                member = getattr(exported_class, member_name)
+                member_signature = signature(member)
+                signature_count += 1
+                assert "→" not in rendered
+
+                is_async = iscoroutinefunction(member)
+                async_count += is_async
+                expected_prefix = "async def " if is_async else "def "
+                assert rendered.startswith(expected_prefix)
+
+                expected_signature = member_signature.replace(
+                    parameters=[
+                        parameter
+                        for parameter in member_signature.parameters.values()
+                        if parameter.name not in {"self", "cls"}
+                    ]
+                )
+                expected_declaration = (
+                    f"{expected_prefix}{member_name}{expected_signature}"
+                )
+                assert _definition_ast(rendered) == _definition_ast(
+                    expected_declaration
+                )
+
+                has_keyword_only = any(
+                    parameter.kind is Parameter.KEYWORD_ONLY
+                    for parameter in member_signature.parameters.values()
+                )
+                has_var_positional = any(
+                    parameter.kind is Parameter.VAR_POSITIONAL
+                    for parameter in member_signature.parameters.values()
+                )
+                if has_keyword_only and not has_var_positional:
+                    assert re.search(r"(?:\(\*,|, \*,|\n    \*,)", rendered)
+
+    assert signature_count > 0
+    assert async_count > 0
+
+
+def test_generated_reference_documents_pydantic_field_contracts():
+    for export_name in nemo_fabric.__all__:
+        exported = getattr(nemo_fabric, export_name)
+        if not isclass(exported) or not issubclass(exported, BaseModel):
+            continue
+        if not exported.model_fields:
+            continue
+
+        page = REFERENCE_DIR / f"{exported.__module__}.md"
+        section = _class_section(page, export_name)
+        rows = {
+            match.group("name"): match.groupdict()
+            for match in MODEL_FIELD_ROW.finditer(section)
+        }
+        assert set(rows) == set(exported.model_fields)
+        annotations = get_annotations(exported, eval_str=False)
+
+        for field_name, field in exported.model_fields.items():
+            row = rows[field_name]
+            assert row["annotation"] == _annotation_text(
+                annotations.get(field_name, field.annotation)
+            )
+            assert row["required"] == ("Yes" if field.is_required() else "No")
+            if field.is_required():
+                assert row["default"] == "—"
+            elif field.default_factory is not None:
+                assert row["default"] == (
+                    f"`{_default_factory_text(field.default_factory)}`"
+                )
+            else:
+                assert row["default"] == f"`{field.default!r}`"
+            if field.metadata:
+                constraints = ", ".join(repr(item) for item in field.metadata)
+                assert row["constraints"] == f"`{constraints}`"
+            else:
+                assert row["constraints"] == "—"
+            expected_description = " ".join((field.description or "—").split()).replace(
+                "|", r"\|"
+            )
+            assert row["description"] == expected_description
+
+
+def test_generated_reference_documents_typed_mapping_fields():
+    for export_name in nemo_fabric.__all__:
+        exported = getattr(nemo_fabric, export_name)
+        if not isclass(exported) or exported.__module__ != "nemo_fabric.types":
+            continue
+
+        annotations = get_annotations(exported, eval_str=False)
+        page = REFERENCE_DIR / f"{exported.__module__}.md"
+        section = _class_section(page, export_name)
+        rows = {
+            match.group("name"): match.group("annotation")
+            for match in TYPED_FIELD_ROW.finditer(section)
+        }
+        assert set(rows) == set(annotations)
+        for field_name, annotation in annotations.items():
+            assert rows[field_name] == _annotation_text(annotation)
+        assert "from_mapping(mapping: Mapping[str, Any]) -> Self" in section
+
+
+def test_generated_reference_documents_error_bases_and_enum_values():
+    for export_name in nemo_fabric.__all__:
+        exported = getattr(nemo_fabric, export_name)
+        if not isclass(exported):
+            continue
+
+        page = REFERENCE_DIR / f"{exported.__module__}.md"
+        section = _class_section(page, export_name)
+        if exported.__module__ == "nemo_fabric.errors":
+            for base in exported.__bases__:
+                assert f"`{base.__name__}`" in section
+        if issubclass(exported, Enum):
+            for member in exported:
+                assert f"| `{member.name}` | `{member.value}` |" in section
+
+
+def test_generated_reference_uses_markdown_spdx_comments():
     for page in REFERENCE_DIR.glob("*.md"):
         text = page.read_text(encoding="utf-8")
         assert "<!-- SPDX-FileCopyrightText:" in text, page
@@ -97,7 +326,7 @@ def test_generated_reference_uses_markdown_spdx_comments() -> None:
         assert "{/* SPDX-FileCopyrightText:" not in text, page
 
 
-def test_generated_reference_uses_full_relay_name_once_per_page() -> None:
+def test_generated_reference_uses_full_relay_name_once_per_page():
     for page in REFERENCE_DIR.glob("*.md"):
         text = page.read_text(encoding="utf-8")
         if "NeMo Relay" in text:
@@ -112,11 +341,15 @@ def test_streaming_reference_hides_constructor_and_preserves_async_methods():
     assert "async def result()" in reference
 
 
-def test_relay_sink_reference_uses_valid_class_heading_spacing():
-    reference = (REFERENCE_DIR / "nemo_fabric.models.md").read_text(encoding="utf-8")
-
-    for class_name in ("RelayAtofFileSinkConfig", "RelayAtofStreamSinkConfig"):
-        assert f"## <kbd>class</kbd> `{class_name}`\n\n" in reference
+def test_generated_module_and_class_headings_have_blank_lines():
+    heading = re.compile(
+        r"^#{1,2} <kbd>(?:module|class)</kbd> `[^`]+`\n",
+        flags=re.MULTILINE,
+    )
+    for page in REFERENCE_DIR.glob("*.md"):
+        text = page.read_text(encoding="utf-8")
+        for match in heading.finditer(text):
+            assert text.startswith("\n", match.end()), (page, match.group())
 
 
 def test_landing_page_routes_new_users_through_the_product() -> None:

--- a/tests/e2e/test_cli_scaffold.py
+++ b/tests/e2e/test_cli_scaffold.py
@@ -6,6 +6,7 @@ import os
 from pathlib import Path
 import subprocess
 import sys
+import tomllib
 
 
 ROOT = Path(__file__).parents[2]
@@ -66,17 +67,21 @@ def test_generated_python_scaffold_installs_editable(tmp_path: Path):
 def test_generated_rust_scaffold_builds(tmp_path: Path):
     destination = tmp_path / "rust-agent"
     generate_scaffold(destination, "rust")
-    assert "path =" not in (destination / "Cargo.toml").read_text()
+    manifest = (destination / "Cargo.toml").read_text()
+    assert "[workspace]" in manifest
+    core_dependency = tomllib.loads(manifest)["dependencies"]["nemo-fabric-core"]
+    assert Path(core_dependency["path"]) == ROOT / "crates/fabric-core"
+    expected_version = tomllib.loads((ROOT / "Cargo.toml").read_text())["workspace"][
+        "package"
+    ]["version"]
+    assert core_dependency["version"] == expected_version
     environment = os.environ.copy()
     environment["CARGO_TARGET_DIR"] = str(ROOT / "target")
-    core_path = json.dumps(str(ROOT / "crates/fabric-core"))
 
     subprocess.run(
         [
             "cargo",
             "build",
-            "--config",
-            f"patch.crates-io.nemo-fabric-core.path={core_path}",
             "--manifest-path",
             str(destination / "Cargo.toml"),
         ],

--- a/tests/python/test_typed_config.py
+++ b/tests/python/test_typed_config.py
@@ -65,7 +65,10 @@ def _shim_adapter_config() -> FabricConfig:
     """Config referencing the test adapter (runs without secrets)."""
 
     config = _repository_adapter_config().to_mapping()
-    config["metadata"] = {"name": "typed-only-run"}
+    config["metadata"] = {
+        "name": "typed-only-run",
+        "caller_annotation": "sdk",
+    }
     config["harness"] = {
         "adapter_id": "test.fabric.hermes_shim",
         "resolution": "preinstalled",
@@ -106,6 +109,7 @@ async def runs_with_typed_config_and_adapter_directory(client: Fabric) -> None:
         base = Path(tmpdir) / "scratch"
         copytree(SHIM_ADAPTERS, base / "adapters")
         (base / "ws").mkdir()
+        plan = client.plan(config, base_dir=base)
         result = await client.run(
             config,
             base_dir=base,
@@ -118,10 +122,12 @@ async def runs_with_typed_config_and_adapter_directory(client: Fabric) -> None:
         )
 
     assert isinstance(result, RunResult)
-    assert result["status"] == "succeeded", result.get("status")
+    assert plan.config.metadata.extra_fields["caller_annotation"] == "sdk"
+    assert result["status"] == "succeeded", result["status"]
     assert result.request_id == "typed-request-1"
     assert result["adapter_kind"] == "python"
     assert result["metadata"]["adapter_runner"] == "persistent_local_host"
+    assert "caller_annotation" not in result.metadata
     assert result["output"]["received"] == "hello typed"
 
 


### PR DESCRIPTION
#### Overview

Correct verified documentation-audit failures in the generated Python API reference and executable workflows.

- Preserve exact Python callable semantics in generated references, including `async`, keyword-only markers, return types, model fields, constraints, enum values, and error inheritance.
- Make Rust scaffolds generated by a source-built CLI compile against that checkout, and correct the documented `just` syntax, standalone Codex snippets, doctor behavior, and metadata semantics.
- Keep the exported consumer skill aligned with the corrected SDK documentation.

There are no breaking changes. This backport is based directly on `release/0.1`; all Fabric package manifests and lockfiles remain at `0.1.0`, and no 0.2 release metadata is included.

#### Details

The generated Python reference was regenerated from the checked-in `release/0.1` public code after correcting its postprocessor. Regression tests compare the complete rendered contracts directly to Python reflection while preserving the release branch’s NeMo Fabric terminology and streaming API.

The Rust scaffold now uses an absolute path plus the matching package version when the CLI is built in a source checkout; packaged CLI builds retain the version-only dependency. An empty `[workspace]` keeps an in-repository generated scaffold independent of the parent workspace.

The branch contains one signed PR-only commit on the latest `release/0.1`. It does not contain merged `main` history, version-bump commits, package metadata changes, or lockfile changes.

Existing issues and open pull requests were searched before publishing. Harbor Relay and release/quickstart work covered elsewhere were left untouched.

#### Validation

- `just test-python` — 472 passed, 44 skipped.
- `just test-rust` — all 44 Rust tests passed, including generated-scaffold coverage.
- `uv run --no-sync pytest tests/docs/test_python_api_docs.py tests/e2e/test_cli_scaffold.py tests/python/test_typed_config.py -q` — 16 passed.
- `scripts/generate_api_docs.sh` — regenerated the release-native Python reference deterministically.
- `cargo fmt --all -- --check` and `git diff --check` passed.
- The GitHub validation matrix passed across Linux, macOS, and Windows, including all wheel builds, pre-commit, Rust, and the Fern docs preview.

#### Where should the reviewer start?

Start with `scripts/docs/enhance_python_api_reference.py` for the Python reference-contract fixes, then review `crates/fabric-cli/src/scaffold.rs` and its Rust/Python regression tests for the source-checkout scaffold decision.

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- Relates to: [FABRIC-144](https://linear.app/nvidia/issue/FABRIC-144/repair-documented-workflows-and-api-references)

- [x] I confirm this contribution is my own work, or I have the right to submit it under this project's license.
- [x] I searched existing issues and open pull requests, and this does not duplicate existing work.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Rust scaffold generation now supports Cargo workspace behavior and improves portability when created from source checkouts.
- **Bug Fixes**
  - Generated Rust projects now correctly reference a local core dependency when available, with a safe published-version fallback.
- **Documentation**
  - Updated scaffold, installation, and SDK documentation for clearer guidance and more accurate runtime behavior.
  - Refreshed Python API reference formatting for signatures, type annotations, fields, inheritance, and enum values.
- **Tests**
  - Expanded scaffold, build, and API-reference contract tests to verify generated outputs end-to-end.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->