### PR TITLE
ci: make `Do Not Merge` tag actually block merging

### DIFF
--- a/.github/workflows/do-not-merge.yml
+++ b/.github/workflows/do-not-merge.yml
@@ -1,0 +1,24 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+name: Do Not Merge
+
+on:
+  pull_request:
+    types: [labeled, unlabeled, opened, reopened, synchronize]
+
+jobs:
+  label-check:
+    name: DO NOT MERGE label
+    runs-on: ubuntu-24.04
+    timeout-minutes: 1
+    permissions: {}
+    steps:
+      - name: Check label
+        env:
+          BLOCK_MERGE: ${{ contains(github.event.pull_request.labels.*.name, 'DO NOT MERGE') }}
+        run: |
+          if [[ "$BLOCK_MERGE" == "true" ]]; then
+            echo "::error::Remove the DO NOT MERGE label before merging."
+            exit 1
+          fi

--- a/.github/workflows/do-not-merge.yml
+++ b/.github/workflows/do-not-merge.yml
@@ -10,15 +10,12 @@ on:
 jobs:
   label-check:
     name: DO NOT MERGE label
+    if: contains(github.event.pull_request.labels.*.name, 'DO NOT MERGE')
     runs-on: ubuntu-24.04
     timeout-minutes: 1
     permissions: {}
     steps:
-      - name: Check label
-        env:
-          BLOCK_MERGE: ${{ contains(github.event.pull_request.labels.*.name, 'DO NOT MERGE') }}
+      - name: Block merge
         run: |
-          if [[ "$BLOCK_MERGE" == "true" ]]; then
-            echo "::error::Remove the DO NOT MERGE label before merging."
-            exit 1
-          fi
+          echo "::error::Remove the DO NOT MERGE label before merging."
+          exit 1

--- a/.github/workflows/do-not-merge.yml
+++ b/.github/workflows/do-not-merge.yml
@@ -7,6 +7,10 @@ on:
   pull_request:
     types: [labeled, unlabeled, opened, reopened, synchronize]
 
+concurrency:
+  group: do-not-merge-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
 jobs:
   label-check:
     name: DO NOT MERGE label


### PR DESCRIPTION
#### Overview

Add a minimal required-check surface that blocks a pull request while it has the `DO NOT MERGE` label. The job is skipped before runner allocation when the label is absent and runs only long enough to report a failure when the label is present.

- [x] I confirm this contribution is my own work, or I have the right to submit it under this project's license.
- [x] I searched existing issues and open pull requests, and this does not duplicate existing work.

#### Details

- Run the label gate when a pull request is opened, reopened, synchronized, labeled, or unlabeled.
- Use a job-level condition so ordinary pull requests do not allocate a runner for this check.
- Grant the job no GitHub token permissions.

After this workflow lands, configure `DO NOT MERGE label` as a required status check for the protected main branch so its failure blocks merging.

#### Validation

- `just --fmt --check`
- Copyright header pre-commit hook for `.github/workflows/do-not-merge.yml`
- `actionlint` pre-commit hook for GitHub Actions workflows
- `git diff --check upstream/main...HEAD`

Rust and Python tests were not run because this change only adds a GitHub Actions workflow.

#### Where should the reviewer start?

Start with `.github/workflows/do-not-merge.yml`, especially the job-level label condition that avoids runner allocation when merging is allowed.

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- Relates to: none


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added an automated GitHub Actions check that fails pull requests marked with the “DO NOT MERGE” label.
  * The check runs on common pull request events (opened, reopened, synchronized) and when labels change, ensuring only one active run per pull request.
  * Updated project versioning to **0.2.0** across the core package, adapters, and examples.
  * Refreshed installation/documentation instructions to reference **0.2.0** and aligned integration tests to validate the updated README/pip command strings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->