### PR TITLE
bug: fix `test_installed_adapter_discovery.py` to run within a `uv` environment

### DIFF
--- a/.github/workflows/ci_python.yml
+++ b/.github/workflows/ci_python.yml
@@ -88,7 +88,7 @@ jobs:
       - name: Build SDK with native extension
         run: |
           uv venv --python "${UV_PYTHON:-${{ matrix.python-version }}}" .venv
-          uv sync --group test --no-group dev --extra claude --extra codex --extra deepagents ${{ matrix.python-version != '3.11' && '--extra harbor' || '' }} ${{ matrix.python-version != '3.14' && '--extra hermes' || '' }} --extra relay --extra runtime
+          uv sync --group test --no-group dev --extra claude --extra codex --extra deepagents ${{ matrix.python-version != '3.11' && '--extra harbor' || '' }} ${{ matrix.python-version != '3.14' && '--extra hermes-agent' || '' }} --extra relay --extra runtime
 
       - name: Run pytest
         run: |

--- a/tests/python/test_installed_adapter_discovery.py
+++ b/tests/python/test_installed_adapter_discovery.py
@@ -94,16 +94,19 @@ def _python_sysconfig_path(python: Path, name: str) -> Path:
         )
     )
 
+def _create_venv(venv_dir: Path):
+    # Use `symlinks=True` on Posix systems to work-around for
+    # https://github.com/astral-sh/uv/issues/8879
+    venv.EnvBuilder(with_pip=False,
+                    symlinks=(os.name != "nt")).create(venv_dir)
+
 
 @pytest.fixture(name="adapter_python")
 def adapter_python_fixture(tmp_path: Path) -> tuple[Path, Path]:
     is_windows = os.name == "nt"
     adapter_env = tmp_path / "adapter-env"
 
-    # Use `symlinks=True`` on Posix systems to work-around for
-    # https://github.com/astral-sh/uv/issues/8879
-    venv.EnvBuilder(with_pip=False,
-                    symlinks=(not is_windows)).create(adapter_env)
+    _create_venv(adapter_env)
 
     python = adapter_env / ("Scripts/python.exe" if is_windows else "bin/python")
     data_root = _python_sysconfig_path(python, "data")
@@ -168,7 +171,7 @@ def test_adapter_python_data_directory_replaces_current_data_directory(
     patch_sysconfig_data(current_data_root)
 
     adapter_env = tmp_path / "adapter-env"
-    venv.EnvBuilder(with_pip=False).create(adapter_env)
+    _create_venv(adapter_env)
     adapter_python = adapter_env / (
         "Scripts/python.exe" if os.name == "nt" else "bin/python"
     )
@@ -241,7 +244,7 @@ def test_unset_harness_python_env_uses_sdk_interpreter(
 
 def test_adapter_python_data_path_query_times_out(tmp_path: Path):
     adapter_env = tmp_path / "slow-adapter-env"
-    venv.EnvBuilder(with_pip=False).create(adapter_env)
+    _create_venv(adapter_env)
     adapter_python = adapter_env / (
         "Scripts/python.exe" if os.name == "nt" else "bin/python"
     )

--- a/tests/python/test_installed_adapter_discovery.py
+++ b/tests/python/test_installed_adapter_discovery.py
@@ -97,9 +97,15 @@ def _python_sysconfig_path(python: Path, name: str) -> Path:
 
 @pytest.fixture(name="adapter_python")
 def adapter_python_fixture(tmp_path: Path) -> tuple[Path, Path]:
+    is_windows = os.name == "nt"
     adapter_env = tmp_path / "adapter-env"
-    venv.EnvBuilder(with_pip=False).create(adapter_env)
-    python = adapter_env / ("Scripts/python.exe" if os.name == "nt" else "bin/python")
+
+    # Use `symlinks=True`` on Posix systems to work-around for
+    # https://github.com/astral-sh/uv/issues/8879
+    venv.EnvBuilder(with_pip=False,
+                    symlinks=(not is_windows)).create(adapter_env)
+
+    python = adapter_env / ("Scripts/python.exe" if is_windows else "bin/python")
     data_root = _python_sysconfig_path(python, "data")
     descriptor = _write_descriptor(data_root, "configured.adapter")
     return python, descriptor


### PR DESCRIPTION
#### Overview

* Work-around for known issue with uv astral-sh/uv#8879
* Ensure that the `hermes-agent` extra is installed for CI tests

#### Where should the reviewer start?

* `tests/python/test_installed_adapter_discovery.py`

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- Closes FABRIC-140

- [x] I confirm this contribution is my own work, or I have the right to submit it under this project's license.
- [x] I searched existing issues and open pull requests, and this does not duplicate existing work.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved validation of adapter discovery across supported Python environments and operating systems.
  * Updated test environment setup to provide more consistent behavior on Windows and Posix systems.

* **Chores**
  * Updated continuous integration configuration to use the appropriate package configuration for different Python versions, improving build reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->