### PR TITLE
test: validate Hermes Relay semantic trajectory

### DIFF
--- a/tests/e2e/test_hermes_e2e.py
+++ b/tests/e2e/test_hermes_e2e.py
@@ -236,13 +236,14 @@ class TestHermesE2E:
         trajectory = json.loads(atif_paths[0].read_text())
         assert trajectory["agent"]["name"] in {"code-review-agent", "Hermes Agent"}
         steps = trajectory["steps"]
-        assert len(steps) == 5
+        user_step = next(step for step in steps if step["source"] == "user")
+        assert user_step["message"] == "Reply with exactly: relay ok"
+        assert user_step["extra"]["llm_request"]["model"] == (
+            "nvidia/nemotron-3-nano-30b-a3b"
+        )
 
-        first_step = steps[0]
-        assert first_step["message"] == "hermes.turn.start"
-        assert first_step["extra"]["event_payload"]["is_first_turn"] is True
-
-        last_step = steps[-1]
-        assert last_step["message"] == "hermes.session.end"
+        last_step = next(step for step in reversed(steps) if step["source"] == "agent")
+        assert "echo user_count=1" in last_step["message"]
+        assert last_step["extra"]["llm_response"]["finish_reason"] == "stop"
         assert last_step["extra"]["invocation"]["framework"] == "nemo_relay"
         assert last_step["extra"]["invocation"]["status"] == "completed"


### PR DESCRIPTION
#### Overview

Update the Hermes Relay E2E assertion to validate the semantic ATIF contract
instead of an obsolete fixed count of internal lifecycle steps.

#### Details

- assert the user step carries the decoded LLM request and expected model;
- assert the agent step carries the decoded LLM response and successful Relay invocation;
- allow Relay to change internal lifecycle-event normalization without weakening
  the request/response acceptance criteria.

#### Validation

- `uv run --no-sync pytest -q tests/e2e/test_hermes_e2e.py::TestHermesE2E::test_atif_artifacts`
- `git diff --check`

#### Where should the reviewer start?

`tests/e2e/test_hermes_e2e.py::TestHermesE2E::test_atif_artifacts`

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- Relates to: [FABRIC-131](https://linear.app/nvidia/issue/FABRIC-131)

- [x] I confirm this contribution is my own work, or I have the right to submit it under this project's license.
- [x] I searched existing issues and open pull requests, and this does not duplicate existing work.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated end-to-end validation for parsed trajectory artifacts.
  * Tests now verify user messages, selected language model details, final agent output, and completion status more reliably.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->