### PR TITLE
chore: restore release package versions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -55,7 +55,7 @@ checksum = "d0881ea181b1df73ff77ffaaf9c7544ecc11e82fba9b5f27b262a3c73a332555"
 
 [[package]]
 name = "fabric-python"
-version = "0.2.0"
+version = "0.1.0"
 dependencies = [
  "nemo-fabric-core",
  "pyo3",
@@ -89,7 +89,7 @@ checksum = "6b947ae49db0d222b1dbc6b113ce7248a3fc3a6ca21b696717bfc000ba4484d8"
 
 [[package]]
 name = "nemo-fabric-cli"
-version = "0.2.0"
+version = "0.1.0"
 dependencies = [
  "clap",
  "nemo-fabric-core",
@@ -98,7 +98,7 @@ dependencies = [
 
 [[package]]
 name = "nemo-fabric-core"
-version = "0.2.0"
+version = "0.1.0"
 dependencies = [
  "schemars",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,13 +14,13 @@ default-members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.2.0"
+version = "0.1.0"
 edition = "2024"
 license = "Apache-2.0"
 repository = "https://github.com/NVIDIA/nemo-fabric"
 
 [workspace.dependencies]
-nemo-fabric-core = { path = "crates/fabric-core", version = "0.2.0" }
+nemo-fabric-core = { path = "crates/fabric-core", version = "0.1.0" }
 
 clap = { version = "4", default-features = false, features = ["derive", "std", "help", "usage", "error-context", "suggestions"] }
 schemars = { version = "1", features = ["derive"] }

--- a/adapters/claude/pyproject.toml
+++ b/adapters/claude/pyproject.toml
@@ -9,7 +9,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "nemo-fabric-adapters-claude"
-version = "0.2.0"
+version = "0.1.0"
 description = "Claude adapter for NeMo Fabric"
 authors = [
   { name = "NVIDIA Corporation" },
@@ -25,7 +25,7 @@ license-files = ["LICENSE"]
 readme = "README.md"
 requires-python = ">=3.11"
 dependencies = [
-  "nemo-fabric-adapters-common == 0.2.0",
+  "nemo-fabric-adapters-common == 0.1.0",
   "tomli-w~=1.2",
 ]
 

--- a/adapters/claude/uv.lock
+++ b/adapters/claude/uv.lock
@@ -350,7 +350,7 @@ wheels = [
 
 [[package]]
 name = "nemo-fabric-adapters-claude"
-version = "0.2.0"
+version = "0.1.0"
 source = { editable = "." }
 dependencies = [
     { name = "nemo-fabric-adapters-common" },
@@ -376,7 +376,7 @@ provides-extras = ["harness", "full"]
 
 [[package]]
 name = "nemo-fabric-adapters-common"
-version = "0.2.0"
+version = "0.1.0"
 source = { editable = "../common" }
 
 [[package]]

--- a/adapters/codex/pyproject.toml
+++ b/adapters/codex/pyproject.toml
@@ -9,7 +9,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "nemo-fabric-adapters-codex"
-version = "0.2.0"
+version = "0.1.0"
 description = "Codex adapter for NeMo Fabric"
 authors = [
   { name = "NVIDIA Corporation" },
@@ -25,7 +25,7 @@ license-files = ["LICENSE"]
 readme = "README.md"
 requires-python = ">=3.11"
 dependencies = [
-  "nemo-fabric-adapters-common == 0.2.0",
+  "nemo-fabric-adapters-common == 0.1.0",
   "tomli-w~=1.2",
 ]
 

--- a/adapters/codex/uv.lock
+++ b/adapters/codex/uv.lock
@@ -13,7 +13,7 @@ wheels = [
 
 [[package]]
 name = "nemo-fabric-adapters-codex"
-version = "0.2.0"
+version = "0.1.0"
 source = { editable = "." }
 dependencies = [
     { name = "nemo-fabric-adapters-common" },
@@ -39,7 +39,7 @@ provides-extras = ["harness", "full"]
 
 [[package]]
 name = "nemo-fabric-adapters-common"
-version = "0.2.0"
+version = "0.1.0"
 source = { editable = "../common" }
 
 [[package]]

--- a/adapters/common/pyproject.toml
+++ b/adapters/common/pyproject.toml
@@ -9,7 +9,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "nemo-fabric-adapters-common"
-version = "0.2.0"
+version = "0.1.0"
 description = "Shared Python helpers for NeMo Fabric adapters"
 authors = [
   { name = "NVIDIA Corporation" },

--- a/adapters/common/uv.lock
+++ b/adapters/common/uv.lock
@@ -4,5 +4,5 @@ requires-python = ">=3.11"
 
 [[package]]
 name = "nemo-fabric-adapters-common"
-version = "0.2.0"
+version = "0.1.0"
 source = { editable = "." }

--- a/adapters/deepagents/pyproject.toml
+++ b/adapters/deepagents/pyproject.toml
@@ -9,7 +9,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "nemo-fabric-adapters-deepagents"
-version = "0.2.0"
+version = "0.1.0"
 description = "LangChain Deep Agents adapter for NeMo Fabric"
 authors = [
   { name = "NVIDIA Corporation" },
@@ -25,7 +25,7 @@ license-files = ["LICENSE"]
 readme = "README.md"
 requires-python = ">=3.11"
 dependencies = [
-  "nemo-fabric-adapters-common == 0.2.0",
+  "nemo-fabric-adapters-common == 0.1.0",
   "langchain-mcp-adapters>=0.1,<0.3.0",
   "langchain-openai>=0.3",
   # Requires 3.x: the 2.x line is incompatible with the langgraph core deepagents

--- a/adapters/deepagents/uv.lock
+++ b/adapters/deepagents/uv.lock
@@ -834,12 +834,12 @@ wheels = [
 
 [[package]]
 name = "nemo-fabric-adapters-common"
-version = "0.2.0"
+version = "0.1.0"
 source = { editable = "../common" }
 
 [[package]]
 name = "nemo-fabric-adapters-deepagents"
-version = "0.2.0"
+version = "0.1.0"
 source = { editable = "." }
 dependencies = [
     { name = "langchain-mcp-adapters" },

--- a/adapters/hermes/pyproject.toml
+++ b/adapters/hermes/pyproject.toml
@@ -9,7 +9,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "nemo-fabric-adapters-hermes"
-version = "0.2.0"
+version = "0.1.0"
 description = "Hermes Agent adapter for NeMo Fabric"
 authors = [
   { name = "NVIDIA Corporation" },
@@ -26,7 +26,7 @@ readme = "README.md"
 # Hermes Agent does not currently support Python 3.14 or later.
 requires-python = ">=3.11,<3.14"
 dependencies = [
-  "nemo-fabric-adapters-common == 0.2.0",
+  "nemo-fabric-adapters-common == 0.1.0",
 ]
 
 [project.optional-dependencies]

--- a/adapters/hermes/uv.lock
+++ b/adapters/hermes/uv.lock
@@ -543,12 +543,12 @@ wheels = [
 
 [[package]]
 name = "nemo-fabric-adapters-common"
-version = "0.2.0"
+version = "0.1.0"
 source = { editable = "../common" }
 
 [[package]]
 name = "nemo-fabric-adapters-hermes"
-version = "0.2.0"
+version = "0.1.0"
 source = { editable = "." }
 dependencies = [
     { name = "nemo-fabric-adapters-common" },

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "nemo-fabric"
-version = "0.2.0"
+version = "0.1.0"
 description = "Python SDK distribution for NeMo Fabric"
 authors = [
   { name = "NVIDIA Corporation" },
@@ -25,7 +25,7 @@ license-files = ["LICENSE"]
 readme = "pypi.md"
 requires-python = ">=3.11"
 dependencies = [
-  "nemo-fabric-runtime == 0.2.0",
+  "nemo-fabric-runtime == 0.1.0",
 ]
 
 [project.urls]
@@ -38,15 +38,15 @@ packages = []
 [project.optional-dependencies]
 
 claude = [
-  "nemo-fabric-adapters-claude[harness] == 0.2.0",
+  "nemo-fabric-adapters-claude[harness] == 0.1.0",
 ]
 
 codex = [
-  "nemo-fabric-adapters-codex[harness] == 0.2.0",
+  "nemo-fabric-adapters-codex[harness] == 0.1.0",
 ]
 
 deepagents = [
-  "nemo-fabric-adapters-deepagents[harness] == 0.2.0",
+  "nemo-fabric-adapters-deepagents[harness] == 0.1.0",
 ]
 
 harbor = [
@@ -55,7 +55,7 @@ harbor = [
 ]
 
 hermes-agent = [
-  "nemo-fabric-adapters-hermes[harness] == 0.2.0; python_version < '3.14'",
+  "nemo-fabric-adapters-hermes[harness] == 0.1.0; python_version < '3.14'",
 ]
 
 relay = [

--- a/uv.lock
+++ b/uv.lock
@@ -2050,7 +2050,7 @@ wheels = [
 
 [[package]]
 name = "nemo-fabric"
-version = "0.2.0"
+version = "0.1.0"
 source = { editable = "." }
 dependencies = [
     { name = "nemo-fabric-runtime" },
@@ -2172,7 +2172,7 @@ test = [
 
 [[package]]
 name = "nemo-fabric-adapters-claude"
-version = "0.2.0"
+version = "0.1.0"
 source = { editable = "adapters/claude" }
 dependencies = [
     { name = "nemo-fabric-adapters-common" },
@@ -2195,7 +2195,7 @@ provides-extras = ["harness", "full"]
 
 [[package]]
 name = "nemo-fabric-adapters-codex"
-version = "0.2.0"
+version = "0.1.0"
 source = { editable = "adapters/codex" }
 dependencies = [
     { name = "nemo-fabric-adapters-common" },
@@ -2218,12 +2218,12 @@ provides-extras = ["harness", "full"]
 
 [[package]]
 name = "nemo-fabric-adapters-common"
-version = "0.2.0"
+version = "0.1.0"
 source = { editable = "adapters/common" }
 
 [[package]]
 name = "nemo-fabric-adapters-deepagents"
-version = "0.2.0"
+version = "0.1.0"
 source = { editable = "adapters/deepagents" }
 dependencies = [
     { name = "langchain-mcp-adapters" },
@@ -2261,7 +2261,7 @@ provides-extras = ["harness", "relay", "full"]
 
 [[package]]
 name = "nemo-fabric-adapters-hermes"
-version = "0.2.0"
+version = "0.1.0"
 source = { editable = "adapters/hermes" }
 dependencies = [
     { name = "nemo-fabric-adapters-common", marker = "python_full_version < '3.14'" },


### PR DESCRIPTION
#### Overview

Restore the active `release/0.1` branch to a consistent `0.1.0` package
version after the forward merge left its publishable Rust and Python packages
at `0.2.0`.

- Set the Rust workspace, Python SDK, runtime, shared adapter package, and all
  adapter distributions to `0.1.0`.
- Keep all exact internal package constraints aligned at `0.1.0`, including
  the root adapter extras.
- Regenerate the Cargo and uv lockfiles without changing the dependency graph.
- Breaking changes: none. This is a release-metadata correction only.

Validation:

- `cargo check --workspace --locked`
- `cargo fmt --all -- --check`
- `just --fmt --check`
- `just test-rust`
- `just build-python`
- `cargo check -p fabric-python --locked`
- `just test-python` (`529 passed, 15 skipped`)
- `just wheels` (all Fabric distributions produced at `0.1.0`)
- `uv run pre-commit run attributions-rust --all-files`
- `uv run pre-commit run attributions-python --all-files`
- `uv run --no-project python scripts/licensing/license_diff.py --base-ref upstream/release/0.1` (no Rust or Python dependency changes)

#### Where should the reviewer start?

Start with `Cargo.toml` and the root `pyproject.toml`, then confirm the adapter
package metadata and lockfiles carry the same `0.1.0` version.

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- Relates to the `release/0.1` packaging and publication flow.

- [x] I confirm this contribution is my own work, or I have the right to submit it under this project's license.
- [x] I searched existing issues and open pull requests, and this does not duplicate existing work.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the project and package release version to **0.1.0**.
  * Aligned runtime, adapter, and shared package versions to **0.1.0**.
  * Updated optional adapter integrations to use the matching **0.1.0** release.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->