### PR TITLE
fix: report partial Hermes results as failures

### DIFF
--- a/adapters/hermes/src/nemo_fabric_adapters/hermes/adapter.py
+++ b/adapters/hermes/src/nemo_fabric_adapters/hermes/adapter.py
@@ -406,11 +406,19 @@ class HermesRuntime:
         messages = result.get("messages") or []
         if isinstance(messages, list):
             self._conversation_history = messages
+        reported_error = result.get("error")
         failed = (
             bool(result.get("failed"))
             or bool(result.get("partial"))
-            or bool(result.get("error"))
+            or bool(reported_error)
         )
+        if isinstance(reported_error, str) and reported_error:
+            reported_error = {
+                "code": "hermes_reported_failure",
+                "message": reported_error,
+                "retryable": False,
+                "metadata": {},
+            }
 
         output = {
             "harness": "hermes",
@@ -424,7 +432,7 @@ class HermesRuntime:
             "api_calls": result.get("api_calls"),
             "messages": messages,
             "message_count": len(messages),
-            "error": result.get("error"),
+            "error": reported_error,
             "adapter_stdout": adapter_stdout,
             "hermes_home": str(self._hermes_home),
             "hermes_config_path": str(self._hermes_config_path),

--- a/adapters/hermes/src/nemo_fabric_adapters/hermes/adapter.py
+++ b/adapters/hermes/src/nemo_fabric_adapters/hermes/adapter.py
@@ -406,6 +406,11 @@ class HermesRuntime:
         messages = result.get("messages") or []
         if isinstance(messages, list):
             self._conversation_history = messages
+        failed = (
+            bool(result.get("failed"))
+            or bool(result.get("partial"))
+            or bool(result.get("error"))
+        )
 
         output = {
             "harness": "hermes",
@@ -415,7 +420,7 @@ class HermesRuntime:
             "base_url": self._base_url,
             "response": result.get("response") or result.get("final_response"),
             "completed": bool(result.get("completed")),
-            "failed": bool(result.get("failed")),
+            "failed": failed,
             "api_calls": result.get("api_calls"),
             "messages": messages,
             "message_count": len(messages),

--- a/tests/adapters/test_hermes_adapter.py
+++ b/tests/adapters/test_hermes_adapter.py
@@ -501,24 +501,43 @@ def test_artifact_root_resolves_relative_to_base_dir(tmp_path: Path):
     assert adapter._artifact_root(payload) == (tmp_path / "run-artifacts").resolve()
 
 
-async def test_incomplete_hermes_result_is_failed():
+@pytest.fixture
+def started_hermes_runtime() -> tuple[adapter.HermesRuntime, MagicMock]:
     mock_ai_agent = MagicMock(spec=AIAgent)
     mock_ai_agent.run_conversation.__signature__ = inspect.signature(
         AIAgent.run_conversation
     )
-    mock_ai_agent.run_conversation.return_value = {
-        "final_response": None,
-        "completed": False,
-        "partial": True,
-        "error": "Response remained truncated after 4 continuation attempts",
-        "messages": [],
-    }
     runtime = adapter.HermesRuntime()
     runtime._started = True
     runtime._start_payload = {}
     runtime._runtime_id = "runtime-incomplete"
     runtime._agent = mock_ai_agent
     runtime._model_config = {"model": "test-model"}
+    return runtime, mock_ai_agent
+
+
+@pytest.mark.parametrize(
+    ("result_update", "expected_failed"),
+    [
+        pytest.param({"failed": True}, True, id="failed"),
+        pytest.param({"partial": True}, True, id="partial"),
+        pytest.param({"error": "reported failure"}, True, id="error"),
+        pytest.param({"error": ""}, False, id="empty-error"),
+        pytest.param({}, False, id="completed-false-only"),
+    ],
+)
+async def test_hermes_failure_indicators_are_independent(
+    started_hermes_runtime: tuple[adapter.HermesRuntime, MagicMock],
+    result_update: dict[str, object],
+    expected_failed: bool,
+):
+    runtime, mock_ai_agent = started_hermes_runtime
+    mock_ai_agent.run_conversation.return_value = {
+        "final_response": "done",
+        "completed": False,
+        "messages": [],
+        **result_update,
+    }
 
     output = await runtime.invoke(
         {
@@ -528,41 +547,66 @@ async def test_incomplete_hermes_result_is_failed():
     )
 
     assert output["completed"] is False
-    assert output["failed"] is True
-    assert output["response"] is None
-    assert output["error"] == (
-        "Response remained truncated after 4 continuation attempts"
-    )
+    assert output["failed"] is expected_failed
 
 
-async def test_hermes_completed_flag_alone_does_not_report_failure():
-    mock_ai_agent = MagicMock(spec=AIAgent)
-    mock_ai_agent.run_conversation.__signature__ = inspect.signature(
-        AIAgent.run_conversation
-    )
+async def test_incomplete_hermes_result_preserves_structured_error(
+    started_hermes_runtime: tuple[adapter.HermesRuntime, MagicMock],
+):
+    runtime, mock_ai_agent = started_hermes_runtime
+    message = "Response remained truncated after 4 continuation attempts"
     mock_ai_agent.run_conversation.return_value = {
-        "final_response": "done",
+        "final_response": None,
         "completed": False,
+        "partial": True,
+        "error": message,
         "messages": [],
     }
-    runtime = adapter.HermesRuntime()
-    runtime._started = True
-    runtime._start_payload = {}
-    runtime._runtime_id = "runtime-legacy-result"
-    runtime._agent = mock_ai_agent
-    runtime._model_config = {"model": "test-model"}
 
     output = await runtime.invoke(
         {
-            "runtime_context": {"runtime_id": "runtime-legacy-result"},
+            "runtime_context": {"runtime_id": "runtime-incomplete"},
             "request": {"input": "complete the task"},
         }
     )
 
-    assert output["completed"] is False
-    assert output["failed"] is False
-    assert output["response"] == "done"
-    assert output["error"] is None
+    assert output["failed"] is True
+    assert output["response"] is None
+    assert output["error"] == {
+        "code": "hermes_reported_failure",
+        "message": message,
+        "retryable": False,
+        "metadata": {},
+    }
+
+
+async def test_hermes_structured_error_is_preserved(
+    started_hermes_runtime: tuple[adapter.HermesRuntime, MagicMock],
+):
+    runtime, mock_ai_agent = started_hermes_runtime
+    reported_error = {
+        "code": "hermes_rate_limited",
+        "message": "provider rate limited the request",
+        "retryable": True,
+        "metadata": {"provider": "test"},
+    }
+    mock_ai_agent.run_conversation.return_value = {
+        "final_response": None,
+        "completed": False,
+        "failed": True,
+        "error": reported_error,
+        "messages": [],
+    }
+
+    output = await runtime.invoke(
+        {
+            "runtime_context": {"runtime_id": "runtime-incomplete"},
+            "request": {"input": "complete the task"},
+        }
+    )
+
+    assert output["failed"] is True
+    assert output["error"] is reported_error
 
 
 async def test_persistent_runtime_reuses_hermes_agent_session_and_history(

--- a/tests/adapters/test_hermes_adapter.py
+++ b/tests/adapters/test_hermes_adapter.py
@@ -501,8 +501,8 @@ def test_artifact_root_resolves_relative_to_base_dir(tmp_path: Path):
     assert adapter._artifact_root(payload) == (tmp_path / "run-artifacts").resolve()
 
 
-@pytest.fixture
-def started_hermes_runtime() -> tuple[adapter.HermesRuntime, MagicMock]:
+@pytest.fixture(name="started_hermes_runtime")
+def started_hermes_runtime_fixture() -> tuple[adapter.HermesRuntime, MagicMock]:
     mock_ai_agent = MagicMock(spec=AIAgent)
     mock_ai_agent.run_conversation.__signature__ = inspect.signature(
         AIAgent.run_conversation
@@ -529,6 +529,7 @@ def started_hermes_runtime() -> tuple[adapter.HermesRuntime, MagicMock]:
 async def test_hermes_failure_indicators_are_independent(
     started_hermes_runtime: tuple[adapter.HermesRuntime, MagicMock],
     result_update: dict[str, object],
+    *,
     expected_failed: bool,
 ):
     runtime, mock_ai_agent = started_hermes_runtime

--- a/tests/adapters/test_hermes_adapter.py
+++ b/tests/adapters/test_hermes_adapter.py
@@ -501,6 +501,70 @@ def test_artifact_root_resolves_relative_to_base_dir(tmp_path: Path):
     assert adapter._artifact_root(payload) == (tmp_path / "run-artifacts").resolve()
 
 
+async def test_incomplete_hermes_result_is_failed():
+    mock_ai_agent = MagicMock(spec=AIAgent)
+    mock_ai_agent.run_conversation.__signature__ = inspect.signature(
+        AIAgent.run_conversation
+    )
+    mock_ai_agent.run_conversation.return_value = {
+        "final_response": None,
+        "completed": False,
+        "partial": True,
+        "error": "Response remained truncated after 4 continuation attempts",
+        "messages": [],
+    }
+    runtime = adapter.HermesRuntime()
+    runtime._started = True
+    runtime._start_payload = {}
+    runtime._runtime_id = "runtime-incomplete"
+    runtime._agent = mock_ai_agent
+    runtime._model_config = {"model": "test-model"}
+
+    output = await runtime.invoke(
+        {
+            "runtime_context": {"runtime_id": "runtime-incomplete"},
+            "request": {"input": "complete the task"},
+        }
+    )
+
+    assert output["completed"] is False
+    assert output["failed"] is True
+    assert output["response"] is None
+    assert output["error"] == (
+        "Response remained truncated after 4 continuation attempts"
+    )
+
+
+async def test_hermes_completed_flag_alone_does_not_report_failure():
+    mock_ai_agent = MagicMock(spec=AIAgent)
+    mock_ai_agent.run_conversation.__signature__ = inspect.signature(
+        AIAgent.run_conversation
+    )
+    mock_ai_agent.run_conversation.return_value = {
+        "final_response": "done",
+        "completed": False,
+        "messages": [],
+    }
+    runtime = adapter.HermesRuntime()
+    runtime._started = True
+    runtime._start_payload = {}
+    runtime._runtime_id = "runtime-legacy-result"
+    runtime._agent = mock_ai_agent
+    runtime._model_config = {"model": "test-model"}
+
+    output = await runtime.invoke(
+        {
+            "runtime_context": {"runtime_id": "runtime-legacy-result"},
+            "request": {"input": "complete the task"},
+        }
+    )
+
+    assert output["completed"] is False
+    assert output["failed"] is False
+    assert output["response"] == "done"
+    assert output["error"] is None
+
+
 async def test_persistent_runtime_reuses_hermes_agent_session_and_history(
     monkeypatch,
     tmp_path: Path,


### PR DESCRIPTION
#### Overview

Hermes Agent can return a terminal partial result with `completed=false`,
`partial=true`, and a non-empty `error`, while leaving `failed=false`. Fabric
currently trusts only the Hermes `failed` field and therefore reports that
invocation as succeeded. This change normalizes Hermes-specific partial/error
signals at the adapter boundary so Fabric reports the invocation as failed
without discarding the original Hermes error.

This change is independent of the runtime cleanup-result preservation work in
#140 and can be reviewed and merged in either order.

#### Details

- Treat Hermes `failed`, `partial`, or non-empty `error` values as independent adapter-reported failure signals.
- Normalize a non-empty Hermes string error into Fabric's structured error contract while preserving its original message.
- Preserve an existing structured Hermes error mapping unchanged.
- Preserve existing Hermes behavior where `completed=false` by itself is not a failure. Hermes 0.18.2 emits that shape for ordinary successful `finish_reason=stop` responses.
- Add regression coverage for the exact Terminal-Bench truncation result: `Response remained truncated after 4 continuation attempts`.
- Keep this normalization Hermes-specific. Claude, Codex, and DeepAgents already normalize their SDK-specific terminal states, while Fabric core intentionally consumes the adapter-neutral `failed` contract.

#### Validation

- Rebased independently onto current `main` at `2b4cf99`.
- Reproduced this Hermes status issue in the Terminal-Bench task 010 Inference Hub smoke run: Hermes returned `completed=false`, `failed=false`, `partial=true`, and `Response remained truncated after 4 continuation attempts`, while Harbor recorded zero exceptions and Fabric reported success.
- `pytest -q tests/adapters/test_hermes_adapter.py tests/e2e/test_hermes_e2e.py` — 37 passed.
- `pre-commit run --from-ref upstream/main --to-ref HEAD` — all applicable checks passed.
- Focused pre-commit validation for the review fixes — passed.
- `git diff --check upstream/main...HEAD`.

#### Where should the reviewer start?

Start with the failure normalization in
`adapters/hermes/src/nemo_fabric_adapters/hermes/adapter.py`, then review the
result-shape regressions in `tests/adapters/test_hermes_adapter.py`. The key
design choice is intentionally not treating `completed=false` alone as failure
because current Hermes successful responses also use that value.

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- Relates to: none

- [x] I confirm this contribution is my own work, or I have the right to submit it under this project's license.
- [x] I searched existing issues and open pull requests, and this does not duplicate existing work.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of Hermes runtime failures, including partial and incomplete responses.
  * Errors reported as text are now presented in a consistent structured format.
  * Existing structured error details are preserved.
  * Failure status is now correctly reported even when a response is incomplete or marked partial.

* **Tests**
  * Added coverage for failure detection, partial responses, and structured error handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->