### PR TITLE
docs: add NeMo Fabric 0.1 release notes

### DIFF
--- a/docs/about-nemo-fabric/release-notes.mdx
+++ b/docs/about-nemo-fabric/release-notes.mdx
@@ -26,7 +26,7 @@ experiment variations without rewriting each integration.
 The first release includes integrations for Claude Code, Codex, LangChain Deep
 Agents, and Hermes Agent. Each adapter translates the shared NeMo Fabric
 contract into the models, tools, skills, MCP servers, runtime state, and
-observability capabilities supported by its harness.
+observability capabilities supported by the harness.
 
 ### Persistent Multi-Turn Runtimes
 
@@ -35,14 +35,15 @@ session or thread state across turns. Single-invocation and multi-turn work use
 the same lifecycle, with consistent startup, invocation, failure handling, and
 cleanup behavior.
 
-### Portable Configuration With Fail-Closed Validation
+### Portable Configuration With Compatibility Validation
 
 The typed configuration model covers models, instructions, runtime limits,
 environments, tool policy, skills, MCP servers, telemetry, and
 [NVIDIA NeMo Relay](https://github.com/NVIDIA/NeMo-Relay/tree/main).
-Adapters declare the configuration and capabilities they support. NeMo Fabric
-reports incompatible settings before execution instead of silently ignoring
-them.
+Adapters declare the normalized configuration, telemetry, and runtime
+capabilities they support. NeMo Fabric rejects incompatible normalized
+settings and unsupported capability routes before harness invocation instead
+of silently dropping them.
 
 ### NeMo Relay Observability and Live Streaming
 
@@ -59,7 +60,7 @@ OpenTelemetry for Codex and OpenTelemetry and OpenInference for Deep Agents.
 
 The Harbor integration brings the shared NeMo Fabric contract into isolated
 evaluation environments and returns normalized result and telemetry evidence.
-This release includes a deterministic calculator workflow anda SWE-Bench
+This release includes a deterministic calculator workflow and a SWE-Bench
 walkthrough built on a single Harbor task for comparing harness behavior on
 the same task.
 

--- a/docs/about-nemo-fabric/release-notes.mdx
+++ b/docs/about-nemo-fabric/release-notes.mdx
@@ -1,8 +1,78 @@
 ---
 title: "Release Notes"
-description: "Release notes for NVIDIA NeMo Fabric."
+description: "Read the NVIDIA NeMo Fabric 0.1 release notes."
 ---
 {/* SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 SPDX-License-Identifier: Apache-2.0 */}
 
-To be filled out at release time
+We're excited to announce NVIDIA NeMo Fabric 0.1, our first release. NeMo
+Fabric introduces a typed, observable execution layer for running applications
+across multiple agent harnesses. Applications, evaluation systems, and rollout
+infrastructure can use the same configuration, lifecycle, result, artifact, and
+telemetry contracts without building a separate integration for each harness.
+
+## Release Highlights
+
+### One Execution Contract Across Harnesses
+
+NeMo Fabric provides one typed contract for configuring, launching, invoking,
+and observing agent harnesses. Runs produce normalized responses, structured
+failure details, lifecycle events, artifact references, and telemetry
+references. This shared contract makes it easier to compare harnesses and build
+experiment variations without rewriting each integration.
+
+### Four Bundled Harness Integrations
+
+The first release includes integrations for Claude Code, Codex, LangChain Deep
+Agents, and Hermes Agent. Each adapter translates the shared NeMo Fabric
+contract into the models, tools, skills, MCP servers, runtime state, and
+observability capabilities supported by its harness.
+
+### Persistent Multi-Turn Runtimes
+
+Bundled adapters use persistent local runtime hosts that retain harness-native
+session or thread state across turns. Single-invocation and multi-turn work use
+the same lifecycle, with consistent startup, invocation, failure handling, and
+cleanup behavior.
+
+### Portable Configuration With Fail-Closed Validation
+
+The typed configuration model covers models, instructions, runtime limits,
+environments, tool policy, skills, MCP servers, telemetry, and NeMo Relay.
+Adapters declare the configuration and capabilities they support. NeMo Fabric
+reports incompatible settings before execution instead of silently ignoring
+them.
+
+### NeMo Relay Observability and Live Streaming
+
+All four bundled adapters integrate with NVIDIA NeMo Relay. Runs can produce
+raw Agent Trajectory Observability Format (ATOF) events and normalized Agent
+Trajectory Interchange Format (ATIF) trajectories. Relay-enabled runtimes can
+also stream live ATOF records while keeping the normalized terminal result
+separate.
+
+Native observability is also available where the harness supports it, including
+OpenTelemetry for Codex and OpenTelemetry and OpenInference for Deep Agents.
+
+### Evaluation and Experimentation Workflows
+
+The Harbor integration brings the shared NeMo Fabric contract into isolated
+evaluation environments and returns normalized result and telemetry evidence.
+This release includes a deterministic calculator workflow and a qualified
+SWE-Bench example for comparing harness behavior on the same task.
+
+Guided notebooks and the experimentation CLI provide additional paths for
+exploring harness and model variations, running maintained examples, and
+creating editable Python or Rust projects.
+
+### Cross-Platform Release Artifacts
+
+NeMo Fabric ships Python artifacts for Linux on x86_64 and arm64, macOS on
+arm64, and Windows on x86_64. The Rust core and experimentation CLI are also
+published as independently versioned crates.
+
+## Current Limitations
+
+- Remote adapter services and a provider-backed third-party adapter registry
+  are not included in this release.
+- The configuration and adapter contracts use `v1alpha1` schema identifiers.

--- a/docs/about-nemo-fabric/release-notes.mdx
+++ b/docs/about-nemo-fabric/release-notes.mdx
@@ -53,9 +53,6 @@ Trajectory Interchange Format (ATIF) trajectories, and export OpenTelemetry and
 OpenInference through Relay. Relay-enabled runtimes can also stream live ATOF
 records while keeping the normalized terminal result separate.
 
-Codex and Deep Agents additionally support native OpenTelemetry. Deep Agents
-also supports native OpenInference.
-
 ### Evaluation and Experimentation Workflows
 
 The Harbor integration brings the shared NeMo Fabric contract into isolated

--- a/docs/about-nemo-fabric/release-notes.mdx
+++ b/docs/about-nemo-fabric/release-notes.mdx
@@ -49,12 +49,12 @@ of silently dropping them.
 
 All four bundled adapters integrate with NVIDIA NeMo Relay. Runs can produce
 raw Agent Trajectory Observability Format (ATOF) events and normalized Agent
-Trajectory Interchange Format (ATIF) trajectories. Relay-enabled runtimes can
-also stream live ATOF records while keeping the normalized terminal result
-separate.
+Trajectory Interchange Format (ATIF) trajectories, and export OpenTelemetry and
+OpenInference through Relay. Relay-enabled runtimes can also stream live ATOF
+records while keeping the normalized terminal result separate.
 
-Native observability is also available where the harness supports it, including
-OpenTelemetry for Codex and OpenTelemetry and OpenInference for Deep Agents.
+Codex and Deep Agents additionally support native OpenTelemetry. Deep Agents
+also supports native OpenInference.
 
 ### Evaluation and Experimentation Workflows
 

--- a/docs/about-nemo-fabric/release-notes.mdx
+++ b/docs/about-nemo-fabric/release-notes.mdx
@@ -38,7 +38,8 @@ cleanup behavior.
 ### Portable Configuration With Fail-Closed Validation
 
 The typed configuration model covers models, instructions, runtime limits,
-environments, tool policy, skills, MCP servers, telemetry, and NeMo Relay.
+environments, tool policy, skills, MCP servers, telemetry, and
+[NVIDIA NeMo Relay](https://github.com/NVIDIA/NeMo-Relay/tree/main).
 Adapters declare the configuration and capabilities they support. NeMo Fabric
 reports incompatible settings before execution instead of silently ignoring
 them.
@@ -58,8 +59,9 @@ OpenTelemetry for Codex and OpenTelemetry and OpenInference for Deep Agents.
 
 The Harbor integration brings the shared NeMo Fabric contract into isolated
 evaluation environments and returns normalized result and telemetry evidence.
-This release includes a deterministic calculator workflow and a qualified
-SWE-Bench example for comparing harness behavior on the same task.
+This release includes a deterministic calculator workflow anda SWE-Bench
+walkthrough built on a single Harbor task for comparing harness behavior on
+the same task.
 
 Guided notebooks and the experimentation CLI provide additional paths for
 exploring harness and model variations, running maintained examples, and


### PR DESCRIPTION
#### Overview

Adds the release notes for NVIDIA NeMo Fabric 0.1. The page replaces the release-time placeholder with a concise, feature-focused summary of the first release. This is a documentation-only change and does not alter runtime behavior, APIs, packaging, or dependencies.

#### Details

- Highlights the shared execution contract, four bundled harness integrations, persistent multi-turn runtimes, fail-closed configuration validation, NeMo Relay observability and streaming, evaluation workflows, and cross-platform artifacts.
- Records the current scope for remote adapter services, third-party adapter discovery, and the `v1alpha1` configuration and adapter contracts.
- Keeps installation procedures and API walkthroughs in their existing documentation rather than duplicating them in the release notes.

#### Validation

- `git diff --check upstream/release/0.1...HEAD`
- `pre-commit run --from-ref upstream/release/0.1 --to-ref HEAD` — all applicable hooks passed.
- `just --set no_uv true docs` with Node.js 20 and Rust 1.93 — generated Python and Rust references, Fern validation, and strict broken-link validation passed. Fern reported only the expected unauthenticated redirects warning.

#### Where should the reviewer start?

Start with `docs/about-nemo-fabric/release-notes.mdx`. The primary review question is whether the page captures the most important 0.1 capabilities without duplicating README, installation, or API-guide content.

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- Relates to: none

- [x] I confirm this contribution is my own work, or I have the right to submit it under this project's license.
- [x] I searched existing issues and open pull requests, and this does not duplicate existing work.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Added NVIDIA NeMo Fabric 0.1 release notes with release highlights covering unified typed execution, normalized responses, and consistent failure/lifecycle/artifact/telemetry outputs.
  - Documented bundled adapter integrations, persistent multi-turn runtimes, and portable typed configuration with compatibility validation.
  - Expanded NeMo Relay observability details (streamed ATOF vs normalized results, additional telemetry exports).
  - Included evaluation/experimentation walkthroughs, cross-platform release artifacts, and a “Current Limitations” section.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->