### PR TITLE
ci: Update CI pipelines to accommodate RC tags

### DIFF
--- a/.github/workflows/fern-docs.yml
+++ b/.github/workflows/fern-docs.yml
@@ -17,7 +17,7 @@ on:
   workflow_dispatch:
     inputs:
       tag:
-        description: 'Raw SemVer docs tag, such as 0.1.0 or 0.1.0-rc.1. Alpha tags are not published.'
+        description: 'Release tag, such as v0.1.0 or v0.1.0-rc1. Alpha tags are not published.'
         required: false
         type: string
 
@@ -314,6 +314,13 @@ jobs:
     permissions:
       contents: write
     steps:
+      - name: Checkout workflow tools
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          path: workflow-checkout
+          fetch-depth: 1
+          persist-credentials: false
+
       - name: Determine version tag
         id: version
         env:
@@ -326,23 +333,18 @@ jobs:
           else
             tag="$GITHUB_REF_NAME"
           fi
-          if [[ ! "$tag" =~ ^[0-9]+\.[0-9]+\.[0-9]+(-(beta|rc)\.[0-9]+)?$ ]]; then
-            echo "Error: docs tags must use raw SemVer such as 0.1.0, 0.1.0-beta.1, or 0.1.0-rc.1; alpha tags are not published" >&2
+          version="$(python workflow-checkout/scripts/ci/normalize_release_tag.py "$tag")"
+          if [[ ! "$version" =~ ^[0-9]+\.[0-9]+\.[0-9]+(-(beta|rc)\.[0-9]+)?$ ]]; then
+            echo "Error: docs tags must identify a stable, beta, or RC release; alpha tags are not published" >&2
             exit 1
           fi
-          printf 'tag=%s\n' "$tag" >> "$GITHUB_OUTPUT"
-
-      - name: Checkout workflow tools
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
-        with:
-          path: workflow-checkout
-          fetch-depth: 1
-          persist-credentials: false
+          printf 'source_tag=%s\n' "$tag" >> "$GITHUB_OUTPUT"
+          printf 'tag=%s\n' "$version" >> "$GITHUB_OUTPUT"
 
       - name: Checkout source tag
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
-          ref: ${{ steps.version.outputs.tag }}
+          ref: ${{ steps.version.outputs.source_tag }}
           path: source-checkout
           fetch-depth: 1
           persist-credentials: false
@@ -409,7 +411,7 @@ jobs:
           git commit -m "docs(fern): release version v${{ steps.version.outputs.tag }}
 
           Automated documentation snapshot.
-          Source tag: ${{ steps.version.outputs.tag }}"
+          Source tag: ${{ steps.version.outputs.source_tag }}"
           git push origin docs-website
 
       - name: Publish docs

--- a/.github/workflows/publish_rust.yml
+++ b/.github/workflows/publish_rust.yml
@@ -52,11 +52,6 @@ jobs:
         with:
           tool: just@1.50.0
 
-      - name: Set project release version
-        env:
-          RELEASE_VERSION: ${{ github.ref_name }}
-        run: just set-version "$RELEASE_VERSION"
-
       - name: Authenticate to crates.io with trusted publishing
         id: crates-io-auth
         uses: rust-lang/crates-io-auth-action@bbd81622f20ce9e2dd9622e3218b975523e45bbe # v1.0.4
@@ -64,11 +59,12 @@ jobs:
       - name: Publish to crates.io
         env:
           CARGO_REGISTRY_TOKEN: ${{ steps.crates-io-auth.outputs.token }}
-          RELEASE_VERSION: ${{ github.ref_name }}
+          RELEASE_TAG: ${{ github.ref_name }}
         run: |
           set -euo pipefail
 
