### PR TITLE
feat(hermes): run Relay-enabled sessions through the gateway

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -55,7 +55,7 @@ checksum = "d0881ea181b1df73ff77ffaaf9c7544ecc11e82fba9b5f27b262a3c73a332555"
 
 [[package]]
 name = "fabric-python"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "nemo-fabric-core",
  "pyo3",
@@ -89,7 +89,7 @@ checksum = "6b947ae49db0d222b1dbc6b113ce7248a3fc3a6ca21b696717bfc000ba4484d8"
 
 [[package]]
 name = "nemo-fabric-cli"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "clap",
  "nemo-fabric-core",
@@ -98,7 +98,7 @@ dependencies = [
 
 [[package]]
 name = "nemo-fabric-core"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "schemars",
  "serde",

--- a/adapters/common/src/nemo_fabric_adapters/common/utils.py
+++ b/adapters/common/src/nemo_fabric_adapters/common/utils.py
@@ -323,17 +323,16 @@ def relay_cli_plugin_config(
     for component in rendered.get("components", []):
         if not isinstance(component, dict) or component.get("kind") != "observability":
             continue
-        config = component.get("config")
-        if isinstance(config, dict):
-            version = config.get("version", 2)
-            if (
-                not isinstance(version, int)
-                or isinstance(version, bool)
-                or version != 2
-            ):
-                raise ValueError(
-                    "NeMo Relay observability config version 2 is required"
-                )
+        config = component.get("config", {})
+        if not isinstance(config, dict):
+            raise ValueError("NeMo Relay observability config version 2 is required")
+        version = config.get("version", 2)
+        if (
+            not isinstance(version, int)
+            or isinstance(version, bool)
+            or version != 2
+        ):
+            raise ValueError("NeMo Relay observability config version 2 is required")
     return rendered
 
 

--- a/adapters/common/src/nemo_fabric_adapters/common/utils.py
+++ b/adapters/common/src/nemo_fabric_adapters/common/utils.py
@@ -5,6 +5,7 @@
 
 from __future__ import annotations
 
+import copy
 import json
 import os
 import sys
@@ -191,6 +192,10 @@ def without_none(mapping: dict[str, Any]) -> dict[str, Any]:
     return {key: value for key, value in mapping.items() if value is not None}
 
 
+def without_none(mapping: dict[str, Any]) -> dict[str, Any]:
+    return {key: value for key, value in mapping.items() if value is not None}
+
+
 def dump_yaml(value: dict[str, Any]) -> str:
     try:
         import yaml
@@ -303,6 +308,25 @@ def collect_relay_artifacts(plugin_config: dict[str, Any]) -> list[dict[str, str
         for path in sorted(directory.glob("*.json")):
             artifacts.append({"kind": "atif", "path": str(path)})
     return artifacts
+
+
+def relay_cli_plugin_config(
+    plugin_config: dict[str, Any], *, observability_version: int
+) -> dict[str, Any]:
+    """Render normalized Relay intent for the current external CLI contract."""
+
+    rendered = copy.deepcopy(plugin_config)
+    if observability_version != 2:
+        raise ValueError(
+            "NeMo Relay 0.6 or newer is required; observability version 1 is unsupported"
+        )
+    for component in rendered.get("components", []):
+        if not isinstance(component, dict) or component.get("kind") != "observability":
+            continue
+        config = component.get("config")
+        if isinstance(config, dict) and int(config.get("version", 2)) != 2:
+            raise ValueError("NeMo Relay observability config version 2 is required")
+    return rendered
 
 
 def write_relay_configs(

--- a/adapters/common/src/nemo_fabric_adapters/common/utils.py
+++ b/adapters/common/src/nemo_fabric_adapters/common/utils.py
@@ -324,8 +324,16 @@ def relay_cli_plugin_config(
         if not isinstance(component, dict) or component.get("kind") != "observability":
             continue
         config = component.get("config")
-        if isinstance(config, dict) and int(config.get("version", 2)) != 2:
-            raise ValueError("NeMo Relay observability config version 2 is required")
+        if isinstance(config, dict):
+            version = config.get("version", 2)
+            if (
+                not isinstance(version, int)
+                or isinstance(version, bool)
+                or version != 2
+            ):
+                raise ValueError(
+                    "NeMo Relay observability config version 2 is required"
+                )
     return rendered
 
 

--- a/adapters/hermes/README.md
+++ b/adapters/hermes/README.md
@@ -5,7 +5,10 @@ SPDX-License-Identifier: Apache-2.0
 
 # NVIDIA NeMo Fabric Hermes Agent Adapter
 
-This adapter runs Hermes Agent through its Python SDK.
+This adapter runs Hermes Agent through its Python SDK when telemetry is disabled.
+When NeMo Relay telemetry is enabled, the same adapter uses the public
+`nemo-relay run` CLI so Relay owns the loopback gateway and Hermes child process.
+There is no user-selectable launch mode.
 
 ## Install
 
@@ -37,7 +40,7 @@ The adapter receives a normalized payload from NeMo Fabric and materializes a na
 - NeMo Fabric MCP servers as Hermes Agent MCP server config;
 - `tools.blocked` as disabled toolsets for Hermes Agent, unioned with
   `harness.settings.disabled_toolsets`;
-- optional NeMo Relay telemetry plugin configuration.
+- optional NeMo Relay 0.6 telemetry configuration.
 
 `hermes_home` configures a base directory. The adapter creates a child under
 `runtimes/<runtime_id>` so invocations in one NeMo Fabric runtime share Hermes Agent state
@@ -45,16 +48,41 @@ without sharing config or the session database with another runtime.
 
 ## Execution Model
 
-Each NeMo Fabric runtime starts one local adapter host, constructs one Hermes Agent
-`AIAgent`, and opens one `SessionDB`. Ordered `Runtime.invoke(...)` calls reuse
-those native objects and pass the prior turn's returned transcript back to
-`run_conversation(...)`. Runtime stop calls the agent's idempotent `close()`
-method, closes the session database, and releases the Relay plugin context when
-enabled.
+For a runtime without Relay, the adapter constructs one Hermes Agent `AIAgent`
+and opens one `SessionDB`. Ordered `Runtime.invoke(...)` calls reuse those
+native objects and pass the prior transcript back to `run_conversation(...)`.
 
-Hermes Agent Relay telemetry is finalized after each NeMo Fabric invocation so its ATOF
-and ATIF artifacts are complete when that invocation returns. This telemetry
-boundary does not recreate the `AIAgent` or `SessionDB`.
+For a Relay-enabled runtime, Fabric writes a Hermes config that excludes the
+native `observability/nemo_relay` plugin. Each invocation gets a distinct
+directory containing colocated `config.toml` and `plugins.toml`, then executes:
+
+```text
+nemo-relay run --config <config.toml> --agent hermes -- <hermes chat args>
+```
+
+The Relay CLI owns gateway startup, the Hermes process, telemetry flush, and
+configuration-overlay restoration. Fabric sends cancellation to the whole
+process group and bounds captured stdout/stderr. The persistent Fabric runtime
+is mapped to a stable Hermes session, so separate invocation processes retain
+conversation history. Relay mode requires NeMo Relay `>=0.6,<0.7`, Hermes Agent
+`>=0.18.2,<0.19`, and an OpenAI-compatible upstream endpoint.
+
+The Relay gateway's `openai.chat_completions` scopes are the canonical source
+for model requests, cost, and cache accounting. Hermes hook scopes provide
+lifecycle and tool-call context only and must not be counted as another model
+request. Adapter output records this as `relay_runtime.model_event_source` and
+`relay_runtime.hook_event_policy`.
+
+The Relay/Hermes process receives an allowlisted child environment: portable
+process settings, `harness.settings.env`, the selected model credential, and
+environment variables explicitly referenced by Relay sinks. Unrelated host
+credentials are not inherited.
+
+Hermes 0.18.x accepts the non-interactive query only as an argument. Fabric
+redacts that argument from results and logs, but it can remain visible to
+same-host process inspection while the command is running. Do not place
+credentials in prompts on a shared host until Hermes exposes a versioned
+stdin/file-descriptor query surface.
 
 ## Maintaining The Adapter
 

--- a/adapters/hermes/README.md
+++ b/adapters/hermes/README.md
@@ -52,12 +52,12 @@ For a runtime without Relay, the adapter constructs one Hermes Agent `AIAgent`
 and opens one `SessionDB`. Ordered `Runtime.invoke(...)` calls reuse those
 native objects and pass the prior transcript back to `run_conversation(...)`.
 
-When Fabric Relay telemetry is disabled, the adapter runs Hermes directly
-through its Python SDK without Fabric-managed Relay telemetry. Configuring the
-native `observability/nemo_relay` Hermes plugin in that mode is rejected; enable
-Relay through Fabric's telemetry configuration instead.
+When NeMo Fabric Relay telemetry is disabled, the adapter runs Hermes directly
+through its Python SDK without Relay telemetry managed by NeMo Fabric.
+Configuring the native `observability/nemo_relay` Hermes plugin in that mode is
+rejected; enable Relay through NeMo Fabric's telemetry configuration instead.
 
-For a Relay-enabled runtime, Fabric writes a Hermes config that excludes the
+For a Relay-enabled runtime, NeMo Fabric writes a Hermes config that excludes the
 native `observability/nemo_relay` plugin. Each invocation gets a distinct
 directory containing colocated `config.toml` and `plugins.toml`, then executes:
 
@@ -66,11 +66,11 @@ nemo-relay run --config <config.toml> --agent hermes -- <hermes chat args>
 ```
 
 The Relay CLI owns gateway startup, the Hermes process, telemetry flush, and
-configuration-overlay restoration. Fabric sends cancellation to the whole
-process group and bounds captured stdout/stderr. The persistent Fabric runtime
-is mapped to a stable Hermes session, so separate invocation processes retain
-conversation history. Relay mode requires NeMo Relay `>=0.6,<0.7`, Hermes Agent
-`>=0.18.2,<0.19`, and an OpenAI-compatible upstream endpoint.
+configuration-overlay restoration. NeMo Fabric sends cancellation to the whole
+process group and bounds captured stdout/stderr. The persistent NeMo Fabric
+runtime is mapped to a stable Hermes session, so separate invocation processes
+retain conversation history. Relay mode requires NeMo Relay `>=0.6,<0.7`,
+Hermes Agent `>=0.18.2,<0.19`, and an OpenAI-compatible upstream endpoint.
 
 The Relay gateway's `openai.chat_completions` scopes are the canonical source
 for model requests, cost, and cache accounting. Hermes hook scopes provide
@@ -83,7 +83,7 @@ process settings, `harness.settings.env`, the selected model credential, and
 environment variables explicitly referenced by Relay sinks. Unrelated host
 credentials are not inherited.
 
-Hermes 0.18.x accepts the non-interactive query only as an argument. Fabric
+Hermes 0.18.x accepts the non-interactive query only as an argument. NeMo Fabric
 redacts that argument from results and logs, but it can remain visible to
 same-host process inspection while the command is running. Do not place
 credentials in prompts on a shared host until Hermes exposes a versioned

--- a/adapters/hermes/README.md
+++ b/adapters/hermes/README.md
@@ -52,6 +52,11 @@ For a runtime without Relay, the adapter constructs one Hermes Agent `AIAgent`
 and opens one `SessionDB`. Ordered `Runtime.invoke(...)` calls reuse those
 native objects and pass the prior transcript back to `run_conversation(...)`.
 
+When Fabric Relay telemetry is disabled, the adapter runs Hermes directly
+through its Python SDK without Fabric-managed Relay telemetry. Configuring the
+native `observability/nemo_relay` Hermes plugin in that mode is rejected; enable
+Relay through Fabric's telemetry configuration instead.
+
 For a Relay-enabled runtime, Fabric writes a Hermes config that excludes the
 native `observability/nemo_relay` plugin. Each invocation gets a distinct
 directory containing colocated `config.toml` and `plugins.toml`, then executes:

--- a/adapters/hermes/src/nemo_fabric_adapters/hermes/adapter.py
+++ b/adapters/hermes/src/nemo_fabric_adapters/hermes/adapter.py
@@ -81,6 +81,17 @@ def disabled_toolsets(payload: dict[str, Any]) -> list[str]:
     )
 
 
+def hermes_working_directory(payload: dict[str, Any]) -> Path:
+    """Resolve the normalized Hermes workspace relative to the Fabric root."""
+
+    root = Path(common_utils.base_dir(payload)).resolve()
+    environment = common_utils.environment_payload(payload)
+    settings = common_utils.settings_payload(payload)
+    workspace = environment.get("workspace") or settings.get("workspace")
+    path = Path(workspace) if workspace else root
+    return path if path.is_absolute() else root / path
+
+
 def build_hermes_config(
     payload: dict[str, Any],
     *,
@@ -90,7 +101,6 @@ def build_hermes_config(
     settings = common_utils.settings_payload(payload)
     model_config = common_utils.selected_model_config(payload)
     native = common_utils.capability_plan(payload).get("native") or {}
-    environment = common_utils.environment_payload(payload)
 
     model_name = settings.get("model_name") or model_config.get("model", "")
     provider = settings.get("provider") or model_config.get("provider")
@@ -114,9 +124,7 @@ def build_hermes_config(
         "terminal": common_utils.without_none(
             {
                 "backend": settings.get("terminal_backend", "local"),
-                "cwd": str(
-                    environment.get("workspace") or settings.get("workspace") or "."
-                ),
+                "cwd": str(hermes_working_directory(payload)),
                 "timeout": settings.get("terminal_timeout", 60),
             }
         ),
@@ -398,10 +406,7 @@ class HermesRuntime:
         )
         if not model:
             raise relay_cli.HermesRelayError("Hermes Relay execution requires a model")
-        environment = common_utils.environment_payload(payload)
-        cwd = Path(self._settings.get("cwd") or environment.get("workspace") or root)
-        if not cwd.is_absolute():
-            cwd = root / cwd
+        cwd = hermes_working_directory(payload)
         env = relay_cli.child_environment(
             self._settings,
             self._model_config,

--- a/adapters/hermes/src/nemo_fabric_adapters/hermes/adapter.py
+++ b/adapters/hermes/src/nemo_fabric_adapters/hermes/adapter.py
@@ -84,7 +84,8 @@ def disabled_toolsets(payload: dict[str, Any]) -> list[str]:
 def hermes_working_directory(payload: dict[str, Any]) -> Path:
     """Resolve the normalized Hermes workspace relative to the Fabric root."""
 
-    root = Path(common_utils.base_dir(payload)).resolve()
+    base_dir = payload.get("base_dir")
+    root = Path(base_dir).resolve() if isinstance(base_dir, str) and base_dir else Path()
     environment = common_utils.environment_payload(payload)
     settings = common_utils.settings_payload(payload)
     workspace = environment.get("workspace") or settings.get("workspace")
@@ -244,7 +245,11 @@ class HermesRuntime:
         self._conversation_history: list[dict[str, Any]] | None = None
         self._session_db: Any = None
         self._agent: Any = None
+        self._invoke_hook: Any = None
         self._relay_plugin_config: dict[str, Any] | None = None
+        self._relay_session_pending = False
+        self._relay_finalize_hook_invoked = False
+        self._relay_model_name = "unknown"
         self._relay_runner: relay_cli.HermesRelayRunner | None = None
         self._hermes_cli_version: tuple[int, int, int] | None = None
 
@@ -314,6 +319,7 @@ class HermesRuntime:
 
             from hermes_cli.config import load_config
             from hermes_cli.plugins import discover_plugins
+            from hermes_cli.plugins import invoke_hook
             from hermes_state import SessionDB
             from run_agent import AIAgent
 
@@ -362,6 +368,8 @@ class HermesRuntime:
                         session_db=self._session_db,
                     )
                 )
+            self._invoke_hook = invoke_hook
+            self._relay_model_name = common_utils.relay_model_name(payload)
             self._start_payload = payload
             self._started = True
         except BaseException:
@@ -600,11 +608,38 @@ class HermesRuntime:
             ),
         }
 
+    def _finalize_relay_session(self) -> None:
+        if (
+            self._relay_plugin_config is None
+            or self._agent is None
+            or self._invoke_hook is None
+            or not self._relay_session_pending
+        ):
+            return
+        if not self._relay_finalize_hook_invoked:
+            self._invoke_hook(
+                "on_session_finalize",
+                session_id=getattr(self._agent, "session_id", ""),
+                model=getattr(self._agent, "model", None) or self._relay_model_name,
+                platform=getattr(self._agent, "platform", None) or "fabric",
+            )
+            self._relay_finalize_hook_invoked = True
+        from nemo_relay import subscribers
+
+        subscribers.flush()
+        self._relay_session_pending = False
+        self._relay_finalize_hook_invoked = False
+
     async def stop(self) -> None:
         agent = self._agent
         session_db = self._session_db
         relay_runner = self._relay_runner
         errors: list[BaseException] = []
+        if self._relay_plugin_config is not None and agent is not None:
+            try:
+                self._finalize_relay_session()
+            except BaseException as error:
+                errors.append(error)
         self._agent = None
         self._session_db = None
         self._start_payload = None
@@ -617,7 +652,11 @@ class HermesRuntime:
         self._hermes_config = {}
         self._enabled_toolsets = None
         self._conversation_history = None
+        self._invoke_hook = None
         self._relay_plugin_config = None
+        self._relay_session_pending = False
+        self._relay_finalize_hook_invoked = False
+        self._relay_model_name = "unknown"
         self._relay_runner = None
         self._hermes_cli_version = None
         self._started = False

--- a/adapters/hermes/src/nemo_fabric_adapters/hermes/adapter.py
+++ b/adapters/hermes/src/nemo_fabric_adapters/hermes/adapter.py
@@ -21,7 +21,9 @@ from pathlib import Path
 from typing import Any
 
 from nemo_fabric_adapters.common import lifecycle
+from nemo_fabric_adapters.common import relay_gateway
 import nemo_fabric_adapters.common.utils as common_utils
+from nemo_fabric_adapters.hermes import relay_cli
 
 # Default agent loop budget when harness.settings.max_iterations is unset.
 # Mirrors Hermes' own AIAgent default (agent/agent_init.py); a lower value such
@@ -66,7 +68,10 @@ def disabled_toolsets(payload: dict[str, Any]) -> list[str]:
 
 
 def build_hermes_config(
-    payload: dict[str, Any], *, relay_enabled: bool = False
+    payload: dict[str, Any],
+    *,
+    relay_enabled: bool = False,
+    exclude_relay_plugin: bool = False,
 ) -> dict[str, Any]:
     settings = common_utils.settings_payload(payload)
     model_config = common_utils.selected_model_config(payload)
@@ -122,6 +127,8 @@ def build_hermes_config(
         }
 
     plugins = common_utils.normalize_list(settings.get("plugins_enabled"))
+    if exclude_relay_plugin:
+        plugins = [plugin for plugin in plugins if plugin != "observability/nemo_relay"]
     if relay_enabled and "observability/nemo_relay" not in plugins:
         plugins.append("observability/nemo_relay")
     if plugins:
@@ -135,9 +142,14 @@ def write_hermes_config(
     hermes_home: Path,
     *,
     relay_enabled: bool = False,
+    exclude_relay_plugin: bool = False,
 ) -> tuple[Path, dict[str, Any]]:
     hermes_home.mkdir(parents=True, exist_ok=True)
-    config = build_hermes_config(payload, relay_enabled=relay_enabled)
+    config = build_hermes_config(
+        payload,
+        relay_enabled=relay_enabled,
+        exclude_relay_plugin=exclude_relay_plugin,
+    )
     config_path = hermes_home / "config.yaml"
     config_path.write_text(common_utils.dump_yaml(config), encoding="utf-8")
     return config_path, config
@@ -210,13 +222,9 @@ class HermesRuntime:
         self._conversation_history: list[dict[str, Any]] | None = None
         self._session_db: Any = None
         self._agent: Any = None
-        self._invoke_hook: Any = None
         self._relay_plugin_config: dict[str, Any] | None = None
-        self._relay_context: Any = None
-        self._relay_context_entered = False
-        self._relay_session_pending = False
-        self._relay_finalize_hook_invoked = False
-        self._relay_model_name = "unknown"
+        self._relay_runner: relay_cli.HermesRelayRunner | None = None
+        self._hermes_cli_version: tuple[int, int, int] | None = None
 
     async def start(self, payload: dict[str, Any]) -> None:
         if self._started:
@@ -226,8 +234,6 @@ class HermesRuntime:
             )
 
         try:
-            self._relay_session_pending = False
-            self._relay_finalize_hook_invoked = False
             validate_hermes_telemetry_provider(payload)
             self._settings = common_utils.settings_payload(payload)
             self._model_config = common_utils.selected_model_config(payload)
@@ -239,6 +245,36 @@ class HermesRuntime:
                 hermes_home_base, payload
             )
             self._hermes_home.mkdir(parents=True, exist_ok=True)
+
+            relay_enabled = common_utils.relay_enabled(payload)
+            if relay_enabled:
+                self._relay_plugin_config = common_utils.load_relay_plugin_config(
+                    payload
+                )
+
+            self._hermes_config_path, self._hermes_config = write_hermes_config(
+                payload,
+                self._hermes_home,
+                relay_enabled=False,
+                exclude_relay_plugin=relay_enabled,
+            )
+            api_key_env = (
+                self._settings.get("api_key_env")
+                or self._model_config.get("api_key_env")
+                or "NVIDIA_API_KEY"
+            )
+            api_key = os.environ.get(api_key_env)
+            if not api_key:
+                raise RuntimeError(f"{api_key_env} is required for Hermes mode")
+            self._base_url = common_utils.get_base_url(
+                self._settings, self._model_config
+            )
+            if relay_enabled:
+                await self._start_relay_runtime(payload)
+                self._start_payload = payload
+                self._started = True
+                return
+
             os.environ["HOME"] = str(self._hermes_home)
             os.environ["HERMES_HOME"] = str(self._hermes_home)
             os.environ.setdefault("HERMES_YOLO_MODE", "1")
@@ -253,38 +289,8 @@ class HermesRuntime:
                 str(self._settings.get("terminal_timeout", 60)),
             )
 
-            relay_enabled = common_utils.relay_enabled(payload)
-            if relay_enabled:
-                self._relay_plugin_config = common_utils.load_relay_plugin_config(
-                    payload
-                )
-                from nemo_relay import plugin
-
-                self._relay_context = plugin.plugin(self._relay_plugin_config)
-                await self._relay_context.__aenter__()
-                self._relay_context_entered = True
-
-            self._hermes_config_path, self._hermes_config = write_hermes_config(
-                payload,
-                self._hermes_home,
-                relay_enabled=relay_enabled,
-            )
-            api_key_env = (
-                self._settings.get("api_key_env")
-                or self._model_config.get("api_key_env")
-                or "NVIDIA_API_KEY"
-            )
-            api_key = os.environ.get(api_key_env)
-            if not api_key:
-                raise RuntimeError(f"{api_key_env} is required for Hermes mode")
-            self._base_url = common_utils.get_base_url(
-                self._settings, self._model_config
-            )
-            self._relay_model_name = common_utils.relay_model_name(payload)
-
             from hermes_cli.config import load_config
             from hermes_cli.plugins import discover_plugins
-            from hermes_cli.plugins import invoke_hook
             from hermes_state import SessionDB
             from run_agent import AIAgent
 
@@ -333,16 +339,93 @@ class HermesRuntime:
                         session_db=self._session_db,
                     )
                 )
-            self._invoke_hook = invoke_hook
             self._start_payload = payload
             self._started = True
         except BaseException:
             await self.stop()
             raise
 
+    async def _start_relay_runtime(self, payload: dict[str, Any]) -> None:
+        if (
+            self._hermes_home is None
+            or self._hermes_config_path is None
+            or self._runtime_id is None
+            or self._relay_plugin_config is None
+        ):
+            raise RuntimeError("Hermes Relay runtime state is incomplete")
+        root = Path(common_utils.base_dir(payload)).resolve()
+        relay_command = (
+            self._settings.get("nemo_relay_command")
+            or self._settings.get("relay_cli_command")
+            or "nemo-relay"
+        )
+        hermes_command = (
+            self._settings.get("hermes_command")
+            or self._settings.get("command")
+            or "hermes"
+        )
+        relay_executable = relay_cli.resolve_executable(
+            root, relay_command, name="NeMo Relay CLI"
+        )
+        hermes_executable = relay_cli.resolve_executable(
+            root, hermes_command, name="Hermes CLI"
+        )
+        relay_contract, hermes_version = await asyncio.gather(
+            asyncio.to_thread(relay_gateway.relay_cli_contract, relay_executable),
+            asyncio.to_thread(relay_cli.hermes_cli_version, hermes_executable),
+        )
+        self._hermes_cli_version = hermes_version
+        base_url = relay_cli.validate_openai_upstream(
+            self._settings, self._model_config, self._base_url
+        )
+        model = str(
+            self._settings.get("model_name") or self._model_config.get("model") or ""
+        )
+        if not model:
+            raise relay_cli.HermesRelayError("Hermes Relay execution requires a model")
+        environment = common_utils.environment_payload(payload)
+        cwd = Path(self._settings.get("cwd") or environment.get("workspace") or root)
+        if not cwd.is_absolute():
+            cwd = root / cwd
+        env = relay_cli.child_environment(
+            self._settings,
+            self._model_config,
+            self._relay_plugin_config,
+            self._hermes_home,
+        )
+        await asyncio.to_thread(
+            _ensure_hermes_runtime_session,
+            self._hermes_home,
+            self._runtime_id,
+            model,
+            self._model_config,
+            str(cwd.resolve()),
+        )
+        self._relay_runner = relay_cli.HermesRelayRunner(
+            relay_cli.HermesRelayLaunch(
+                relay_executable=relay_executable,
+                relay_contract=relay_contract,
+                hermes_executable=hermes_executable,
+                hermes_config_path=self._hermes_config_path,
+                hermes_home=self._hermes_home,
+                cwd=cwd.resolve(),
+                env=env,
+                base_url=base_url,
+                model=model,
+                runtime_id=self._runtime_id,
+                settings=self._settings,
+                model_config=self._model_config,
+                plugin_config=self._relay_plugin_config,
+            )
+        )
+
     async def invoke(self, invocation: dict[str, Any]) -> dict[str, Any]:
         start_payload = self._start_payload
-        if not self._started or self._agent is None or start_payload is None:
+        if (
+            not self._started
+            or start_payload is None
+            or (self._agent is None and self._relay_runner is None)
+        ):
             raise lifecycle.LifecycleError(
                 "hermes_runtime_not_started",
                 "Hermes runtime is not started",
@@ -362,6 +445,8 @@ class HermesRuntime:
         user_message = request.get("input") or ""
         if not isinstance(user_message, str):
             user_message = json.dumps(user_message, sort_keys=True)
+        if self._relay_runner is not None:
+            return await self._invoke_relay(payload, user_message)
 
         def invoke_turn() -> tuple[dict[str, Any], str]:
             return _invoke_hermes_turn(
@@ -431,43 +516,75 @@ class HermesRuntime:
             )
         return output
 
-    def _finalize_relay_session(self) -> None:
-        if (
-            self._relay_plugin_config is None
-            or self._agent is None
-            or self._invoke_hook is None
-            or not self._relay_session_pending
-        ):
-            return
-        if not self._relay_finalize_hook_invoked:
-            self._invoke_hook(
-                "on_session_finalize",
-                session_id=getattr(self._agent, "session_id", ""),
-                model=getattr(self._agent, "model", None) or self._relay_model_name,
-                platform=getattr(self._agent, "platform", None) or "fabric",
+    async def _invoke_relay(
+        self, payload: dict[str, Any], user_message: str
+    ) -> dict[str, Any]:
+        if self._relay_runner is None:
+            raise RuntimeError("Hermes Relay runtime is not initialized")
+        context = common_utils.runtime_context(payload)
+        invocation_id = str(
+            context.get("invocation_id")
+            or context.get("request_id")
+            or f"{self._runtime_id}-invocation"
+        )
+        result = await self._relay_runner.invoke(user_message, invocation_id)
+        response = relay_cli.quiet_response(result.stdout)
+        failed = result.returncode != 0
+        error = None
+        if failed:
+            error = (
+                "NeMo Relay/Hermes exited with status "
+                f"{result.returncode}; see {result.stderr_path}"
             )
-            self._relay_finalize_hook_invoked = True
-        # Relay subscriber callbacks are queued. The long-lived plugin context
-        # does not flush them until runtime shutdown, but invocation results
-        # must include artifacts produced by this turn.
-        from nemo_relay import subscribers
-
-        subscribers.flush()
-        self._relay_session_pending = False
-        self._relay_finalize_hook_invoked = False
+        return {
+            "harness": "hermes",
+            "adapter": "cli",
+            "mode": "hermes_relay_gateway",
+            "model": self._model_config.get("model"),
+            "base_url": self._base_url,
+            "response": response,
+            "completed": not failed or bool(response),
+            "failed": failed,
+            "api_calls": None,
+            "messages": [],
+            "message_count": 0,
+            "error": error,
+            "adapter_stdout": result.stdout,
+            "hermes_home": str(self._hermes_home),
+            "hermes_config_path": str(self._hermes_config_path),
+            "hermes_native_config": summarize_hermes_config(self._hermes_config),
+            "enabled_toolsets": common_utils.normalize_list(
+                self._settings.get("enabled_toolsets")
+            ),
+            "command": result.command,
+            "returncode": result.returncode,
+            "stdout_path": str(result.stdout_path),
+            "stderr_path": str(result.stderr_path),
+            "output_truncated": result.truncated,
+            "relay_runtime": {
+                "enabled": True,
+                "config_path": str(result.config_path),
+                "plugin_config_path": str(result.plugin_config_path),
+                "emitter": "nemo-relay.cli-gateway",
+                "model_event_source": "gateway",
+                "hook_event_policy": "lifecycle_context_only",
+                "relay_version": ".".join(
+                    str(value) for value in self._relay_runner.relay_version
+                ),
+                "hermes_version": ".".join(
+                    str(value) for value in self._hermes_cli_version or ()
+                ),
+            },
+            "relay_artifacts": common_utils.collect_relay_artifacts(
+                result.plugin_config
+            ),
+        }
 
     async def stop(self) -> None:
         agent = self._agent
         session_db = self._session_db
-        relay_context = self._relay_context
-        relay_context_entered = self._relay_context_entered
-        relay_plugin_config = self._relay_plugin_config
+        relay_runner = self._relay_runner
         errors: list[BaseException] = []
-        if relay_plugin_config is not None and agent is not None:
-            try:
-                self._finalize_relay_session()
-            except BaseException as error:
-                errors.append(error)
         self._agent = None
         self._session_db = None
         self._start_payload = None
@@ -480,15 +597,16 @@ class HermesRuntime:
         self._hermes_config = {}
         self._enabled_toolsets = None
         self._conversation_history = None
-        self._relay_context = None
-        self._relay_context_entered = False
-        self._relay_session_pending = False
-        self._relay_finalize_hook_invoked = False
-        self._invoke_hook = None
         self._relay_plugin_config = None
-        self._relay_model_name = "unknown"
+        self._relay_runner = None
+        self._hermes_cli_version = None
         self._started = False
 
+        if relay_runner is not None:
+            try:
+                await relay_runner.stop()
+            except BaseException as error:
+                errors.append(error)
         if agent is not None:
             try:
                 agent.close()
@@ -499,12 +617,6 @@ class HermesRuntime:
                 session_db.close()
             except BaseException as error:
                 errors.append(error)
-        if relay_context is not None and relay_context_entered:
-            try:
-                await relay_context.__aexit__(None, None, None)
-            except BaseException as error:
-                errors.append(error)
-
         if errors:
             for error in errors:
                 if isinstance(error, asyncio.CancelledError):
@@ -540,6 +652,30 @@ def _invoke_hermes_turn(
             **conversation_kwargs,
         )
     return result, hermes_stdout.getvalue()
+
+
+def _ensure_hermes_runtime_session(
+    hermes_home: Path,
+    runtime_id: str,
+    model: str,
+    model_config: dict[str, Any],
+    cwd: str,
+) -> None:
+    """Create the stable session that ``hermes chat --continue`` resumes."""
+
+    from hermes_state import SessionDB
+
+    session_db = SessionDB(db_path=hermes_home / "state.db")
+    try:
+        session_db.create_session(
+            runtime_id,
+            "fabric",
+            model=model,
+            model_config=model_config,
+            cwd=cwd,
+        )
+    finally:
+        session_db.close()
 
 
 def filter_supported_kwargs(callable_obj: Any, **kwargs: Any) -> dict[str, Any]:

--- a/adapters/hermes/src/nemo_fabric_adapters/hermes/adapter.py
+++ b/adapters/hermes/src/nemo_fabric_adapters/hermes/adapter.py
@@ -31,6 +31,7 @@ from nemo_fabric_adapters.hermes import relay_cli
 # answering while the trial still reports success). See FABRIC-85.
 DEFAULT_MAX_ITERATIONS: int = 90
 LOGGER = logging.getLogger(__name__)
+NATIVE_RELAY_PLUGIN = "observability/nemo_relay"
 
 
 def _fabric_stream_sink_enabled(config: dict[str, Any] | None) -> bool:
@@ -57,6 +58,19 @@ def validate_hermes_telemetry_provider(payload: dict[str, Any]) -> None:
     providers = common_utils.telemetry_providers(payload)
     if any(provider != "relay" for provider in providers):
         raise ValueError("only relay telemetry is supported for Hermes")
+
+
+def validate_hermes_relay_plugin_mode(payload: dict[str, Any]) -> None:
+    """Reject the native Relay plugin outside Fabric-managed Relay telemetry."""
+
+    plugins = common_utils.normalize_list(
+        common_utils.settings_payload(payload).get("plugins_enabled")
+    )
+    if not common_utils.relay_enabled(payload) and NATIVE_RELAY_PLUGIN in plugins:
+        raise ValueError(
+            "observability/nemo_relay cannot be enabled directly; "
+            "enable Fabric Relay telemetry instead"
+        )
 
 
 def disabled_toolsets(payload: dict[str, Any]) -> list[str]:
@@ -128,9 +142,9 @@ def build_hermes_config(
 
     plugins = common_utils.normalize_list(settings.get("plugins_enabled"))
     if exclude_relay_plugin:
-        plugins = [plugin for plugin in plugins if plugin != "observability/nemo_relay"]
-    if relay_enabled and "observability/nemo_relay" not in plugins:
-        plugins.append("observability/nemo_relay")
+        plugins = [plugin for plugin in plugins if plugin != NATIVE_RELAY_PLUGIN]
+    if relay_enabled and NATIVE_RELAY_PLUGIN not in plugins:
+        plugins.append(NATIVE_RELAY_PLUGIN)
     if plugins:
         config["plugins"] = {"enabled": plugins}
 
@@ -235,6 +249,7 @@ class HermesRuntime:
 
         try:
             validate_hermes_telemetry_provider(payload)
+            validate_hermes_relay_plugin_mode(payload)
             self._settings = common_utils.settings_payload(payload)
             self._model_config = common_utils.selected_model_config(payload)
             self._runtime_id = common_utils.runtime_id(payload)

--- a/adapters/hermes/src/nemo_fabric_adapters/hermes/relay_cli.py
+++ b/adapters/hermes/src/nemo_fabric_adapters/hermes/relay_cli.py
@@ -385,7 +385,12 @@ def _write_configs(
     except ImportError as error:
         raise HermesRelayError("tomli_w is required for Relay execution") from error
 
-    invocation_dir.mkdir(parents=True, exist_ok=False)
+    try:
+        invocation_dir.mkdir(parents=True, exist_ok=False)
+    except OSError as error:
+        raise HermesRelayError(
+            f"NeMo Relay invocation directory could not be created: {invocation_dir}"
+        ) from error
     config_path = invocation_dir / "config.toml"
     plugin_config_path = invocation_dir / "plugins.toml"
     plugin_config = copy.deepcopy(launch.plugin_config)

--- a/adapters/hermes/src/nemo_fabric_adapters/hermes/relay_cli.py
+++ b/adapters/hermes/src/nemo_fabric_adapters/hermes/relay_cli.py
@@ -1,0 +1,531 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Invocation-scoped Hermes execution through the public NeMo Relay CLI."""
+
+from __future__ import annotations
+
+import asyncio
+import copy
+import hashlib
+import os
+import re
+import shutil
+import signal
+import subprocess
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+import nemo_fabric_adapters.common.utils as common_utils
+from nemo_fabric_adapters.common.relay_gateway import RelayCliContract
+
+
+HERMES_MINIMUM_VERSION = (0, 18, 2)
+HERMES_MAXIMUM_VERSION = (0, 19, 0)
+HERMES_VERSION_TIMEOUT_SECONDS = 5.0
+PROCESS_STOP_TIMEOUT_SECONDS = 10.0
+MAX_CAPTURE_BYTES = 4 * 1024 * 1024
+ANSI_ESCAPE = re.compile(r"\x1b\[[0-?]*[ -/]*[@-~]")
+INHERITED_ENV_NAMES = {
+    "APPDATA",
+    "COMSPEC",
+    "HTTP_PROXY",
+    "HTTPS_PROXY",
+    "LANG",
+    "LC_ALL",
+    "LC_CTYPE",
+    "LOCALAPPDATA",
+    "NO_PROXY",
+    "PATH",
+    "PATHEXT",
+    "SHELL",
+    "SSL_CERT_DIR",
+    "SSL_CERT_FILE",
+    "SYSTEMROOT",
+    "TEMP",
+    "TMP",
+    "TMPDIR",
+    "USER",
+    "USERPROFILE",
+    "XDG_CACHE_HOME",
+    "XDG_DATA_HOME",
+    "http_proxy",
+    "https_proxy",
+    "no_proxy",
+}
+
+
+class HermesRelayError(RuntimeError):
+    """Hermes/Relay CLI lifecycle or contract failure."""
+
+
+@dataclass(frozen=True)
+class HermesRelayLaunch:
+    """Stable runtime inputs used to execute invocation-scoped Relay runs."""
+
+    relay_executable: Path
+    relay_contract: RelayCliContract
+    hermes_executable: Path
+    hermes_config_path: Path
+    hermes_home: Path
+    cwd: Path
+    env: dict[str, str]
+    base_url: str
+    model: str
+    runtime_id: str
+    settings: dict[str, Any]
+    model_config: dict[str, Any]
+    plugin_config: dict[str, Any]
+
+
+@dataclass(frozen=True)
+class HermesRelayResult:
+    """Bounded output and evidence from one Relay-owned Hermes process."""
+
+    command: list[str]
+    returncode: int
+    stdout: str
+    stderr: str
+    stdout_path: Path
+    stderr_path: Path
+    config_path: Path
+    plugin_config_path: Path
+    plugin_config: dict[str, Any]
+    truncated: bool
+
+
+def resolve_executable(root: Path, value: str | Path, *, name: str) -> Path:
+    """Resolve a configured executable without invoking a shell."""
+
+    command = Path(value)
+    if len(command.parts) == 1:
+        resolved = shutil.which(str(command))
+    else:
+        candidate = command if command.is_absolute() else root / command
+        resolved = shutil.which(str(candidate.resolve()))
+    if resolved is None:
+        raise HermesRelayError(f"{name} executable was not found")
+    return Path(resolved).resolve()
+
+
+def hermes_cli_version(executable: Path) -> tuple[int, int, int]:
+    """Validate the Hermes CLI features consumed by the gateway path."""
+
+    try:
+        completed = subprocess.run(
+            [str(executable), "--version"],
+            stdout=subprocess.PIPE,
+            stderr=subprocess.STDOUT,
+            text=True,
+            timeout=HERMES_VERSION_TIMEOUT_SECONDS,
+            check=False,
+        )
+    except (OSError, subprocess.TimeoutExpired) as error:
+        raise HermesRelayError("Hermes CLI version could not be determined") from error
+    # Hermes renders the package version as ``v0.18.2`` before a separate
+    # calendar build version. A word-boundary regex skips the package version
+    # because both ``v`` and ``0`` are word characters.
+    match = re.search(r"(?<!\d)(\d+)\.(\d+)\.(\d+)(?!\d)", completed.stdout)
+    if completed.returncode != 0 or match is None:
+        raise HermesRelayError("Hermes CLI version could not be determined")
+    version = tuple(int(value) for value in match.groups())
+    if not HERMES_MINIMUM_VERSION <= version < HERMES_MAXIMUM_VERSION:
+        rendered = ".".join(str(value) for value in version)
+        raise HermesRelayError(
+            f"unsupported Hermes CLI version {rendered}; "
+            "Fabric requires >=0.18.2,<0.19.0 for Relay execution"
+        )
+    return version
+
+
+def validate_openai_upstream(
+    settings: dict[str, Any], model_config: dict[str, Any], base_url: str | None
+) -> str:
+    """Reject provider configurations the transparent OpenAI route cannot preserve."""
+
+    provider = str(
+        settings.get("provider") or model_config.get("provider") or ""
+    ).lower()
+    if provider == "anthropic":
+        raise HermesRelayError(
+            "Hermes Relay execution requires an OpenAI-compatible provider endpoint"
+        )
+    if not base_url:
+        raise HermesRelayError(
+            "Hermes Relay execution requires an OpenAI-compatible base URL"
+        )
+    return base_url
+
+
+def child_environment(
+    settings: dict[str, Any],
+    model_config: dict[str, Any],
+    plugin_config: dict[str, Any],
+    hermes_home: Path,
+) -> dict[str, str]:
+    """Build a least-privilege child environment without mutating Fabric.
+
+    Relay and Hermes receive portable process variables, explicitly configured
+    values, the selected model credential, and environment variables named by
+    the Relay plugin configuration. Unrelated host credentials are not copied.
+    """
+
+    configured = settings.get("env") or {}
+    if not isinstance(configured, dict) or any(
+        not isinstance(key, str) or not isinstance(value, str)
+        for key, value in configured.items()
+    ):
+        raise HermesRelayError("harness.settings.env must contain strings")
+    inherited = common_utils.virtualenv_subprocess_env()
+    names = set(INHERITED_ENV_NAMES)
+    names.update(name for name in inherited if name.startswith("LC_"))
+    names.update(_referenced_environment_names(plugin_config))
+    api_key_env = str(
+        settings.get("api_key_env")
+        or model_config.get("api_key_env")
+        or "NVIDIA_API_KEY"
+    )
+    names.add(api_key_env)
+    env = {name: inherited[name] for name in names if name in inherited}
+    for name in ("PATH", "VIRTUAL_ENV"):
+        if name in inherited:
+            env[name] = inherited[name]
+    env.update(configured)
+    if api_key_env in inherited:
+        # Hermes is intentionally forced through its OpenAI-compatible custom
+        # provider so Relay can own the gateway. Keep the source credential
+        # available for plugin references and map it only in the child.
+        env["OPENAI_API_KEY"] = inherited[api_key_env]
+    env.update(
+        {
+            "HOME": str(hermes_home),
+            "HERMES_HOME": str(hermes_home),
+            "HERMES_YOLO_MODE": "1",
+            "HERMES_ACCEPT_HOOKS": "1",
+            "HERMES_SESSION_SOURCE": "fabric",
+            "TERMINAL_ENV": str(settings.get("terminal_backend", "local")),
+            "TERMINAL_TIMEOUT": str(settings.get("terminal_timeout", 60)),
+            "XDG_CONFIG_HOME": str(hermes_home / ".config"),
+        }
+    )
+    return env
+
+
+def _referenced_environment_names(value: Any) -> set[str]:
+    """Collect credential variable names from normalized Relay configuration."""
+
+    names: set[str] = set()
+    if isinstance(value, list):
+        for item in value:
+            names.update(_referenced_environment_names(item))
+        return names
+    if not isinstance(value, dict):
+        return names
+    for key, item in value.items():
+        if key == "header_env" and isinstance(item, dict):
+            names.update(
+                name for name in item.values() if isinstance(name, str) and name
+            )
+        elif (key.endswith("_env") or key.endswith("_var")) and isinstance(item, str):
+            if item:
+                names.add(item)
+        names.update(_referenced_environment_names(item))
+    return names
+
+
+def build_hermes_args(launch: HermesRelayLaunch, prompt: str) -> list[str]:
+    """Build the Hermes portion passed after ``nemo-relay run --``."""
+
+    args = [
+        *common_utils.normalize_list(
+            launch.settings.get("hermes_args") or launch.settings.get("command_args")
+        ),
+        "chat",
+        "-Q",
+        "--query",
+        prompt,
+        "--continue",
+        launch.runtime_id,
+        "--model",
+        launch.model,
+        "--provider",
+        "custom",
+    ]
+    toolsets = common_utils.normalize_list(launch.settings.get("enabled_toolsets"))
+    if toolsets:
+        args.extend(["--toolsets", ",".join(toolsets)])
+    return args
+
+
+def redact_command(command: list[str]) -> list[str]:
+    """Remove prompt contents from command evidence."""
+
+    redacted: list[str] = []
+    redact_next = False
+    for argument in command:
+        if redact_next:
+            redacted.append("<prompt>")
+            redact_next = False
+        else:
+            redacted.append(argument)
+        if argument in {"--query", "--oneshot", "-z"}:
+            redact_next = True
+    return redacted
+
+
+def quiet_response(stdout: str) -> str:
+    """Parse Hermes 0.18.x's documented quiet response channel."""
+
+    lines: list[str] = []
+    for line in stdout.splitlines():
+        plain = ANSI_ESCAPE.sub("", line).strip()
+        # Hermes 0.18.2 emits this optional-security diagnostic on stdout
+        # before it enters quiet mode. It is not part of the model response.
+        if plain.startswith("⚠ tirith security scanner enabled but not available"):
+            continue
+        lines.append(line)
+    return "\n".join(lines).strip()
+
+
+class HermesRelayRunner:
+    """Own at most one Relay/Hermes process for a persistent Fabric runtime."""
+
+    def __init__(self, launch: HermesRelayLaunch) -> None:
+        self._launch = launch
+        self._process: asyncio.subprocess.Process | None = None
+        self._sequence = 0
+        self._invoke_lock = asyncio.Lock()
+
+    @property
+    def relay_version(self) -> tuple[int, int, int]:
+        return self._launch.relay_contract.version
+
+    async def invoke(self, prompt: str, invocation_id: str) -> HermesRelayResult:
+        async with self._invoke_lock:
+            self._sequence += 1
+            invocation_dir = (
+                self._launch.hermes_home
+                / "relay"
+                / "invocations"
+                / f"{_safe_id(invocation_id)}-{self._sequence:04d}"
+            )
+            config_path, plugin_config_path, plugin_config = _write_configs(
+                self._launch, invocation_dir
+            )
+            command = [
+                str(self._launch.relay_executable),
+                "run",
+                "--config",
+                str(config_path),
+                "--agent",
+                "hermes",
+                "--",
+                *build_hermes_args(self._launch, prompt),
+            ]
+            stdout_path = invocation_dir / "stdout.log"
+            stderr_path = invocation_dir / "stderr.log"
+            try:
+                preexec_fn = (
+                    _linux_parent_death_signal
+                    if sys.platform.startswith("linux")
+                    else None
+                )
+                process = await asyncio.create_subprocess_exec(
+                    *command,
+                    cwd=self._launch.cwd,
+                    env=self._launch.env,
+                    stdout=asyncio.subprocess.PIPE,
+                    stderr=asyncio.subprocess.PIPE,
+                    start_new_session=True,
+                    preexec_fn=preexec_fn,
+                )
+            except OSError as error:
+                raise HermesRelayError(
+                    f"NeMo Relay could not start; see {stderr_path}"
+                ) from error
+            self._process = process
+            stdout_task = asyncio.create_task(_drain(process.stdout))
+            stderr_task = asyncio.create_task(_drain(process.stderr))
+            try:
+                returncode = await process.wait()
+            except asyncio.CancelledError:
+                try:
+                    await _stop_process(process)
+                finally:
+                    await asyncio.gather(
+                        stdout_task, stderr_task, return_exceptions=True
+                    )
+                raise
+            finally:
+                if self._process is process:
+                    self._process = None
+            stdout_bytes, stdout_truncated = await stdout_task
+            stderr_bytes, stderr_truncated = await stderr_task
+            stdout_path.write_bytes(stdout_bytes)
+            stderr_path.write_bytes(stderr_bytes)
+            return HermesRelayResult(
+                command=redact_command(command),
+                returncode=returncode,
+                stdout=stdout_bytes.decode("utf-8", errors="replace"),
+                stderr=stderr_bytes.decode("utf-8", errors="replace"),
+                stdout_path=stdout_path,
+                stderr_path=stderr_path,
+                config_path=config_path,
+                plugin_config_path=plugin_config_path,
+                plugin_config=plugin_config,
+                truncated=stdout_truncated or stderr_truncated,
+            )
+
+    async def stop(self) -> None:
+        process = self._process
+        if process is not None:
+            await _stop_process(process)
+
+
+def _write_configs(
+    launch: HermesRelayLaunch, invocation_dir: Path
+) -> tuple[Path, Path, dict[str, Any]]:
+    try:
+        import tomli_w
+    except ImportError as error:
+        raise HermesRelayError("tomli_w is required for Relay execution") from error
+
+    invocation_dir.mkdir(parents=True, exist_ok=False)
+    config_path = invocation_dir / "config.toml"
+    plugin_config_path = invocation_dir / "plugins.toml"
+    plugin_config = copy.deepcopy(launch.plugin_config)
+    _scope_artifact_directories(plugin_config, invocation_dir / "artifacts")
+    config_path.write_text(
+        tomli_w.dumps(
+            {
+                "agents": {
+                    "hermes": {
+                        "command": str(launch.hermes_executable),
+                        "hooks_path": str(launch.hermes_config_path),
+                    }
+                },
+                "upstream": {"openai_base_url": launch.base_url},
+            }
+        ),
+        encoding="utf-8",
+    )
+    plugin_config_path.write_text(
+        tomli_w.dumps(
+            common_utils.relay_cli_plugin_config(
+                plugin_config,
+                observability_version=launch.relay_contract.observability_version,
+            )
+        ),
+        encoding="utf-8",
+    )
+    return config_path, plugin_config_path, plugin_config
+
+
+def _scope_artifact_directories(
+    plugin_config: dict[str, Any], artifact_dir: Path
+) -> None:
+    """Keep overwrite-mode exporters distinct across runtime invocations."""
+
+    for component in plugin_config.get("components", []):
+        if not isinstance(component, dict) or component.get("kind") != "observability":
+            continue
+        config = component.get("config") or {}
+        atof = config.get("atof")
+        if isinstance(atof, dict):
+            for sink in atof.get("sinks") or []:
+                if isinstance(sink, dict) and sink.get("type") == "file":
+                    sink["output_directory"] = str(artifact_dir / "atof")
+                    (artifact_dir / "atof").mkdir(parents=True, exist_ok=True)
+        atif = config.get("atif")
+        if isinstance(atif, dict) and atif.get("enabled"):
+            atif["output_directory"] = str(artifact_dir / "atif")
+            (artifact_dir / "atif").mkdir(parents=True, exist_ok=True)
+
+
+async def _drain(
+    stream: asyncio.StreamReader | None,
+) -> tuple[bytes, bool]:
+    if stream is None:
+        return b"", False
+    captured = bytearray()
+    tail = bytearray()
+    truncated = False
+    marker = b"\n...[output truncated]...\n"
+    available = max(0, MAX_CAPTURE_BYTES - len(marker))
+    head_limit = available // 2
+    tail_limit = available - head_limit
+    while chunk := await stream.read(64 * 1024):
+        if not truncated and len(captured) + len(chunk) <= MAX_CAPTURE_BYTES:
+            captured.extend(chunk)
+            continue
+        if not truncated:
+            combined = captured + chunk
+            captured = combined[:head_limit]
+            if tail_limit:
+                tail = combined[-tail_limit:]
+            truncated = True
+            continue
+        if tail_limit:
+            tail.extend(chunk)
+            if len(tail) > tail_limit:
+                del tail[:-tail_limit]
+    if not truncated:
+        return bytes(captured), False
+    return bytes(captured) + marker + bytes(tail), True
+
+
+async def _stop_process(process: asyncio.subprocess.Process) -> None:
+    if process.returncode is not None:
+        return
+    try:
+        if os.name == "posix":
+            os.killpg(process.pid, signal.SIGINT)
+        else:
+            process.terminate()
+    except ProcessLookupError:
+        return
+    try:
+        await asyncio.wait_for(process.wait(), timeout=PROCESS_STOP_TIMEOUT_SECONDS)
+        return
+    except TimeoutError:
+        pass
+    try:
+        if os.name == "posix":
+            os.killpg(process.pid, signal.SIGTERM)
+        else:
+            process.terminate()
+    except ProcessLookupError:
+        return
+    try:
+        await asyncio.wait_for(process.wait(), timeout=PROCESS_STOP_TIMEOUT_SECONDS)
+        return
+    except TimeoutError:
+        pass
+    try:
+        if os.name == "posix":
+            os.killpg(process.pid, signal.SIGKILL)
+        else:
+            process.kill()
+    except ProcessLookupError:
+        return
+    await asyncio.wait_for(process.wait(), timeout=PROCESS_STOP_TIMEOUT_SECONDS)
+
+
+def _safe_id(value: str) -> str:
+    normalized = re.sub(r"[^A-Za-z0-9_.-]+", "-", value).strip(".-")[:48]
+    digest = hashlib.sha256(value.encode()).hexdigest()[:8]
+    return f"{normalized or 'invocation'}-{digest}"
+
+
+def _linux_parent_death_signal() -> None:
+    """Ask Linux to stop Relay if Fabric's Python host is killed on timeout."""
+
+    import ctypes
+
+    libc = ctypes.CDLL(None, use_errno=True)
+    if libc.prctl(1, signal.SIGTERM) != 0:
+        raise OSError(ctypes.get_errno(), "prctl(PR_SET_PDEATHSIG) failed")
+    if os.getppid() == 1:
+        os.kill(os.getpid(), signal.SIGTERM)

--- a/adapters/hermes/src/nemo_fabric_adapters/hermes/relay_cli.py
+++ b/adapters/hermes/src/nemo_fabric_adapters/hermes/relay_cli.py
@@ -13,7 +13,6 @@ import re
 import shutil
 import signal
 import subprocess
-import sys
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
@@ -327,11 +326,6 @@ class HermesRelayRunner:
             stdout_path = invocation_dir / "stdout.log"
             stderr_path = invocation_dir / "stderr.log"
             try:
-                preexec_fn = (
-                    _linux_parent_death_signal
-                    if sys.platform.startswith("linux")
-                    else None
-                )
                 process = await asyncio.create_subprocess_exec(
                     *command,
                     cwd=self._launch.cwd,
@@ -339,7 +333,6 @@ class HermesRelayRunner:
                     stdout=asyncio.subprocess.PIPE,
                     stderr=asyncio.subprocess.PIPE,
                     start_new_session=True,
-                    preexec_fn=preexec_fn,
                 )
             except OSError as error:
                 raise HermesRelayError(
@@ -517,15 +510,3 @@ def _safe_id(value: str) -> str:
     normalized = re.sub(r"[^A-Za-z0-9_.-]+", "-", value).strip(".-")[:48]
     digest = hashlib.sha256(value.encode()).hexdigest()[:8]
     return f"{normalized or 'invocation'}-{digest}"
-
-
-def _linux_parent_death_signal() -> None:
-    """Ask Linux to stop Relay if Fabric's Python host is killed on timeout."""
-
-    import ctypes
-
-    libc = ctypes.CDLL(None, use_errno=True)
-    if libc.prctl(1, signal.SIGTERM) != 0:
-        raise OSError(ctypes.get_errno(), "prctl(PR_SET_PDEATHSIG) failed")
-    if os.getppid() == 1:
-        os.kill(os.getpid(), signal.SIGTERM)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -60,7 +60,7 @@ hermes = [
 
 hermes-agent = [
     "nemo-fabric-adapters-hermes == 0.2.0; python_version < '3.14'",
-    "hermes-agent>=0.17.0; python_version < '3.14'",
+    "hermes-agent>=0.18.2,<0.19; python_version < '3.14'",
 ]
 
 relay = [

--- a/tests/adapters/test_adapaters_common_utils.py
+++ b/tests/adapters/test_adapaters_common_utils.py
@@ -361,6 +361,28 @@ def test_load_relay_plugin_config_wraps_and_normalizes_bare_observability_config
     ]
 
 
+@pytest.mark.parametrize("version", [None, [], "two", "2", 2.0, True])
+def test_relay_cli_plugin_config_rejects_malformed_observability_versions(
+    version: object,
+):
+    plugin_config = {
+        "components": [
+            {
+                "kind": "observability",
+                "config": {"version": version},
+            }
+        ]
+    }
+
+    with pytest.raises(
+        ValueError, match="NeMo Relay observability config version 2 is required"
+    ):
+        common_utils.relay_cli_plugin_config(
+            plugin_config,
+            observability_version=2,
+        )
+
+
 def test_collect_relay_artifacts(tmp_path: Path):
     atof_dir = tmp_path / "atof"
     atif_dir = tmp_path / "atif"

--- a/tests/adapters/test_adapaters_common_utils.py
+++ b/tests/adapters/test_adapaters_common_utils.py
@@ -361,7 +361,7 @@ def test_load_relay_plugin_config_wraps_and_normalizes_bare_observability_config
     ]
 
 
-@pytest.mark.parametrize("version", [None, [], "two", "2", 2.0, True])
+@pytest.mark.parametrize("version", [None, [], "two", "2", 1, 2.0, 3, True])
 def test_relay_cli_plugin_config_rejects_malformed_observability_versions(
     version: object,
 ):
@@ -370,6 +370,28 @@ def test_relay_cli_plugin_config_rejects_malformed_observability_versions(
             {
                 "kind": "observability",
                 "config": {"version": version},
+            }
+        ]
+    }
+
+    with pytest.raises(
+        ValueError, match="NeMo Relay observability config version 2 is required"
+    ):
+        common_utils.relay_cli_plugin_config(
+            plugin_config,
+            observability_version=2,
+        )
+
+
+@pytest.mark.parametrize("config", [None, [], "2"])
+def test_relay_cli_plugin_config_rejects_non_mapping_observability_config(
+    config: object,
+):
+    plugin_config = {
+        "components": [
+            {
+                "kind": "observability",
+                "config": config,
             }
         ]
     }

--- a/tests/adapters/test_hermes_adapter.py
+++ b/tests/adapters/test_hermes_adapter.py
@@ -12,6 +12,7 @@ import os
 import sys
 from pathlib import Path
 from types import ModuleType
+from unittest.mock import AsyncMock
 from unittest.mock import MagicMock
 
 import pytest
@@ -58,11 +59,52 @@ def test_validate_hermes_telemetry_provider_rejects_mixed_native_and_relay():
         adapter.validate_hermes_telemetry_provider(payload)
 
 
-def test_build_hermes_config_maps_fabric_config_to_hermes_config():
+async def test_stop_stops_relay_runner_and_resets_runtime_state():
+    relay_runner = MagicMock()
+    relay_runner.stop = AsyncMock()
+    runtime = adapter.HermesRuntime()
+    runtime._started = True
+    runtime._runtime_id = "runtime-1"
+    runtime._settings = {"model": "test"}
+    runtime._relay_runner = relay_runner
+
+    await runtime.stop()
+
+    relay_runner.stop.assert_awaited_once_with()
+    assert runtime._relay_runner is None
+    assert runtime._runtime_id is None
+    assert runtime._settings == {}
+    assert runtime._started is False
+
+
+async def test_stop_resets_runtime_state_and_reports_relay_runner_failure():
+    relay_runner = MagicMock()
+    relay_runner.stop = AsyncMock(side_effect=RuntimeError("stop failed"))
+    runtime = adapter.HermesRuntime()
+    runtime._started = True
+    runtime._runtime_id = "runtime-1"
+    runtime._relay_runner = relay_runner
+
+    with pytest.raises(
+        adapter.lifecycle.LifecycleError,
+        match="Hermes runtime failed to stop cleanly",
+    ) as error:
+        await runtime.stop()
+
+    relay_runner.stop.assert_awaited_once_with()
+    assert error.value.code == "hermes_runtime_stop_failed"
+    assert runtime._relay_runner is None
+    assert runtime._runtime_id is None
+    assert runtime._started is False
+
+
+def test_build_hermes_config_maps_fabric_config_to_hermes_config(tmp_path: Path):
     os.environ["MCP_URL"] = "http://localhost:9000/mcp"
+    root = tmp_path / "fabric-root"
+    workspace = tmp_path / "workspace" / "repo"
     payload = {
-        "base_dir": "/fabric-root",
-        "runtime_context": {"environment": {"workspace": "/workspace/repo"}},
+        "base_dir": str(root),
+        "runtime_context": {"environment": {"workspace": str(workspace)}},
         "capability_plan": {
             "native": {
                 "skill_paths": ["skills/review"],
@@ -114,7 +156,7 @@ def test_build_hermes_config_maps_fabric_config_to_hermes_config():
         },
         "terminal": {
             "backend": "local",
-            "cwd": "/workspace/repo",
+            "cwd": str(workspace),
             "timeout": 90,
         },
         "skills": {"external_dirs": ["skills/review"]},
@@ -147,11 +189,13 @@ def test_default_max_iterations_matches_hermes_library_default():
     assert adapter.DEFAULT_MAX_ITERATIONS == hermes_default
 
 
-def test_build_hermes_config_omits_max_turns_when_max_iterations_unset():
+def test_build_hermes_config_omits_max_turns_when_max_iterations_unset(
+    tmp_path: Path,
+):
     # When max_iterations is unset the config layer must leave agent.max_turns
     # absent so Hermes applies its own default rather than a starving override.
     payload = {
-        "base_dir": "/fabric-root",
+        "base_dir": str(tmp_path / "fabric-root"),
         "config": {
             "harness": {"settings": {}},
             "models": {"default": {"provider": "nvidia", "model": "nvidia/test-model"}},
@@ -163,11 +207,13 @@ def test_build_hermes_config_omits_max_turns_when_max_iterations_unset():
     assert "max_turns" not in config["agent"]
 
 
-def test_build_hermes_config_omits_max_turns_when_max_iterations_null():
+def test_build_hermes_config_omits_max_turns_when_max_iterations_null(
+    tmp_path: Path,
+):
     # An explicit null max_iterations is treated like unset: agent.max_turns is
     # omitted so Hermes applies its own default instead of a starving override.
     payload = {
-        "base_dir": "/fabric-root",
+        "base_dir": str(tmp_path / "fabric-root"),
         "config": {
             "harness": {"settings": {"max_iterations": None}},
             "models": {"default": {"provider": "nvidia", "model": "nvidia/test-model"}},
@@ -305,9 +351,9 @@ def test_write_hermes_config_writes_file(tmp_path: Path):
     assert "nvidia/test-model" in config_path.read_text(encoding="utf-8")
 
 
-def test_gateway_config_excludes_native_relay_plugin():
+def test_gateway_config_excludes_native_relay_plugin(tmp_path: Path):
     payload = {
-        "base_dir": "/fabric-root",
+        "base_dir": str(tmp_path / "fabric-root"),
         "config": {
             "harness": {
                 "settings": {

--- a/tests/adapters/test_hermes_adapter.py
+++ b/tests/adapters/test_hermes_adapter.py
@@ -61,6 +61,7 @@ def test_validate_hermes_telemetry_provider_rejects_mixed_native_and_relay():
 def test_build_hermes_config_maps_fabric_config_to_hermes_config():
     os.environ["MCP_URL"] = "http://localhost:9000/mcp"
     payload = {
+        "base_dir": "/fabric-root",
         "runtime_context": {"environment": {"workspace": "/workspace/repo"}},
         "capability_plan": {
             "native": {
@@ -150,6 +151,7 @@ def test_build_hermes_config_omits_max_turns_when_max_iterations_unset():
     # When max_iterations is unset the config layer must leave agent.max_turns
     # absent so Hermes applies its own default rather than a starving override.
     payload = {
+        "base_dir": "/fabric-root",
         "config": {
             "harness": {"settings": {}},
             "models": {"default": {"provider": "nvidia", "model": "nvidia/test-model"}},
@@ -165,6 +167,7 @@ def test_build_hermes_config_omits_max_turns_when_max_iterations_null():
     # An explicit null max_iterations is treated like unset: agent.max_turns is
     # omitted so Hermes applies its own default instead of a starving override.
     payload = {
+        "base_dir": "/fabric-root",
         "config": {
             "harness": {"settings": {"max_iterations": None}},
             "models": {"default": {"provider": "nvidia", "model": "nvidia/test-model"}},
@@ -287,6 +290,7 @@ def test_hermes_config_variation_matrix_surfaces_supported_capabilities(
 
 def test_write_hermes_config_writes_file(tmp_path: Path):
     payload = {
+        "base_dir": str(tmp_path),
         "config": {
             "harness": {"settings": {}},
             "models": {"default": {"provider": "nvidia", "model": "nvidia/test-model"}},
@@ -303,6 +307,7 @@ def test_write_hermes_config_writes_file(tmp_path: Path):
 
 def test_gateway_config_excludes_native_relay_plugin():
     payload = {
+        "base_dir": "/fabric-root",
         "config": {
             "harness": {
                 "settings": {

--- a/tests/adapters/test_hermes_adapter.py
+++ b/tests/adapters/test_hermes_adapter.py
@@ -11,7 +11,7 @@ import json
 import os
 import sys
 from pathlib import Path
-from types import ModuleType, SimpleNamespace
+from types import ModuleType
 from unittest.mock import MagicMock
 
 import pytest
@@ -56,109 +56,6 @@ def test_validate_hermes_telemetry_provider_rejects_mixed_native_and_relay():
         ValueError, match="only relay telemetry is supported for Hermes"
     ):
         adapter.validate_hermes_telemetry_provider(payload)
-
-
-def test_finalize_relay_session_flushes_before_artifact_collection(monkeypatch):
-    calls: list[str] = []
-    invoke_hook = MagicMock(side_effect=lambda *args, **kwargs: calls.append("hook"))
-    runtime = adapter.HermesRuntime()
-    runtime._relay_plugin_config = {"components": []}
-    runtime._agent = SimpleNamespace(
-        session_id="runtime-1",
-        model="test-model",
-        platform="fabric",
-    )
-    runtime._invoke_hook = invoke_hook
-    runtime._relay_session_pending = True
-
-    from nemo_relay import subscribers
-
-    monkeypatch.setattr(subscribers, "flush", lambda: calls.append("flush"))
-
-    runtime._finalize_relay_session()
-
-    assert calls == ["hook", "flush"]
-    invoke_hook.assert_called_once_with(
-        "on_session_finalize",
-        session_id="runtime-1",
-        model="test-model",
-        platform="fabric",
-    )
-
-
-async def test_stop_does_not_refinalize_completed_relay_turn(monkeypatch):
-    invoke_hook = MagicMock()
-    runtime = adapter.HermesRuntime()
-    runtime._started = True
-    runtime._relay_plugin_config = {"components": []}
-    agent = MagicMock(
-        session_id="runtime-1",
-        model="test-model",
-        platform="fabric",
-    )
-    session_db = MagicMock()
-    runtime._agent = agent
-    runtime._session_db = session_db
-    runtime._invoke_hook = invoke_hook
-    runtime._relay_session_pending = True
-
-    from nemo_relay import subscribers
-
-    flush = MagicMock()
-    monkeypatch.setattr(subscribers, "flush", flush)
-
-    runtime._finalize_relay_session()
-    await runtime.stop()
-
-    invoke_hook.assert_called_once_with(
-        "on_session_finalize",
-        session_id="runtime-1",
-        model="test-model",
-        platform="fabric",
-    )
-    flush.assert_called_once_with()
-    agent.close.assert_called_once_with()
-    session_db.close.assert_called_once_with()
-    assert runtime._started is False
-    assert runtime._relay_session_pending is False
-    assert runtime._relay_finalize_hook_invoked is False
-
-
-async def test_stop_retries_failed_relay_flush_without_refinalizing(monkeypatch):
-    invoke_hook = MagicMock()
-    runtime = adapter.HermesRuntime()
-    runtime._started = True
-    runtime._relay_plugin_config = {"components": []}
-    runtime._agent = MagicMock(
-        session_id="runtime-1",
-        model="test-model",
-        platform="fabric",
-    )
-    runtime._session_db = MagicMock()
-    runtime._invoke_hook = invoke_hook
-    runtime._relay_session_pending = True
-
-    from nemo_relay import subscribers
-
-    flush = MagicMock(side_effect=[RuntimeError("flush failed"), None])
-    monkeypatch.setattr(subscribers, "flush", flush)
-
-    with pytest.raises(RuntimeError, match="flush failed"):
-        runtime._finalize_relay_session()
-
-    assert runtime._relay_session_pending is True
-    assert runtime._relay_finalize_hook_invoked is True
-    await runtime.stop()
-
-    invoke_hook.assert_called_once_with(
-        "on_session_finalize",
-        session_id="runtime-1",
-        model="test-model",
-        platform="fabric",
-    )
-    assert flush.call_count == 2
-    assert runtime._relay_session_pending is False
-    assert runtime._relay_finalize_hook_invoked is False
 
 
 def test_build_hermes_config_maps_fabric_config_to_hermes_config():
@@ -288,6 +185,7 @@ def test_hermes_config_variation_matrix_surfaces_supported_capabilities(
             {
                 "relay": {
                     "config": {
+                        "version": 2,
                         "atof": {
                             "enabled": True,
                             "sinks": [
@@ -401,6 +299,26 @@ def test_write_hermes_config_writes_file(tmp_path: Path):
     assert config_path.exists()
     assert config["model"]["default"] == "nvidia/test-model"
     assert "nvidia/test-model" in config_path.read_text(encoding="utf-8")
+
+
+def test_gateway_config_excludes_native_relay_plugin():
+    payload = {
+        "config": {
+            "harness": {
+                "settings": {
+                    "plugins_enabled": [
+                        "custom/plugin",
+                        "observability/nemo_relay",
+                    ]
+                }
+            },
+            "models": {"default": {"provider": "nvidia", "model": "nvidia/test-model"}},
+        }
+    }
+
+    config = adapter.build_hermes_config(payload, exclude_relay_plugin=True)
+
+    assert config["plugins"]["enabled"] == ["custom/plugin"]
 
 
 @pytest.mark.parametrize(

--- a/tests/adapters/test_hermes_relay_cli.py
+++ b/tests/adapters/test_hermes_relay_cli.py
@@ -19,6 +19,38 @@ from nemo_fabric_adapters.hermes import relay_cli
 
 
 @pytest.mark.parametrize(
+    ("environment_workspace", "settings_workspace", "settings_cwd", "expected"),
+    [
+        ("/environment", "/settings", "/legacy", Path("/environment")),
+        (None, "settings-relative", "/legacy", Path("/fabric-root/settings-relative")),
+        ("environment-relative", "/settings", "/legacy", Path("/fabric-root/environment-relative")),
+        (None, None, "/legacy", Path("/fabric-root")),
+    ],
+)
+def test_hermes_working_directory_uses_normalized_workspace_precedence(
+    environment_workspace: str | None,
+    settings_workspace: str | None,
+    settings_cwd: str,
+    expected: Path,
+):
+    environment = (
+        {"workspace": environment_workspace}
+        if environment_workspace is not None
+        else {}
+    )
+    settings = {"cwd": settings_cwd}
+    if settings_workspace is not None:
+        settings["workspace"] = settings_workspace
+    payload = {
+        "base_dir": "/fabric-root",
+        "runtime_context": {"environment": environment},
+        "config": {"harness": {"settings": settings}},
+    }
+
+    assert adapter.hermes_working_directory(payload) == expected
+
+
+@pytest.mark.parametrize(
     ("relay_enabled", "plugins_enabled", "raises"),
     [
         (False, [], False),

--- a/tests/adapters/test_hermes_relay_cli.py
+++ b/tests/adapters/test_hermes_relay_cli.py
@@ -18,6 +18,43 @@ from nemo_fabric_adapters.hermes import adapter
 from nemo_fabric_adapters.hermes import relay_cli
 
 
+@pytest.mark.parametrize(
+    ("relay_enabled", "plugins_enabled", "raises"),
+    [
+        (False, [], False),
+        (False, ["custom/plugin"], False),
+        (False, ["observability/nemo_relay"], True),
+        (True, ["observability/nemo_relay"], False),
+    ],
+)
+def test_validate_hermes_relay_plugin_mode(
+    relay_enabled: bool,
+    plugins_enabled: list[str],
+    raises: bool,
+):
+    payload = {
+        "telemetry_plan": {
+            "providers": ["relay"] if relay_enabled else [],
+            "relay_enabled": relay_enabled,
+        },
+        "config": {
+            "harness": {"settings": {"plugins_enabled": plugins_enabled}},
+        },
+    }
+
+    if raises:
+        with pytest.raises(
+            ValueError,
+            match=(
+                "observability/nemo_relay cannot be enabled directly; "
+                "enable Fabric Relay telemetry instead"
+            ),
+        ):
+            adapter.validate_hermes_relay_plugin_mode(payload)
+    else:
+        adapter.validate_hermes_relay_plugin_mode(payload)
+
+
 def test_build_hermes_args_uses_public_gateway_contract(tmp_path: Path):
     launch = _launch(tmp_path)
 

--- a/tests/adapters/test_hermes_relay_cli.py
+++ b/tests/adapters/test_hermes_relay_cli.py
@@ -1,0 +1,536 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Contract and process-lifecycle tests for Hermes through ``nemo-relay run``."""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import os
+from pathlib import Path
+
+import pytest
+
+from nemo_fabric_adapters.common.relay_gateway import RelayCliContract
+import nemo_fabric_adapters.common.utils as common_utils
+from nemo_fabric_adapters.hermes import adapter
+from nemo_fabric_adapters.hermes import relay_cli
+
+
+def test_build_hermes_args_uses_public_gateway_contract(tmp_path: Path):
+    launch = _launch(tmp_path)
+
+    command = [
+        str(launch.relay_executable),
+        "run",
+        "--config",
+        "/tmp/config.toml",
+        "--agent",
+        "hermes",
+        "--",
+        *relay_cli.build_hermes_args(launch, "repair the service"),
+    ]
+
+    assert "--plugin-config-path" not in command
+    assert command[command.index("--provider") + 1] == "custom"
+    assert command[command.index("--continue") + 1] == "runtime-123"
+    assert command[command.index("--toolsets") + 1] == "terminal,file"
+    assert "repair the service" not in relay_cli.redact_command(command)
+
+
+def test_quiet_response_removes_only_pinned_hermes_startup_diagnostic():
+    stdout = (
+        "\x1b[2m  ⚠ tirith security scanner enabled but not available "
+        "— command scanning will use pattern matching only\x1b[0m\r\n"
+        "first response line\nsecond response line\n"
+    )
+
+    assert relay_cli.quiet_response(stdout) == (
+        "first response line\nsecond response line"
+    )
+
+
+@pytest.mark.parametrize(
+    ("version", "accepted"),
+    [
+        ("0.18.2", True),
+        ("0.18.9", True),
+        ("0.18.1", False),
+        ("0.19.0", False),
+    ],
+)
+def test_hermes_cli_version_contract(tmp_path: Path, version: str, accepted: bool):
+    executable = tmp_path / f"hermes-{version}"
+    executable.write_text(
+        f"#!/bin/sh\nprintf 'Hermes Agent v{version} (2026.7.7.2)\\n'\n",
+        encoding="utf-8",
+    )
+    executable.chmod(0o755)
+
+    if accepted:
+        assert relay_cli.hermes_cli_version(executable) == tuple(
+            int(value) for value in version.split(".")
+        )
+    else:
+        with pytest.raises(relay_cli.HermesRelayError, match="unsupported Hermes"):
+            relay_cli.hermes_cli_version(executable)
+
+
+@pytest.mark.parametrize(
+    ("provider", "base_url", "message"),
+    [
+        ("anthropic", "https://api.anthropic.com", "OpenAI-compatible provider"),
+        ("custom", None, "OpenAI-compatible base URL"),
+    ],
+)
+def test_validate_openai_upstream_rejects_incompatible_routes(
+    provider: str, base_url: str | None, message: str
+):
+    with pytest.raises(relay_cli.HermesRelayError, match=message):
+        relay_cli.validate_openai_upstream({}, {"provider": provider}, base_url)
+
+
+def test_child_environment_forwards_only_explicit_credentials(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+):
+    monkeypatch.setenv("PATH", os.environ.get("PATH", ""))
+    monkeypatch.setenv("SELECTED_MODEL_KEY", "model-secret")
+    monkeypatch.setenv("RELAY_HEADER_TOKEN", "relay-secret")
+    monkeypatch.setenv("RELAY_S3_SECRET", "storage-secret")
+    monkeypatch.setenv("UNRELATED_HOST_SECRET", "must-not-leak")
+
+    env = relay_cli.child_environment(
+        {"env": {"EXPLICIT_SETTING": "present"}},
+        {"api_key_env": "SELECTED_MODEL_KEY"},
+        {
+            "components": [
+                {
+                    "config": {
+                        "header_env": {"authorization": "RELAY_HEADER_TOKEN"},
+                        "secret_access_key_var": "RELAY_S3_SECRET",
+                    }
+                }
+            ]
+        },
+        tmp_path / "hermes-home",
+    )
+
+    assert env["SELECTED_MODEL_KEY"] == "model-secret"
+    assert env["OPENAI_API_KEY"] == "model-secret"
+    assert env["RELAY_HEADER_TOKEN"] == "relay-secret"
+    assert env["RELAY_S3_SECRET"] == "storage-secret"
+    assert env["EXPLICIT_SETTING"] == "present"
+    assert "UNRELATED_HOST_SECRET" not in env
+    assert env["HOME"] == str(tmp_path / "hermes-home")
+    assert env["XDG_CONFIG_HOME"] == str(tmp_path / "hermes-home" / ".config")
+
+
+async def test_runner_executes_colocated_relay_config_and_collects_artifacts(
+    tmp_path: Path,
+):
+    executable = _write_fake_relay(tmp_path / "fake-relay.py")
+    record_path = tmp_path / "record.json"
+    launch = _launch(
+        tmp_path,
+        relay_executable=executable,
+        env={
+            **os.environ,
+            "FAKE_RELAY_RECORD": str(record_path),
+            "EXPECTED_CHILD_ONLY": "present",
+        },
+    )
+    runner = relay_cli.HermesRelayRunner(launch)
+
+    result = await runner.invoke("hello from Fabric", "invocation/1")
+
+    assert result.returncode == 0
+    assert result.stdout.strip() == "relay response: hello from Fabric"
+    assert result.config_path.parent == result.plugin_config_path.parent
+    assert result.config_path.name == "config.toml"
+    assert result.plugin_config_path.name == "plugins.toml"
+    assert "hello from Fabric" not in result.command
+    record = json.loads(record_path.read_text(encoding="utf-8"))
+    assert record["agent"] == "hermes"
+    assert record["child_only"] == "present"
+    assert record["hermes_command"] == str(launch.hermes_executable)
+    assert record["hooks_path"] == str(launch.hermes_config_path)
+    collected = common_utils.collect_relay_artifacts(result.plugin_config)
+    artifacts = {artifact["kind"] for artifact in collected}
+    assert artifacts == {"atof", "atif"}
+    assert all(
+        Path(artifact["path"]).is_relative_to(result.config_path.parent)
+        for artifact in collected
+    )
+
+
+async def test_runner_preserves_response_tail_when_output_is_truncated(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+):
+    executable = _write_fake_relay(tmp_path / "fake-relay.py")
+    monkeypatch.setattr(relay_cli, "MAX_CAPTURE_BYTES", 256)
+    launch = _launch(
+        tmp_path,
+        relay_executable=executable,
+        env={
+            **os.environ,
+            "FAKE_RELAY_RECORD": str(tmp_path / "record.json"),
+            "FAKE_RELAY_PREFIX_BYTES": "512",
+        },
+    )
+
+    result = await relay_cli.HermesRelayRunner(launch).invoke(
+        "tail response", "large-output"
+    )
+
+    assert result.truncated is True
+    assert result.stdout.endswith("relay response: tail response\n")
+    assert "...[output truncated]..." in result.stdout
+
+
+async def test_normalized_output_preserves_response_after_late_failure(
+    tmp_path: Path,
+):
+    executable = _write_fake_relay(tmp_path / "fake-relay.py")
+    launch = _launch(
+        tmp_path,
+        relay_executable=executable,
+        env={
+            **os.environ,
+            "FAKE_RELAY_RECORD": str(tmp_path / "record.json"),
+            "FAKE_RELAY_EXIT": "7",
+        },
+    )
+    runtime = adapter.HermesRuntime()
+    runtime._relay_runner = relay_cli.HermesRelayRunner(launch)
+    runtime._runtime_id = launch.runtime_id
+    runtime._model_config = launch.model_config
+    runtime._settings = launch.settings
+    runtime._base_url = launch.base_url
+    runtime._hermes_home = launch.hermes_home
+    runtime._hermes_config_path = launch.hermes_config_path
+    runtime._hermes_config = {"plugins": {"enabled": []}}
+    runtime._hermes_cli_version = (0, 18, 2)
+
+    output = await runtime._invoke_relay(
+        {"runtime_context": {"invocation_id": "late-failure"}},
+        "completed answer",
+    )
+
+    assert output["returncode"] == 7
+    assert output["failed"] is True
+    assert output["completed"] is True
+    assert output["response"] == "relay response: completed answer"
+    assert "status 7" in output["error"]
+    assert output["relay_runtime"]["model_event_source"] == "gateway"
+    assert output["relay_runtime"]["hook_event_policy"] == "lifecycle_context_only"
+
+
+async def test_concurrent_runtimes_isolate_config_and_child_environment(
+    tmp_path: Path,
+):
+    executable = _write_fake_relay(tmp_path / "fake-relay.py")
+    first_root = tmp_path / "first"
+    second_root = tmp_path / "second"
+    first = relay_cli.HermesRelayRunner(
+        _launch(
+            first_root,
+            relay_executable=executable,
+            env={
+                **os.environ,
+                "FAKE_RELAY_RECORD": str(first_root / "record.json"),
+                "EXPECTED_CHILD_ONLY": "first",
+                "FAKE_RELAY_DELAY": "0.2",
+            },
+        )
+    )
+    second = relay_cli.HermesRelayRunner(
+        _launch(
+            second_root,
+            relay_executable=executable,
+            env={
+                **os.environ,
+                "FAKE_RELAY_RECORD": str(second_root / "record.json"),
+                "EXPECTED_CHILD_ONLY": "second",
+                "FAKE_RELAY_DELAY": "0.2",
+            },
+        )
+    )
+
+    first_result, second_result = await asyncio.gather(
+        first.invoke("first prompt", "same-id"),
+        second.invoke("second prompt", "same-id"),
+    )
+
+    assert first_result.config_path != second_result.config_path
+    assert (
+        json.loads((first_root / "record.json").read_text(encoding="utf-8"))[
+            "child_only"
+        ]
+        == "first"
+    )
+    assert (
+        json.loads((second_root / "record.json").read_text(encoding="utf-8"))[
+            "child_only"
+        ]
+        == "second"
+    )
+    assert "EXPECTED_CHILD_ONLY" not in os.environ
+
+
+async def test_runner_cancellation_interrupts_process_group_and_restores_overlay(
+    tmp_path: Path,
+):
+    executable = _write_cancellable_relay(tmp_path / "cancellable-relay.py")
+    marker = tmp_path / "hermes-config-overlay"
+    pid_path = tmp_path / "relay.pid"
+    child_pid_path = tmp_path / "child.pid"
+    launch = _launch(
+        tmp_path,
+        relay_executable=executable,
+        env={
+            **os.environ,
+            "FAKE_OVERLAY": str(marker),
+            "FAKE_PID": str(pid_path),
+            "FAKE_CHILD_PID": str(child_pid_path),
+        },
+    )
+    runner = relay_cli.HermesRelayRunner(launch)
+    task = asyncio.create_task(runner.invoke("cancel me", "cancel-invocation"))
+    await _wait_for_path(pid_path)
+    await _wait_for_path(child_pid_path)
+
+    task.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await task
+
+    assert not marker.exists()
+    assert not _process_exists(int(pid_path.read_text(encoding="utf-8")))
+    assert not _process_exists(int(child_pid_path.read_text(encoding="utf-8")))
+
+
+async def test_relay_enabled_runtime_selects_cli_without_mutating_host_env(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+):
+    relay_config = tmp_path / "relay.json"
+    relay_config.write_text(
+        json.dumps(
+            {
+                "relay": {
+                    "config": {
+                        "version": 2,
+                        "atof": {
+                            "enabled": True,
+                            "sinks": [{"type": "file"}],
+                        },
+                    }
+                }
+            }
+        ),
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("FABRIC_RELAY_CONFIG_PATH", str(relay_config))
+    monkeypatch.setenv("TEST_API_KEY", "test-only-secret")
+    monkeypatch.setenv("HOME", "/host/home")
+    monkeypatch.delenv("HERMES_HOME", raising=False)
+    relay_executable = tmp_path / "nemo-relay"
+    hermes_executable = tmp_path / "hermes"
+    monkeypatch.setattr(
+        relay_cli,
+        "resolve_executable",
+        lambda _root, _value, *, name: (
+            relay_executable if "Relay" in name else hermes_executable
+        ),
+    )
+    monkeypatch.setattr(
+        adapter.relay_gateway,
+        "relay_cli_contract",
+        lambda _path: RelayCliContract((0, 6, 0), 2),
+    )
+    monkeypatch.setattr(relay_cli, "hermes_cli_version", lambda _path: (0, 18, 2))
+    monkeypatch.setattr(adapter, "_ensure_hermes_runtime_session", lambda *args: None)
+    payload = {
+        "agent_name": "gateway-agent",
+        "base_dir": str(tmp_path),
+        "runtime_context": {
+            "runtime_id": "runtime-gateway",
+            "environment": {"workspace": str(tmp_path)},
+            "telemetry": {"relay_enabled": True},
+        },
+        "telemetry_plan": {"providers": ["relay"], "relay_enabled": True},
+        "config": {
+            "harness": {
+                "settings": {
+                    "hermes_home": "hermes-home",
+                    "plugins_enabled": [
+                        "custom/plugin",
+                        "observability/nemo_relay",
+                    ],
+                }
+            },
+            "models": {
+                "default": {
+                    "provider": "nvidia",
+                    "model": "nvidia/test-model",
+                    "api_key_env": "TEST_API_KEY",
+                    "settings": {"base_url": "https://model.example/v1"},
+                }
+            },
+        },
+    }
+    runtime = adapter.HermesRuntime()
+
+    await runtime.start(payload)
+
+    assert runtime._agent is None
+    assert runtime._relay_runner is not None
+    assert os.environ["HOME"] == "/host/home"
+    assert "HERMES_HOME" not in os.environ
+    assert runtime._hermes_config["plugins"]["enabled"] == ["custom/plugin"]
+    assert runtime._relay_runner._launch.env["TEST_API_KEY"] == "test-only-secret"
+    assert runtime._relay_runner._launch.env["OPENAI_API_KEY"] == "test-only-secret"
+    await runtime.stop()
+
+
+def _launch(
+    tmp_path: Path,
+    *,
+    relay_executable: Path | None = None,
+    env: dict[str, str] | None = None,
+) -> relay_cli.HermesRelayLaunch:
+    hermes_config = tmp_path / "hermes-home" / "config.yaml"
+    hermes_config.parent.mkdir(parents=True, exist_ok=True)
+    hermes_config.write_text("model: {}\n", encoding="utf-8")
+    hermes_executable = tmp_path / "hermes"
+    hermes_executable.touch()
+    return relay_cli.HermesRelayLaunch(
+        relay_executable=relay_executable or tmp_path / "nemo-relay",
+        relay_contract=RelayCliContract((0, 6, 0), 2),
+        hermes_executable=hermes_executable,
+        hermes_config_path=hermes_config,
+        hermes_home=hermes_config.parent,
+        cwd=tmp_path,
+        env=env or os.environ.copy(),
+        base_url="https://model.example/v1",
+        model="nvidia/test-model",
+        runtime_id="runtime-123",
+        settings={"enabled_toolsets": ["terminal", "file"]},
+        model_config={"provider": "nvidia"},
+        plugin_config={
+            "version": 1,
+            "components": [
+                {
+                    "kind": "observability",
+                    "enabled": True,
+                    "config": {
+                        "version": 2,
+                        "atof": {
+                            "enabled": True,
+                            "sinks": [
+                                {
+                                    "type": "file",
+                                    "filename": "events.jsonl",
+                                    "mode": "overwrite",
+                                }
+                            ],
+                        },
+                        "atif": {
+                            "enabled": True,
+                            "filename_template": "trajectory-{session_id}.json",
+                        },
+                    },
+                }
+            ],
+        },
+    )
+
+
+def _write_fake_relay(path: Path) -> Path:
+    path.write_text(
+        """#!/usr/bin/env python3
+import json
+import os
+import sys
+import time
+import tomllib
+from pathlib import Path
+
+args = sys.argv[1:]
+time.sleep(float(os.environ.get("FAKE_RELAY_DELAY", "0")))
+config_path = Path(args[args.index("--config") + 1])
+config = tomllib.loads(config_path.read_text())
+plugins = tomllib.loads((config_path.parent / "plugins.toml").read_text())
+inner = args[args.index("--") + 1:]
+prompt = inner[inner.index("--query") + 1]
+sys.stdout.write("x" * int(os.environ.get("FAKE_RELAY_PREFIX_BYTES", "0")))
+atof = plugins["components"][0]["config"]["atof"]["sinks"][0]
+atof_dir = Path(atof["output_directory"])
+atof_dir.mkdir(parents=True, exist_ok=True)
+(atof_dir / atof["filename"]).write_text("{}")
+atif = plugins["components"][0]["config"]["atif"]
+atif_dir = Path(atif["output_directory"])
+atif_dir.mkdir(parents=True, exist_ok=True)
+(atif_dir / "trajectory-test.json").write_text("{}")
+Path(os.environ["FAKE_RELAY_RECORD"]).write_text(json.dumps({
+    "agent": args[args.index("--agent") + 1],
+    "child_only": os.environ.get("EXPECTED_CHILD_ONLY"),
+    "hermes_command": config["agents"]["hermes"]["command"],
+    "hooks_path": config["agents"]["hermes"]["hooks_path"],
+}))
+print(f"relay response: {prompt}")
+raise SystemExit(int(os.environ.get("FAKE_RELAY_EXIT", "0")))
+""",
+        encoding="utf-8",
+    )
+    path.chmod(0o755)
+    return path
+
+
+def _write_cancellable_relay(path: Path) -> Path:
+    path.write_text(
+        """#!/usr/bin/env python3
+import os
+import signal
+import subprocess
+import sys
+import time
+from pathlib import Path
+
+marker = Path(os.environ["FAKE_OVERLAY"])
+marker.write_text("active")
+child = subprocess.Popen([sys.executable, "-c", "import time; time.sleep(60)"])
+Path(os.environ["FAKE_PID"]).write_text(str(os.getpid()))
+Path(os.environ["FAKE_CHILD_PID"]).write_text(str(child.pid))
+
+def stop(_signum, _frame):
+    child.terminate()
+    child.wait(timeout=5)
+    marker.unlink(missing_ok=True)
+    raise SystemExit(130)
+
+signal.signal(signal.SIGINT, stop)
+while True:
+    time.sleep(0.1)
+""",
+        encoding="utf-8",
+    )
+    path.chmod(0o755)
+    return path
+
+
+async def _wait_for_path(path: Path) -> None:
+    for _ in range(100):
+        if path.exists():
+            return
+        await asyncio.sleep(0.05)
+    raise AssertionError(f"timed out waiting for {path}")
+
+
+def _process_exists(pid: int) -> bool:
+    try:
+        os.kill(pid, 0)
+    except ProcessLookupError:
+        return False
+    except PermissionError:
+        return True
+    return True

--- a/tests/adapters/test_hermes_relay_cli.py
+++ b/tests/adapters/test_hermes_relay_cli.py
@@ -12,42 +12,65 @@ from pathlib import Path
 
 import pytest
 
+pytest.importorskip("nemo_fabric_adapters.hermes")
+
 from nemo_fabric_adapters.common.relay_gateway import RelayCliContract
 import nemo_fabric_adapters.common.utils as common_utils
 from nemo_fabric_adapters.hermes import adapter
 from nemo_fabric_adapters.hermes import relay_cli
 
 
+requires_posix_processes = pytest.mark.skipif(
+    os.name != "posix",
+    reason="Relay CLI executable and process-group tests require POSIX",
+)
+
+
 @pytest.mark.parametrize(
-    ("environment_workspace", "settings_workspace", "settings_cwd", "expected"),
+    ("environment_workspace", "settings_workspace", "expected"),
     [
-        ("/environment", "/settings", "/legacy", Path("/environment")),
-        (None, "settings-relative", "/legacy", Path("/fabric-root/settings-relative")),
-        ("environment-relative", "/settings", "/legacy", Path("/fabric-root/environment-relative")),
-        (None, None, "/legacy", Path("/fabric-root")),
+        ("absolute-environment", "absolute-settings", "absolute-environment"),
+        (None, "settings-relative", "settings-relative"),
+        ("environment-relative", "absolute-settings", "environment-relative"),
+        (None, None, None),
     ],
 )
 def test_hermes_working_directory_uses_normalized_workspace_precedence(
     environment_workspace: str | None,
     settings_workspace: str | None,
-    settings_cwd: str,
-    expected: Path,
+    expected: str | None,
+    tmp_path: Path,
 ):
+    root = tmp_path / "fabric-root"
+    absolute_paths = {
+        "absolute-environment": tmp_path / "environment",
+        "absolute-settings": tmp_path / "settings",
+    }
+    resolved_environment_workspace = (
+        str(absolute_paths[environment_workspace])
+        if environment_workspace in absolute_paths
+        else environment_workspace
+    )
     environment = (
-        {"workspace": environment_workspace}
-        if environment_workspace is not None
+        {"workspace": resolved_environment_workspace}
+        if resolved_environment_workspace is not None
         else {}
     )
-    settings = {"cwd": settings_cwd}
+    settings = {"cwd": str(tmp_path / "legacy")}
     if settings_workspace is not None:
-        settings["workspace"] = settings_workspace
+        settings["workspace"] = str(
+            absolute_paths.get(settings_workspace, settings_workspace)
+        )
     payload = {
-        "base_dir": "/fabric-root",
+        "base_dir": str(root),
         "runtime_context": {"environment": environment},
         "config": {"harness": {"settings": settings}},
     }
+    expected_path = (
+        absolute_paths.get(expected, root / expected) if expected is not None else root
+    )
 
-    assert adapter.hermes_working_directory(payload) == expected
+    assert adapter.hermes_working_directory(payload) == expected_path
 
 
 @pytest.mark.parametrize(
@@ -129,6 +152,7 @@ def test_quiet_response_removes_only_pinned_hermes_startup_diagnostic():
         ("0.19.0", False),
     ],
 )
+@requires_posix_processes
 def test_hermes_cli_version_contract(tmp_path: Path, version: str, accepted: bool):
     executable = tmp_path / f"hermes-{version}"
     executable.write_text(
@@ -195,6 +219,18 @@ def test_child_environment_forwards_only_explicit_credentials(
     assert env["XDG_CONFIG_HOME"] == str(tmp_path / "hermes-home" / ".config")
 
 
+def test_write_configs_wraps_existing_invocation_directory(tmp_path: Path):
+    invocation_dir = tmp_path / "existing-invocation"
+    invocation_dir.mkdir()
+
+    with pytest.raises(
+        relay_cli.HermesRelayError,
+        match="NeMo Relay invocation directory could not be created",
+    ):
+        relay_cli._write_configs(_launch(tmp_path), invocation_dir)
+
+
+@requires_posix_processes
 async def test_runner_executes_colocated_relay_config_and_collects_artifacts(
     tmp_path: Path,
 ):
@@ -233,6 +269,7 @@ async def test_runner_executes_colocated_relay_config_and_collects_artifacts(
     )
 
 
+@requires_posix_processes
 async def test_runner_preserves_response_tail_when_output_is_truncated(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ):
@@ -257,6 +294,7 @@ async def test_runner_preserves_response_tail_when_output_is_truncated(
     assert "...[output truncated]..." in result.stdout
 
 
+@requires_posix_processes
 async def test_normalized_output_preserves_response_after_late_failure(
     tmp_path: Path,
 ):
@@ -295,6 +333,7 @@ async def test_normalized_output_preserves_response_after_late_failure(
     assert output["relay_runtime"]["hook_event_policy"] == "lifecycle_context_only"
 
 
+@requires_posix_processes
 async def test_concurrent_runtimes_isolate_config_and_child_environment(
     tmp_path: Path,
 ):
@@ -347,6 +386,7 @@ async def test_concurrent_runtimes_isolate_config_and_child_environment(
     assert "EXPECTED_CHILD_ONLY" not in os.environ
 
 
+@requires_posix_processes
 async def test_runner_cancellation_interrupts_process_group_and_restores_overlay(
     tmp_path: Path,
 ):

--- a/tests/adapters/test_hermes_relay_cli.py
+++ b/tests/adapters/test_hermes_relay_cli.py
@@ -12,12 +12,11 @@ from pathlib import Path
 
 import pytest
 
-pytest.importorskip("nemo_fabric_adapters.hermes")
-
 from nemo_fabric_adapters.common.relay_gateway import RelayCliContract
 import nemo_fabric_adapters.common.utils as common_utils
-from nemo_fabric_adapters.hermes import adapter
-from nemo_fabric_adapters.hermes import relay_cli
+
+adapter = pytest.importorskip("nemo_fabric_adapters.hermes.adapter")
+relay_cli = pytest.importorskip("nemo_fabric_adapters.hermes.relay_cli")
 
 
 requires_posix_processes = pytest.mark.skipif(

--- a/uv.lock
+++ b/uv.lock
@@ -1106,12 +1106,13 @@ wheels = [
 
 [[package]]
 name = "hermes-agent"
-version = "0.17.0"
+version = "0.18.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "certifi", marker = "python_full_version < '3.14'" },
     { name = "concurrent-log-handler", marker = "python_full_version < '3.14' and sys_platform == 'win32'" },
     { name = "croniter", marker = "python_full_version < '3.14'" },
+    { name = "cryptography", version = "46.0.7", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.14'" },
     { name = "fastapi", marker = "python_full_version < '3.14'" },
     { name = "fire", marker = "python_full_version < '3.14'" },
     { name = "httpx", extra = ["socks"], marker = "python_full_version < '3.14'" },
@@ -1139,9 +1140,9 @@ dependencies = [
     { name = "uvicorn", extra = ["standard"], marker = "python_full_version < '3.14'" },
     { name = "websockets", marker = "python_full_version < '3.14'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/99/c2/6b65b1c1d093eff415304472709479a392ac1422e36d007e32f3bb848f58/hermes_agent-0.17.0.tar.gz", hash = "sha256:5ceda2a131627fecf5fd52b05d0162b48032023a5d814bb5d1894db4aa146120", size = 12156176, upload-time = "2026-06-19T19:40:16.589Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/5c/44/c2e588a0d49049aa3fa6833d52bd6e803dc62ac7369a7ecb483b9a7b9a3d/hermes_agent-0.18.2.tar.gz", hash = "sha256:1cc7ccb6bca6e6d2aef448bbf9b79d4bc31247288a8bf549231fc148a343c678", size = 13618103, upload-time = "2026-07-08T03:12:49.202Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/e3/e2/d18d5ec6735b412fde47ecac3b6a63874c824c83e9821e1c1f4a07bcff85/hermes_agent-0.17.0-py3-none-any.whl", hash = "sha256:f11dcc1b168d2db626ef8b2175301741a86b5247c5ffaff4b0f0e24018d1b190", size = 8642279, upload-time = "2026-06-19T19:40:14.014Z" },
+    { url = "https://files.pythonhosted.org/packages/0c/4c/91652c61450763bfe165c65b83026503de0ac9ddad2c11ee522490bf4c2d/hermes_agent-0.18.2-py3-none-any.whl", hash = "sha256:8f02155cfc84b28bd98551cd18dffec0efa9ec070dd08f90f1a850f1c779492f", size = 9569078, upload-time = "2026-07-08T03:12:46.369Z" },
 ]
 
 [[package]]
@@ -2119,7 +2120,7 @@ test = [
 [package.metadata]
 requires-dist = [
     { name = "harbor", marker = "python_full_version >= '3.12' and extra == 'harbor'", specifier = ">=0.18,<0.19" },
-    { name = "hermes-agent", marker = "python_full_version < '3.14' and extra == 'hermes-agent'", specifier = ">=0.17.0" },
+    { name = "hermes-agent", marker = "python_full_version < '3.14' and extra == 'hermes-agent'", specifier = ">=0.18.2,<0.19" },
     { name = "nemo-fabric-adapters-claude", marker = "extra == 'claude'", editable = "adapters/claude" },
     { name = "nemo-fabric-adapters-codex", marker = "extra == 'codex'", editable = "adapters/codex" },
     { name = "nemo-fabric-adapters-deepagents", marker = "extra == 'deepagents'", editable = "adapters/deepagents" },


### PR DESCRIPTION
## Summary

Run Relay-enabled Hermes sessions through the public NeMo Relay CLI/gateway
boundary. When Fabric Relay telemetry is disabled, run Hermes directly through
its Python SDK without Fabric-managed Relay telemetry.

This is the first of three stacked follow-ups to #107 and #114. The later
layers add sink-aware artifact compatibility and invocation-scoped dynamic
plugins.

## Why

The Terminal-Bench 2.0 evaluation exposed several brittle integration
boundaries in the earlier Hermes path:

- provider configuration could remain pointed at the fail-closed
  `127.0.0.1:9` endpoint instead of the configured upstream;
- a completed Hermes response could be lost when Relay flush or process
  teardown failed afterward;
- timeout and cancellation did not have a single owner for the complete
  Relay/gateway/Hermes process tree;
- the Relay CLI, Hermes CLI, model, credential, workspace, and child
  environment contracts were implicit.

Using the CLI/gateway boundary gives Relay ownership of gateway startup and the
wrapped Hermes process while keeping that execution detail internal to the
Fabric adapter.

## Changes

- Select the CLI/gateway path whenever normalized Fabric telemetry enables
  Relay; keep the existing direct Hermes path otherwise.
- Build a least-privilege child environment containing the selected model
  credential, explicitly configured values, and environment variables
  referenced by Relay plugin configuration.
- Validate the Relay CLI contract and supported Hermes CLI version before
  provider-token work.
- Reject unsupported provider protocols or missing OpenAI-compatible upstream
  configuration before launch.
- Write invocation-scoped Hermes and Relay configuration without introducing a
  public native-versus-gateway mode selector.
- Resolve the Hermes working directory consistently as normalized
  `environment.workspace`, then `harness.settings.workspace`, then the Fabric
  root; relative values remain rooted under the Fabric invocation.
- Supervise the subprocess group with bounded output capture, cancellation,
  timeout, and descendant cleanup.
- Preserve bounded stdout/stderr and a completed response when a later teardown
  error occurs.
- Exclude Hermes' native `observability/nemo_relay` plugin from the gateway
  path to avoid duplicate model-event observation.
- Reject an explicitly configured native `observability/nemo_relay` plugin when
  Fabric Relay telemetry is disabled, rather than silently running a partial,
  unmanaged Relay integration.
- Document the supported execution and configuration contract.

Sink-aware artifact containment is intentionally left to the next stacked PR.
Invocation-scoped dynamic plugin registration is left to the third PR.

## Evaluation evidence

- Terminal-Bench task 001 completed provider traffic through the configured
  gateway route and passed validation, routing attribution, and Phoenix upload.
  Its reward of zero was a valid benchmark nonpass, not an integration failure.
- Task 010 passed the benchmark through this path and supports the
  completed-response preservation contract.
- Task 035 completed its bounded soak and uploaded 548 spans; the historical
  2,700-second hang was not reproduced.
- Task 056 completed through the static gateway path; artifact-specific claims
  are deferred to the next PR.

The PR does not claim to fix evaluation-harness failures, Docker outages,
upstream Hermes stdout/SQLite deadlocks, Relay binary packaging, or Phoenix
exporter scalability.

## Validation

```text
62 passed, 21 skipped
```

Focused suites:

- `tests/adapters/test_adapaters_common_utils.py`
- `tests/adapters/test_hermes_adapter.py`
- `tests/adapters/test_hermes_relay_cli.py`

`uv lock --check` also passes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enhanced Hermes Agent relay mode to run via NeMo Relay CLI when telemetry is enabled, with per-invocation directories, stable session continuity across turns, and relay artifact collection.
  * Added stricter relay observability configuration validation for safer execution.
* **Documentation**
  * Expanded the Hermes “Execution Model” to clarify relay vs non-relay behavior and operational details.
* **Bug Fixes**
  * Prevented enabling the native relay plugin in unsupported scenarios and improved stdout/stderr capture and command redaction.
  * Hardened shutdown so relay runs are properly stopped and state is reset.
* **Chores**
  * Updated Hermes Agent optional dependency constraints for Python < 3.14.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->