### PR TITLE
fix: replace deprecated Nemotron Nano model

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,7 +112,7 @@ config = FabricConfig(
     models={
         "default": ModelConfig(
             provider="nvidia",
-            model="nvidia/nemotron-3-nano-30b-a3b",
+            model="nvidia/nemotron-3-nano-omni-30b-a3b-reasoning",
             api_key_env="NVIDIA_API_KEY",
             base_url="https://integrate.api.nvidia.com/v1",
         )

--- a/crates/fabric-cli/src/presets.rs
+++ b/crates/fabric-cli/src/presets.rs
@@ -184,7 +184,7 @@ fn hermes() -> FabricConfig {
         "nvidia.fabric.hermes",
         Some(model(
             "nvidia",
-            "nvidia/nemotron-3-nano-30b-a3b",
+            "nvidia/nemotron-3-nano-omni-30b-a3b-reasoning",
             Some("NVIDIA_API_KEY"),
             Some(NVIDIA_API_CATALOG_BASE_URL),
         )),
@@ -240,7 +240,7 @@ fn deepagents() -> FabricConfig {
         "nvidia.fabric.langchain.deepagents",
         Some(model(
             "nvidia",
-            "nvidia/nemotron-3-nano-30b-a3b",
+            "nvidia/nemotron-3-nano-omni-30b-a3b-reasoning",
             Some("NVIDIA_API_KEY"),
             Some(NVIDIA_API_CATALOG_BASE_URL),
         )),

--- a/crates/fabric-cli/src/scaffold.rs
+++ b/crates/fabric-cli/src/scaffold.rs
@@ -431,7 +431,7 @@ mod tests {
             };
             let source = fs::read_to_string(launcher).expect("read launcher");
             assert!(source.contains("nvidia.fabric.hermes"));
-            assert!(source.contains("nvidia/nemotron-3-nano-30b-a3b"));
+            assert!(source.contains("nvidia/nemotron-3-nano-omni-30b-a3b-reasoning"));
             assert!(source.contains("https://integrate.api.nvidia.com/v1"));
             if language == Language::Rust {
                 let manifest =

--- a/docs/experimentation/cli.mdx
+++ b/docs/experimentation/cli.mdx
@@ -67,10 +67,10 @@ experiments:
 | Preset | Harness | Default model | Endpoint |
 | --- | --- | --- | --- |
 | `scripted` | Deterministic test adapter | None | None |
-| `hermes` | Hermes Agent | `nvidia/nemotron-3-nano-30b-a3b` | NVIDIA API Catalog |
+| `hermes` | Hermes Agent | `nvidia/nemotron-3-nano-omni-30b-a3b-reasoning` | NVIDIA API Catalog |
 | `claude` | Claude Code | `aws/anthropic/claude-opus-4-5` | `NVIDIA_FRONTIER_BASE_URL` |
 | `codex` | Codex | `azure/openai/gpt-5.4` | `NVIDIA_FRONTIER_BASE_URL` |
-| `deepagents` | LangChain Deep Agents | `nvidia/nemotron-3-nano-30b-a3b` | NVIDIA API Catalog |
+| `deepagents` | LangChain Deep Agents | `nvidia/nemotron-3-nano-omni-30b-a3b-reasoning` | NVIDIA API Catalog |
 
 The `scripted` preset does not call a model. It returns a deterministic response
 through the same NeMo Fabric runtime and adapter contract, which makes it useful for

--- a/docs/getting-started/quickstart.mdx
+++ b/docs/getting-started/quickstart.mdx
@@ -53,7 +53,7 @@ config = FabricConfig(
     models={
         "default": ModelConfig(
             provider="nvidia",
-            model="nvidia/nemotron-3-nano-30b-a3b",
+            model="nvidia/nemotron-3-nano-omni-30b-a3b-reasoning",
             api_key_env="NVIDIA_API_KEY",
             base_url="https://integrate.api.nvidia.com/v1",
         )

--- a/docs/sdk/python.mdx
+++ b/docs/sdk/python.mdx
@@ -60,7 +60,7 @@ config = FabricConfig(
     models={
         "default": ModelConfig(
             provider="nvidia",
-            model="nvidia/nemotron-3-nano-30b-a3b",
+            model="nvidia/nemotron-3-nano-omni-30b-a3b-reasoning",
             api_key_env="NVIDIA_API_KEY",
         )
     },

--- a/examples/code_review_agent/config.py
+++ b/examples/code_review_agent/config.py
@@ -44,7 +44,7 @@ def base_config() -> FabricConfig:
         models={
             "default": ModelConfig(
                 provider="nvidia",
-                model="nvidia/nemotron-3-nano-30b-a3b",
+                model="nvidia/nemotron-3-nano-omni-30b-a3b-reasoning",
                 temperature=0.0,
                 api_key_env="NVIDIA_API_KEY",
             )

--- a/examples/harbor/calculator/README.md
+++ b/examples/harbor/calculator/README.md
@@ -81,7 +81,7 @@ Expected Harbor summary: one trial, zero exceptions, and mean reward `1.000`.
 uv run --extra harbor harbor run \
   --path "$TASK_DIR" \
   --agent nemo_fabric.integrations.harbor:FabricAgent \
-  --model nvidia/nemotron-3-nano-30b-a3b \
+  --model nvidia/nemotron-3-nano-omni-30b-a3b-reasoning \
   --ak fabric_adapter_id=nvidia.fabric.hermes \
   --ak fabric_config_base_dir=/opt/fabric-calculator \
   --ak fabric_workspace=/app \
@@ -106,7 +106,7 @@ typed config. The API key is passed separately as a task credential.
 uv run --extra harbor harbor run \
   --path "$TASK_DIR" \
   --agent nemo_fabric.integrations.harbor:FabricAgent \
-  --model nvidia/nemotron-3-nano-30b-a3b \
+  --model nvidia/nemotron-3-nano-omni-30b-a3b-reasoning \
   --ak fabric_adapter_id=nvidia.fabric.hermes \
   --ak fabric_config_base_dir=/opt/fabric-calculator \
   --ak fabric_workspace=/app \

--- a/examples/harbor/swebench/README.md
+++ b/examples/harbor/swebench/README.md
@@ -75,7 +75,7 @@ The default Hermes Agent command uses NVIDIA's hosted API:
 uv run --extra harbor harbor run \
   --task swe-bench/django__django-13741 \
   --agent "$FABRIC_AGENT" \
-  --model nvidia/nemotron-3-nano-30b-a3b \
+  --model nvidia/nemotron-3-nano-omni-30b-a3b-reasoning \
   --ak fabric_adapter_id=nvidia.fabric.hermes \
   --ak fabric_config_bundle="$FABRIC_BUNDLE" \
   --ak "fabric_package=$FABRIC_PACKAGE" \
@@ -141,7 +141,7 @@ For example, the complete skill variation is:
 uv run --extra harbor harbor run \
   --task swe-bench/django__django-13741 \
   --agent "$FABRIC_AGENT" \
-  --model nvidia/nemotron-3-nano-30b-a3b \
+  --model nvidia/nemotron-3-nano-omni-30b-a3b-reasoning \
   --skill "$PWD/examples/harbor/swebench/skills/swebench-debugging" \
   --ak fabric_adapter_id=nvidia.fabric.hermes \
   --ak fabric_config_bundle="$FABRIC_BUNDLE" \
@@ -232,7 +232,7 @@ uv run --extra harbor harbor run \
   --dataset swe-bench/swe-bench-verified \
   --n-tasks 5 \
   --agent "$FABRIC_AGENT" \
-  --model nvidia/nemotron-3-nano-30b-a3b \
+  --model nvidia/nemotron-3-nano-omni-30b-a3b-reasoning \
   --ak fabric_adapter_id=nvidia.fabric.hermes \
   --ak fabric_config_bundle="$FABRIC_BUNDLE" \
   --ak fabric_telemetry=relay \

--- a/examples/notebooks/01_quickstart.ipynb
+++ b/examples/notebooks/01_quickstart.ipynb
@@ -216,7 +216,7 @@
     "    models={\n",
     "        \"default\": ModelConfig(\n",
     "            provider=\"nvidia\",\n",
-    "            model=\"nvidia/nemotron-3-nano-30b-a3b\",\n",
+    "            model=\"nvidia/nemotron-3-nano-omni-30b-a3b-reasoning\",\n",
     "            base_url=\"https://integrate.api.nvidia.com/v1\",\n",
     "            temperature=0.0,\n",
     "            api_key_env=\"NVIDIA_API_KEY\",\n",

--- a/examples/notebooks/02_variations.ipynb
+++ b/examples/notebooks/02_variations.ipynb
@@ -197,7 +197,7 @@
     "\n",
     "\n",
     "NVIDIA_MODEL = ModelConfig(\n",
-    "    provider=\"nvidia\", model=\"nvidia/nemotron-3-nano-30b-a3b\",\n",
+    "    provider=\"nvidia\", model=\"nvidia/nemotron-3-nano-omni-30b-a3b-reasoning\",\n",
     "    temperature=0.0, api_key_env=\"NVIDIA_API_KEY\",\n",
     ")\n",
     "\n",

--- a/tests/adapters/test_deepagents.py
+++ b/tests/adapters/test_deepagents.py
@@ -158,7 +158,7 @@ def make_payload_fixture():
                 "models": {
                     "default": {
                         "provider": "nvidia",
-                        "model": "nvidia/nemotron-3-nano-30b-a3b",
+                        "model": "nvidia/nemotron-3-nano-omni-30b-a3b-reasoning",
                         "api_key_env": "NVIDIA_API_KEY",
                         "base_url": "https://integrate.api.nvidia.com/v1",
                     }
@@ -268,7 +268,7 @@ async def test_single_invocation_normalizes_response_usage_and_thread(
 
     assert output["harness"] == "deepagents"
     assert output["mode"] == "deepagents"
-    assert output["model"] == "nvidia/nemotron-3-nano-30b-a3b"
+    assert output["model"] == "nvidia/nemotron-3-nano-omni-30b-a3b-reasoning"
     assert output["response"] == "reply to hello"
     assert output["message_count"] == 2
     assert output["usage"] == {

--- a/tests/e2e/test_hermes_config_mapping.py
+++ b/tests/e2e/test_hermes_config_mapping.py
@@ -32,7 +32,7 @@ def test_hermes_config_mapping(tmp_path: Path):
 
     assert config["model"] == {
         "provider": "nvidia",
-        "default": "nvidia/nemotron-3-nano-30b-a3b",
+        "default": "nvidia/nemotron-3-nano-omni-30b-a3b-reasoning",
         "base_url": "https://integrate.api.nvidia.com/v1",
     }
     assert config["terminal"]["backend"] == "local"
@@ -59,7 +59,7 @@ def payload(tmpdir: str) -> dict:
             "models": {
                 "default": {
                     "provider": "nvidia",
-                    "model": "nvidia/nemotron-3-nano-30b-a3b",
+                    "model": "nvidia/nemotron-3-nano-omni-30b-a3b-reasoning",
                     "api_key_env": "NVIDIA_API_KEY",
                     "base_url": "https://integrate.api.nvidia.com/v1",
                 }

--- a/tests/e2e/test_hermes_e2e.py
+++ b/tests/e2e/test_hermes_e2e.py
@@ -162,7 +162,7 @@ class TestHermesE2E:
 
         hermes_config = yaml.safe_load(hermes_config_path.read_text(encoding="utf-8"))
         assert hermes_config["model"]["provider"] == "nvidia"
-        assert hermes_config["model"]["default"] == "nvidia/nemotron-3-nano-30b-a3b"
+        assert hermes_config["model"]["default"] == "nvidia/nemotron-3-nano-omni-30b-a3b-reasoning"
         assert hermes_config["model"]["base_url"] == f"{self.api_server}/v1"
         assert hermes_config["plugins"]["enabled"] == ["observability/nemo_relay"]
         assert output["hermes_native_config"]["plugins"] == ["observability/nemo_relay"]
@@ -223,7 +223,7 @@ class TestHermesE2E:
         assert len(atof_records) == 7
 
         assert all(
-            record["metadata"]["model"] == "nvidia/nemotron-3-nano-30b-a3b"
+            record["metadata"]["model"] == "nvidia/nemotron-3-nano-omni-30b-a3b-reasoning"
             and record["metadata"]["platform"] == self.atof_platform
             for record in atof_records
         )
@@ -254,12 +254,12 @@ class TestHermesE2E:
         assert first_step["message"] == "Reply with exactly: relay ok"
         assert (
             first_step["extra"]["llm_request"]["model"]
-            == "nvidia/nemotron-3-nano-30b-a3b"
+            == "nvidia/nemotron-3-nano-omni-30b-a3b-reasoning"
         )
 
         last_step = steps[-1]
         assert last_step["source"] == "agent"
         assert last_step["message"] == self.output["response"]
-        assert last_step["model_name"] == "nvidia/nemotron-3-nano-30b-a3b"
+        assert last_step["model_name"] == "nvidia/nemotron-3-nano-omni-30b-a3b-reasoning"
         assert last_step["extra"]["invocation"]["framework"] == "nemo_relay"
         assert last_step["extra"]["invocation"]["status"] == "completed"

--- a/tests/integrations/test_harbor_runner.py
+++ b/tests/integrations/test_harbor_runner.py
@@ -314,7 +314,7 @@ def test_harbor_calculator_documents_explicit_cli_commands():
     assert "fabric_config_factory" not in swebench
     assert "fabric_harness_settings" not in calculator
     assert "fabric_workspace=/app" in calculator
-    assert "--model nvidia/nemotron-3-nano-30b-a3b" in calculator
+    assert "--model nvidia/nemotron-3-nano-omni-30b-a3b-reasoning" in calculator
     assert "--model anthropic/claude-sonnet-4-5" in calculator
     assert 'CALCULATOR_DIR="$PWD/examples/harbor/calculator"' in calculator
     assert "calculator/README.md" in landing
@@ -396,7 +396,7 @@ def test_harbor_relay_telemetry_exports_direct_atof_and_atif():
     config = build_harbor_config(
         adapter_id="nvidia.fabric.hermes",
         workspace="/app",
-        model_name="nvidia/nemotron-3-nano-30b-a3b",
+        model_name="nvidia/nemotron-3-nano-omni-30b-a3b-reasoning",
         telemetry="relay",
     )
     assert config.harness.settings == {}
@@ -446,7 +446,7 @@ def test_swebench_matrix_translates_harbor_inputs_to_typed_config(tmp_path: Path
         adapter_id="nvidia.fabric.hermes",
         workspace="/testbed",
         telemetry="relay",
-        model_name="nvidia/nemotron-3-nano-30b-a3b",
+        model_name="nvidia/nemotron-3-nano-omni-30b-a3b-reasoning",
         skills_dir="/harbor/skills",
         mcp_servers=tuple(
             HarborMcpServer.model_validate(server.model_dump(mode="python"))
@@ -478,7 +478,7 @@ def test_swebench_matrix_translates_harbor_inputs_to_typed_config(tmp_path: Path
     assert base.mcp is None
     assert base.tools is None
     assert base.telemetry is None
-    assert relay.models["default"].model == "nvidia/nemotron-3-nano-30b-a3b"
+    assert relay.models["default"].model == "nvidia/nemotron-3-nano-omni-30b-a3b-reasoning"
     assert relay.skills is not None
     assert relay.skills.paths == ["/harbor/skills"]
     assert relay.mcp is not None


### PR DESCRIPTION
#### Overview

Replace the deprecated `nvidia/nemotron-3-nano-30b-a3b` model with `nvidia/nemotron-3-nano-omni-30b-a3b-reasoning` across the maintained runtime presets and every dependent repository surface. This keeps the Hermes and Deep Agents NVIDIA API Catalog paths usable without changing their provider, credential, endpoint, or harness configuration.

- [x] I confirm this contribution is my own work, or I have the right to submit it under this project's license.
- [x] I searched existing issues and open pull requests, and this does not duplicate existing work.

#### Details

- Update the Hermes and Deep Agents CLI preset defaults.
- Keep generated Python and Rust scaffolds aligned with the updated preset.
- Update README, Fern documentation, code-review and Harbor examples, and both onboarding notebooks.
- Update Deep Agents, Hermes, Harbor, ATOF, and ATIF expectations to assert the replacement model.
- Remove all 28 tracked references to the deprecated identifier.

There are no breaking API or configuration-shape changes.

#### Validation

- `cargo fmt --all -- --check`
- `just test-rust` — passed
- `just test-python` — 574 passed, 15 skipped
- `npx --prefix docs --no-install fern check --warnings` — 0 errors; redirect check skipped because Fern authentication was unavailable
- Verified `nemo-fabric plan --preset hermes` and `nemo-fabric plan --preset deepagents` resolve the replacement model
- Manually ran the Hermes code-review example with Relay and confirmed ATOF/ATIF model metadata
- Manually ran the Harbor calculator Hermes Relay job — 1 trial, 0 exceptions, reward 1.0, telemetry validation succeeded
- Manually ran the Harbor SWE-bench `django__django-13741` Hermes job — 1 trial, 0 exceptions, reward 1.0

#### Where should the reviewer start?

Start in `crates/fabric-cli/src/presets.rs`, where the maintained Hermes and Deep Agents defaults are defined, then review the corresponding model expectations in `crates/fabric-cli/src/scaffold.rs` and `tests/e2e/test_hermes_e2e.py`.

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- Relates to: none


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated quick-start guides, SDK examples, preset references, notebooks, and sample projects to use `nvidia/nemotron-3-nano-omni-30b-a3b-reasoning`.
  - Refreshed Hermes and Deep Agents preset documentation and example commands with the new default model.

- **Configuration**
  - Updated default model selections across generated configurations and example agents.

- **Tests**
  - Updated validation and integration coverage to reflect the new model identifier.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->