### PR TITLE
ci: Batch wheels by package name

### DIFF
--- a/scripts/ci/artifactory_upload.py
+++ b/scripts/ci/artifactory_upload.py
@@ -46,12 +46,6 @@ def perform_release(published_wheels: list[tuple[Path, str]]) -> None:
     response.raise_for_status()
     projects = response.json()
 
-    if len(projects) < len(published_wheels):
-        print(
-            f"Warning: KitMaker returned {len(projects)} projects for {len(published_wheels)} published wheels.",
-            flush=True,
-        )
-
     project_ids = {project["name"]: project["id"] for project in projects}
 
     # Group published wheels by package name
@@ -59,6 +53,13 @@ def perform_release(published_wheels: list[tuple[Path, str]]) -> None:
     for (wheel_file, wheel_url) in published_wheels:
         package_name = pkginfo.Wheel(str(wheel_file)).name
         packages[package_name].append(wheel_url)
+
+    if len(projects) < len(packages):
+        print(
+            f"Warning: KitMaker returned {len(projects)} projects for {len(packages)} packages.",
+            flush=True,
+        )
+
 
     for package_name, wheel_urls in packages.items():
         package_id = project_ids[package_name]

--- a/scripts/ci/artifactory_upload.py
+++ b/scripts/ci/artifactory_upload.py
@@ -4,6 +4,7 @@
 
 import os
 import sys
+from collections import defaultdict
 from pathlib import Path
 from urllib.parse import quote
 
@@ -52,17 +53,26 @@ def perform_release(published_wheels: list[tuple[Path, str]]) -> None:
         )
 
     project_ids = {project["name"]: project["id"] for project in projects}
-    for wheel_file, wheel_url in published_wheels:
+
+    # Group published wheels by package name
+    packages = defaultdict(list)
+    for (wheel_file, wheel_url) in published_wheels:
         package_name = pkginfo.Wheel(str(wheel_file)).name
+        packages[package_name].append(wheel_url)
+
+    for package_name, wheel_urls in packages.items():
         package_id = project_ids[package_name]
+        wheels_payload = [{
+                            "pic": kitmaker_owner,
+                            "job_type": "wheel-release-job",
+                            "url": wheel_url,
+                            "upload": True,
+                        }
+                        for wheel_url in wheel_urls]
+
         payload = {
             "project_name": package_name,
-            "payload": [{
-                "pic": kitmaker_owner,
-                "job_type": "wheel-release-job",
-                "url": wheel_url,
-                "upload": True,
-            }],
+            "payload": wheels_payload,
         }
 
         response = requests.post(


### PR DESCRIPTION
#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- Closes FABRIC-146

- [x] I confirm this contribution is my own work, or I have the right to submit it under this project's license.
- [x] I searched existing issues and open pull requests, and this does not duplicate existing work.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved release publishing by grouping uploaded wheel files by package.
  * Prevented duplicate release payloads when multiple wheels belong to the same package.
  * Ensured each package release includes all of its associated wheel download links.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->