-          version="$RELEASE_VERSION"
+          just set-version "$RELEASE_TAG"
+          version="$(sed -n 's/^version = "\(.*\)"$/\1/p' Cargo.toml | head -n 1)"
           packages=(
             nemo-fabric-core
             nemo-fabric-cli

--- a/adapters/common/src/nemo_fabric_adapters/common/utils.py
+++ b/adapters/common/src/nemo_fabric_adapters/common/utils.py
@@ -183,6 +183,9 @@ def merge_unique(*values: Any) -> list[str]:
                 merged.append(item)
     return merged
 
+def without_none(mapping: dict[str, Any]) -> dict[str, Any]:
+    return {key: value for key, value in mapping.items() if value is not None}
+
 
 def dump_yaml(value: dict[str, Any]) -> str:
     try:

--- a/justfile
+++ b/justfile
@@ -360,7 +360,11 @@ lock-python:
         uv lock --project "$project"
     done
 
-# [version] or --set ref_name=<version>
+# Normalize a release tag to the version used by package metadata.
+normalize-release-tag tag:
+    @uv run --no-project --no-cache python scripts/ci/normalize_release_tag.py "{{ tag }}"
+
+# [version-or-tag] or --set ref_name=<version-or-tag>
 set-version version="":
     #!/usr/bin/env bash
     {{ bash_helpers }}
@@ -372,6 +376,7 @@ set-version version="":
         echo "Error: version is required for set-version" >&2
         exit 1
     fi
+    version="$(just normalize-release-tag "$version")"
     cd "$REPO_ROOT"
     set_project_version "$version"
     just lock-python

--- a/scripts/ci/normalize_release_tag.py
+++ b/scripts/ci/normalize_release_tag.py
@@ -1,0 +1,40 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+import re
+import sys
+
+
+RELEASE_TAG_PATTERN = re.compile(
+    r"^v?(?P<release>\d+\.\d+\.\d+)"
+    r"(?:(?P<prerelease>-(?:alpha|beta|rc)(?:\.\d+)?)"
+    r"|-rc(?P<compact_rc>\d+))?"
+    r"(?P<build>\+[0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*)?$"
+)
+
+
+def normalize_release_tag(tag: str) -> str:
+    match = RELEASE_TAG_PATTERN.fullmatch(tag)
+    if not match:
+        raise ValueError(
+            f"Unsupported release tag '{tag}'; use v0.1.0, v0.1.0-rc1, "
+            "or raw SemVer such as 0.1.0-rc.1"
+        )
+
+    prerelease = match.group("prerelease") or ""
+    compact_rc = match.group("compact_rc")
+    if compact_rc is not None:
+        prerelease = f"-rc.{compact_rc}"
+
+    return f"{match.group('release')}{prerelease}{match.group('build') or ''}"
+
+
+if __name__ == "__main__":
+    if len(sys.argv) != 2:
+        raise SystemExit("Usage: normalize_release_tag.py <tag>")
+    try:
+        print(normalize_release_tag(sys.argv[1]))
+    except ValueError as error:
+        raise SystemExit(str(error)) from error

--- a/tests/e2e/test_hermes_e2e.py
+++ b/tests/e2e/test_hermes_e2e.py
@@ -236,13 +236,18 @@ class TestHermesE2E:
         trajectory = json.loads(atif_paths[0].read_text())
         assert trajectory["agent"]["name"] in {"code-review-agent", "Hermes Agent"}
         steps = trajectory["steps"]
-        assert len(steps) == 5
+        assert len(steps) == 2
 
         first_step = steps[0]
-        assert first_step["message"] == "hermes.turn.start"
-        assert first_step["extra"]["event_payload"]["is_first_turn"] is True
+        assert first_step["source"] == "user"
+        assert first_step["message"] == "Reply with exactly: relay ok"
+        assert (
+            first_step["extra"]["llm_request"]["model"]
+            == "nvidia/nemotron-3-nano-30b-a3b"
+        )
 
         last_step = steps[-1]
-        assert last_step["message"] == "hermes.session.end"
+        assert last_step["source"] == "agent"
+        assert last_step["message"] == self.output["response"]
         assert last_step["extra"]["invocation"]["framework"] == "nemo_relay"
         assert last_step["extra"]["invocation"]["status"] == "completed"

--- a/tests/scripts/test_normalize_release_tag.py
+++ b/tests/scripts/test_normalize_release_tag.py
@@ -1,0 +1,34 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+CI_SCRIPTS = Path(__file__).resolve().parents[2] / "scripts" / "ci"
+sys.path.insert(0, str(CI_SCRIPTS))
+
+import normalize_release_tag  # noqa: E402
+
+
+@pytest.mark.parametrize(
+    ("tag", "expected"),
+    [
+        ("v0.1.0", "0.1.0"),
+        ("v0.1.0-rc1", "0.1.0-rc.1"),
+        ("0.1.0-rc1", "0.1.0-rc.1"),
+        ("0.1.0-rc.1", "0.1.0-rc.1"),
+        ("0.1.0-alpha.20260727", "0.1.0-alpha.20260727"),
+    ],
+)
+def test_normalize_release_tag(tag: str, expected: str):
+    assert normalize_release_tag.normalize_release_tag(tag) == expected
+
+
+@pytest.mark.parametrize("tag", ["v0.1", "v0.1.0-dev", "v0.1.0-beta1"])
+def test_normalize_release_tag_rejects_unsupported_tags(tag: str):
+    with pytest.raises(ValueError, match="Unsupported release tag"):
+        normalize_release_tag.normalize_release_tag(tag)


### PR DESCRIPTION
#### Overview

* Python and Rust have different ideas on how RC tags in version numbers should work

#### Where should the reviewer start?

* `scripts/ci/normalize_release_tag.py`
* `justfile`


- [x] I confirm this contribution is my own work, or I have the right to submit it under this project's license.
- [x] I searched existing issues and open pull requests, and this does not duplicate existing work.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Release Management**
  * Release tags are now consistently normalized across documentation snapshots and package publishing.
  * Supports stable, beta, and release-candidate formats, including optional `v` prefixes and compact `-rcN` forms.
  * Improved validation provides clearer errors for unsupported tag formats.
  * Publish/version setting is streamlined to use the normalized package version.
* **Documentation**
  * Updated manual release documentation for the release tag input.
* **Bug Fixes**
  * Ensures published package metadata matches the intended release version.
* **Tests**
  * Updated Hermes end-to-end assertions to match expected relay artifact steps.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->