### PR TITLE
chore: refresh Cargo lock during version stamping

### DIFF
--- a/justfile
+++ b/justfile
@@ -203,7 +203,8 @@ PY
 
     local metadata_file=""
     metadata_file="$(mktemp)"
-    if ! cargo metadata --no-deps --format-version 1 > "$metadata_file"; then
+    # Resolve dependencies so Cargo refreshes workspace package versions in Cargo.lock.
+    if ! cargo metadata --format-version 1 > "$metadata_file"; then
         rm -f "$metadata_file"
         return 1
     fi


### PR DESCRIPTION
#### Overview

Ensure release version stamping refreshes workspace package versions in `Cargo.lock`.
Without this, an RC tag updates `Cargo.toml` while leaving the lockfile at the
stable version, so Maturin's locked build cannot produce the exact-version
`nemo-fabric-runtime` wheel required by the root package.

#### Details

- Run full `cargo metadata` resolution during `set_cargo_workspace_version`.
- Preserve the existing workspace package version validation.
- Document why dependency resolution is required at this point in the release flow.

#### Validation

- `just set-version 0.1.0-rc.5` in an isolated clone
  - Updated only the three Fabric workspace versions in `Cargo.lock`
  - Updated all Python package versions and exact internal pins to `0.1.0rc5`
- `just wheels`
  - Built all seven RC5 wheels, including the portable native runtime wheel
- Clean Python 3.13 install from `dist/`
  - Installed `nemo-fabric[hermes-agent]==0.1.0rc5`
  - Resolved the root, runtime, common adapter, and Hermes adapter at `0.1.0rc5`
- `cargo check --workspace --locked`
- `just build-python`
- `just test-python` — 531 passed, 14 skipped
- `just --fmt --check`
- `git diff --check`

License and attribution checks were not run because this PR does not change
manifests, committed lockfiles, dependencies, or attribution inputs.

#### Where should the reviewer start?

Start with the `cargo metadata` invocation in `set_cargo_workspace_version` in
`justfile`; removing `--no-deps` is the functional change that lets Cargo refresh
workspace versions in `Cargo.lock`.

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- Relates to: none

- [x] I confirm this contribution is my own work, or I have the right to submit it under this project's license.
- [x] I searched existing issues and open pull requests, and this does not duplicate existing work.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved workspace version synchronization by ensuring dependency information is fully resolved during the update process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->