### PR TITLE
fix(test): enable Relay for Hermes streaming coverage

### DIFF
--- a/justfile
+++ b/justfile
@@ -414,7 +414,7 @@ test-python:
     #!/usr/bin/env bash
     set -euo pipefail
     if [[ "{{ no_uv }}" != "true" ]]; then
-        uv sync --group test --no-group dev --extra claude --extra codex --extra deepagents --extra harbor --extra hermes --extra relay --extra runtime
+        uv sync --group test --no-group dev --extra claude --extra codex --extra deepagents --extra harbor --extra hermes --extra hermes-agent --extra relay --extra runtime
     fi
     uv run --no-sync pytest
 

--- a/tests/e2e/test_hermes_e2e.py
+++ b/tests/e2e/test_hermes_e2e.py
@@ -22,13 +22,13 @@ from nemo_fabric import Fabric
 pytestmark = pytest.mark.usefixtures("requires_hermes_agent")
 
 
-@pytest.mark.usefixtures("mock_nvidia_api_key")
+@pytest.mark.usefixtures("mock_nvidia_api_key", "nemo_relay")
 async def test_hermes_persistent_host_reuses_native_session(
     code_review_agent_dir: Path,
     api_server: str,
 ):
     os.environ["ADAPTER_PYTHON"] = sys.executable
-    config = hermes_config()
+    config = with_relay(hermes_config())
     config.harness.settings["base_url"] = f"{api_server}/v1"
 
     with warnings.catch_warnings():


### PR DESCRIPTION
#### Overview

Enable NeMo Relay for the Hermes persistent-runtime streaming test and keep Hermes Agent installed when the CI-equivalent Python test recipe synchronizes its environment. This ensures the streaming assertions execute instead of failing the Relay precondition or skipping because the optional harness dependency was removed.

This changes test and CI-recipe behavior only. There are no public API, runtime behavior, dependency-version, or breaking changes.

#### Details

- Build the Hermes streaming test configuration with `with_relay(...)` and require the `nemo_relay` fixture.
- Include the `hermes-agent` extra in `just test-python` so the recipe preserves the harness dependency installed by Python CI.
- Leave the intentional negative unit test for `streaming=True` without Relay unchanged.

#### Validation

- `uv run --no-sync pytest tests/e2e/test_hermes_e2e.py::test_hermes_persistent_host_reuses_native_session -vv -rs` — 1 passed
- `uv run --no-sync pytest tests/python/test_streaming.py tests/e2e/test_hermes_e2e.py -q -rs` — 40 passed
- `just test-python` — 501 passed, 15 unrelated opt-in integration tests skipped; all five Hermes E2E tests executed
- `just --fmt --check`
- `git diff --check`

#### Where should the reviewer start?

Start with `tests/e2e/test_hermes_e2e.py::test_hermes_persistent_host_reuses_native_session`, then review the optional extras in the `justfile` `test-python` recipe.

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- Relates to #109 and #105

- [x] I confirm this contribution is my own work, or I have the right to submit it under this project's license.
- [x] I searched existing issues and open pull requests, and this does not duplicate existing work.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Improved end-to-end coverage for persistent host sessions using relay-enabled runtime configurations.
  - Updated Python test setup to include the optional dependencies required for Hermes agent testing.
  - Enhanced validation of native session reuse behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->