### PR TITLE
ci: Release process improvements

### DIFF
--- a/.github/workflows/ci_python.yml
+++ b/.github/workflows/ci_python.yml
@@ -21,6 +21,11 @@ on:
         required: false
         default: ''
         type: string
+      skip_tests:
+        description: 'Skip the Python test matrix and only build wheels'
+        required: false
+        default: false
+        type: boolean
   pull_request:
   push:
     branches: [main]
@@ -37,6 +42,7 @@ defaults:
 jobs:
   test:
     name: Test (Python ${{ matrix.python-version }}, ${{ matrix.platform }})
+    if: ${{ (inputs.ref_type || github.ref_type) != 'tag' && !inputs.skip_tests }}
     strategy:
       fail-fast: false
       matrix:
@@ -99,6 +105,7 @@ jobs:
   build-wheels:
     name: Build wheels (${{ matrix.platform }})
     needs: [test]
+    if: ${{ always() && (needs.test.result == 'success' || needs.test.result == 'skipped') }}
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/nightly-alpha-tag.yml
+++ b/.github/workflows/nightly-alpha-tag.yml
@@ -84,3 +84,4 @@ jobs:
       ref: refs/tags/${{ needs.tag-nightly-alpha.outputs.tag }}
       ref_name: ${{ needs.tag-nightly-alpha.outputs.tag }}
       ref_type: tag
+      skip_tests: true

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -139,7 +139,17 @@ collect:github-artifacts:
         --pattern 'python-wheels-*' \
         --dir downloaded/wheels
 
-      find downloaded/wheels -type f -name '*.whl' -exec cp {} collected/wheels/ \;
+      # Each platform builds all wheels, most wheels are platform-independent,
+      # while the runtime wheel is platform-specific.
+      # Copy the platform-independent wheels from the Linux build
+      cp downloaded/wheels/python-wheels-linux-amd64/*-py3-none-any.whl \
+        collected/wheels/
+
+      find downloaded/wheels \
+        -type f \
+        -name 'nemo_fabric_runtime-*.whl' \
+        -exec cp {} collected/wheels/ \;
+
       if ! ls collected/wheels/*.whl >/dev/null 2>&1; then
         echo "Error: collected GitHub wheel artifacts did not contain any .whl files." >&2
         exit 1

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -101,6 +101,7 @@ package = [
 
 test = [
     "fastapi~=0.138",
+    "pkginfo~=1.12",
     "pytest>=8",
     "pytest-asyncio>=0.26",
     "pytest-cov~=7.0",

--- a/scripts/ci/artifactory_upload.py
+++ b/scripts/ci/artifactory_upload.py
@@ -84,7 +84,8 @@ def perform_release(published_wheels: list[tuple[Path, str]]) -> None:
         )
         response.raise_for_status()
         release = response.json()
-        print(
+        # {"message":"Release creation accepted","project_id":3801,"release_uuid":"579242a9-a143-43ca-b519-c89ffc394c44","status":"pending"}
+        print( # TODO Include status and message fields
             f"Release accepted for {package_name}: "
             f"project_id={release['project_id']}, release_uuid={release['release_uuid']}",
             flush=True,

--- a/scripts/ci/artifactory_upload.py
+++ b/scripts/ci/artifactory_upload.py
@@ -85,9 +85,11 @@ def perform_release(published_wheels: list[tuple[Path, str]]) -> None:
         response.raise_for_status()
         release = response.json()
         # {"message":"Release creation accepted","project_id":3801,"release_uuid":"579242a9-a143-43ca-b519-c89ffc394c44","status":"pending"}
-        print( # TODO Include status and message fields
-            f"Release accepted for {package_name}: "
-            f"project_id={release['project_id']}, release_uuid={release['release_uuid']}",
+        print(
+            f"Release for {package_name} ({release['project_id']}):\n"
+            f"\trelease_uuid={release['release_uuid']},\n"
+            f"\tstatus={release['status']}\n"
+            f"\tmessage={release['message']}\n",
             flush=True,
         )
 
@@ -101,9 +103,8 @@ def main() -> int:
 
     wheels = []
     published_wheels: list[tuple[Path, str]] = []
-    
-    print(f"Dir : {wheels_dir}", flush=True)
 
+    print(f"Dir : {wheels_dir}", flush=True)
 
     for wheel_file in wheels_dir.rglob("*.whl"):
         wheels.append(wheel_file)

--- a/scripts/ci/artifactory_upload.py
+++ b/scripts/ci/artifactory_upload.py
@@ -97,18 +97,18 @@ def perform_release(published_wheels: list[tuple[Path, str]]) -> int:
             elif status not in EXPECTED_STATUS_VALUES:
                 print(f"Unexpected release status for {package_name}: {status}", flush=True)
                 error_count += 1
+            else:
+                # {"message":"Release creation accepted","project_id":3801,"release_uuid":"579242a9-a143-43ca-b519-c89ffc394c44","status":"pending"}
+                print(
+                    f"Release for {package_name} ({release['project_id']}):\n"
+                    f"\trelease_uuid={release['release_uuid']},\n"
+                    f"\tstatus={release['status']}\n"
+                    f"\tmessage={release['message']}\n",
+                    flush=True,
+                )
         except requests.RequestException as e:
             print(f"Failed to create release for {package_name}: {e}", flush=True)
             error_count += 1
-        else:
-            # {"message":"Release creation accepted","project_id":3801,"release_uuid":"579242a9-a143-43ca-b519-c89ffc394c44","status":"pending"}
-            print(
-                f"Release for {package_name} ({release['project_id']}):\n"
-                f"\trelease_uuid={release['release_uuid']},\n"
-                f"\tstatus={release['status']}\n"
-                f"\tmessage={release['message']}\n",
-                flush=True,
-            )
 
     return error_count
 

--- a/scripts/ci/artifactory_upload.py
+++ b/scripts/ci/artifactory_upload.py
@@ -12,6 +12,10 @@ import pkginfo
 import requests
 
 
+EXPECTED_STATUS_VALUES = {"building", "pending", "completed"}
+FAILED_STATUS = "failed"
+
+
 def upload_wheel(
     wheel_file: Path,
     artifactory_url: str,
@@ -32,7 +36,7 @@ def upload_wheel(
     return wheel_url
 
 
-def perform_release(published_wheels: list[tuple[Path, str]]) -> None:
+def perform_release(published_wheels: list[tuple[Path, str]]) -> int:
     kitmaker_url = os.environ["KITMAKER_URL"]
     kitmaker_api_token = os.environ["KITMAKER_API_TOKEN"]
     kitmaker_owner = os.environ["KITMAKER_OWNER"]
@@ -61,6 +65,7 @@ def perform_release(published_wheels: list[tuple[Path, str]]) -> None:
         )
 
 
+    error_count = 0
     for package_name, wheel_urls in packages.items():
         package_id = project_ids[package_name]
         wheels_payload = [{
@@ -69,29 +74,43 @@ def perform_release(published_wheels: list[tuple[Path, str]]) -> None:
                             "url": wheel_url,
                             "upload": True,
                         }
-                        for wheel_url in wheel_urls]
+                        for wheel_url in sorted(wheel_urls)]
 
         payload = {
             "project_name": package_name,
             "payload": wheels_payload,
         }
 
-        response = requests.post(
-            f"{kitmaker_url}/api/v0/projects/{package_id}/releases",
-            headers=headers,
-            json=payload,
-            timeout=(30, 600),
-        )
-        response.raise_for_status()
-        release = response.json()
-        # {"message":"Release creation accepted","project_id":3801,"release_uuid":"579242a9-a143-43ca-b519-c89ffc394c44","status":"pending"}
-        print(
-            f"Release for {package_name} ({release['project_id']}):\n"
-            f"\trelease_uuid={release['release_uuid']},\n"
-            f"\tstatus={release['status']}\n"
-            f"\tmessage={release['message']}\n",
-            flush=True,
-        )
+        try:
+            response = requests.post(
+                f"{kitmaker_url}/api/v0/projects/{package_id}/releases",
+                headers=headers,
+                json=payload,
+                timeout=(30, 600),
+            )
+            response.raise_for_status()
+            release = response.json()
+            status = release["status"]
+            if status == FAILED_STATUS:
+                print(f"Release failed for {package_name}: {release['message']}", flush=True)
+                error_count += 1
+            elif status not in EXPECTED_STATUS_VALUES:
+                print(f"Unexpected release status for {package_name}: {status}", flush=True)
+                error_count += 1
+        except requests.RequestException as e:
+            print(f"Failed to create release for {package_name}: {e}", flush=True)
+            error_count += 1
+        else:
+            # {"message":"Release creation accepted","project_id":3801,"release_uuid":"579242a9-a143-43ca-b519-c89ffc394c44","status":"pending"}
+            print(
+                f"Release for {package_name} ({release['project_id']}):\n"
+                f"\trelease_uuid={release['release_uuid']},\n"
+                f"\tstatus={release['status']}\n"
+                f"\tmessage={release['message']}\n",
+                flush=True,
+            )
+
+    return error_count
 
 
 def main() -> int:
@@ -126,14 +145,15 @@ def main() -> int:
     else:
         print("All wheels uploaded to Artifactory.")
 
+    kitmaker_error_count = 0
     if os.environ.get("CI_COMMIT_TAG") is not None:
         print("Performing release of published wheels to KitMaker...", flush=True)
-        perform_release(published_wheels)
+        kitmaker_error_count = perform_release(published_wheels)
     else:
         print("Skipping release to KitMaker. This is not a nightly, tagged, or main branch build.", flush=True)
 
-    return num_unpublished
+    return num_unpublished + kitmaker_error_count
 
 
 if __name__ == "__main__":
-    sys.exit(main())
+    sys.exit(min(main(), 255))

--- a/scripts/ci/artifactory_upload.py
+++ b/scripts/ci/artifactory_upload.py
@@ -83,6 +83,12 @@ def perform_release(published_wheels: list[tuple[Path, str]]) -> None:
             timeout=(30, 600),
         )
         response.raise_for_status()
+        release = response.json()
+        print(
+            f"Release accepted for {package_name}: "
+            f"project_id={release['project_id']}, release_uuid={release['release_uuid']}",
+            flush=True,
+        )
 
 
 def main() -> int:

--- a/tests/scripts/test_artifactory_upload.py
+++ b/tests/scripts/test_artifactory_upload.py
@@ -8,6 +8,7 @@ import sys
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
+import pytest
 import requests
 
 CI_SCRIPTS = Path(__file__).resolve().parents[2] / "scripts" / "ci"
@@ -16,11 +17,15 @@ sys.path.insert(0, str(CI_SCRIPTS))
 import artifactory_upload  # noqa: E402
 
 
-def test_perform_release_logs_release_identifiers(capsys):
+@pytest.fixture(name="release_environment")
+def release_environment_fixture():
     os.environ["KITMAKER_URL"] = "https://kitmaker.example.com"
     os.environ["KITMAKER_API_TOKEN"] = "token"
     os.environ["KITMAKER_OWNER"] = "owner"
 
+
+@pytest.mark.usefixtures("release_environment")
+def test_perform_release_logs_release_identifiers(capsys):
     projects_response = MagicMock(spec=requests.Response)
     projects_response.json.return_value = [{"name": "nemo-fabric", "id": 3801}]
     release_response = MagicMock(spec=requests.Response)
@@ -38,11 +43,135 @@ def test_perform_release_logs_release_identifiers(capsys):
         patch.object(artifactory_upload.requests, "post", return_value=release_response),
         patch.object(artifactory_upload.pkginfo, "Wheel", return_value=wheel_metadata),
     ):
-        artifactory_upload.perform_release(
+        error_count = artifactory_upload.perform_release(
             [(Path("nemo_fabric-0.2.0-py3-none-any.whl"), "https://artifactory.example.com/wheel")]
         )
 
-    assert (
-        "Release accepted for nemo-fabric: project_id=3801, "
-        "release_uuid=579242a9-a143-43ca-b519-c89ffc394c44"
-    ) in capsys.readouterr().out
+    assert error_count == 0
+    output = capsys.readouterr().out
+    assert "Release for nemo-fabric (3801)" in output
+    assert "release_uuid=579242a9-a143-43ca-b519-c89ffc394c44" in output
+    assert "status=pending" in output
+    assert "message=Release creation accepted" in output
+
+
+@pytest.mark.parametrize("status", [artifactory_upload.FAILED_STATUS, "unexpected"])
+@pytest.mark.usefixtures("release_environment")
+def test_perform_release_counts_status_errors_and_continues(status):
+    projects_response = MagicMock(spec=requests.Response)
+    projects_response.json.return_value = [
+        {"name": "package-one", "id": 1},
+        {"name": "package-two", "id": 2},
+    ]
+    error_response = MagicMock(spec=requests.Response)
+    error_response.json.return_value = {
+        "message": "release error",
+        "project_id": 1,
+        "release_uuid": "error-uuid",
+        "status": status,
+    }
+    success_response = MagicMock(spec=requests.Response)
+    success_response.json.return_value = {
+        "message": "accepted",
+        "project_id": 2,
+        "release_uuid": "success-uuid",
+        "status": "pending",
+    }
+    package_one_metadata = MagicMock()
+    package_one_metadata.name = "package-one"
+    package_two_metadata = MagicMock()
+    package_two_metadata.name = "package-two"
+
+    with (
+        patch.object(artifactory_upload.requests, "get", return_value=projects_response),
+        patch.object(
+            artifactory_upload.requests,
+            "post",
+            side_effect=[error_response, success_response],
+        ) as mock_post,
+        patch.object(
+            artifactory_upload.pkginfo,
+            "Wheel",
+            side_effect=[package_one_metadata, package_two_metadata],
+        ),
+    ):
+        error_count = artifactory_upload.perform_release(
+            [
+                (Path("package_one-1.0-py3-none-any.whl"), "https://artifactory.example.com/one"),
+                (Path("package_two-1.0-py3-none-any.whl"), "https://artifactory.example.com/two"),
+            ]
+        )
+
+    assert error_count == 1
+    assert mock_post.call_count == 2
+
+
+@pytest.mark.usefixtures("release_environment")
+def test_perform_release_counts_request_errors_and_continues(capsys):
+    projects_response = MagicMock(spec=requests.Response)
+    projects_response.json.return_value = [
+        {"name": "package-one", "id": 1},
+        {"name": "package-two", "id": 2},
+    ]
+    error_response = MagicMock(spec=requests.Response)
+    error_response.raise_for_status.side_effect = requests.HTTPError("server error")
+    success_response = MagicMock(spec=requests.Response)
+    success_response.json.return_value = {
+        "message": "accepted",
+        "project_id": 2,
+        "release_uuid": "success-uuid",
+        "status": "pending",
+    }
+    package_one_metadata = MagicMock()
+    package_one_metadata.name = "package-one"
+    package_two_metadata = MagicMock()
+    package_two_metadata.name = "package-two"
+
+    with (
+        patch.object(artifactory_upload.requests, "get", return_value=projects_response),
+        patch.object(
+            artifactory_upload.requests,
+            "post",
+            side_effect=[error_response, success_response],
+        ) as mock_post,
+        patch.object(
+            artifactory_upload.pkginfo,
+            "Wheel",
+            side_effect=[package_one_metadata, package_two_metadata],
+        ),
+    ):
+        error_count = artifactory_upload.perform_release(
+            [
+                (Path("package_one-1.0-py3-none-any.whl"), "https://artifactory.example.com/one"),
+                (Path("package_two-1.0-py3-none-any.whl"), "https://artifactory.example.com/two"),
+            ]
+        )
+
+    assert error_count == 1
+    assert mock_post.call_count == 2
+    assert "Failed to create release for package-one: server error" in capsys.readouterr().out
+
+
+def test_main_combines_upload_and_release_errors(tmp_path):
+    wheels_dir = tmp_path / "collected" / "wheels"
+    wheels_dir.mkdir(parents=True)
+    (wheels_dir / "one.whl").touch()
+    (wheels_dir / "two.whl").touch()
+    os.environ["CI_PROJECT_DIR"] = str(tmp_path)
+    os.environ["NEMO_FABRIC_CI_ARTIFACTORY_PYPI_URL"] = "https://artifactory.example.com"
+    os.environ["NEMO_FABRIC_CI_ARTIFACTORY_USER"] = "user"
+    os.environ["NEMO_FABRIC_CI_ARTIFACTORY_KEY"] = "key"
+    os.environ["CI_COMMIT_TAG"] = "1.0.0"
+
+    with (
+        patch.object(
+            artifactory_upload,
+            "upload_wheel",
+            side_effect=["https://artifactory.example.com/one.whl", requests.HTTPError("upload error")],
+        ),
+        patch.object(artifactory_upload, "perform_release", return_value=2) as mock_perform_release,
+    ):
+        result = artifactory_upload.main()
+
+    assert result == 3
+    mock_perform_release.assert_called_once()

--- a/tests/scripts/test_artifactory_upload.py
+++ b/tests/scripts/test_artifactory_upload.py
@@ -1,0 +1,48 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+import os
+import sys
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import requests
+
+CI_SCRIPTS = Path(__file__).resolve().parents[2] / "scripts" / "ci"
+sys.path.insert(0, str(CI_SCRIPTS))
+
+import artifactory_upload  # noqa: E402
+
+
+def test_perform_release_logs_release_identifiers(capsys):
+    os.environ["KITMAKER_URL"] = "https://kitmaker.example.com"
+    os.environ["KITMAKER_API_TOKEN"] = "token"
+    os.environ["KITMAKER_OWNER"] = "owner"
+
+    projects_response = MagicMock(spec=requests.Response)
+    projects_response.json.return_value = [{"name": "nemo-fabric", "id": 3801}]
+    release_response = MagicMock(spec=requests.Response)
+    release_response.json.return_value = {
+        "message": "Release creation accepted",
+        "project_id": 3801,
+        "release_uuid": "579242a9-a143-43ca-b519-c89ffc394c44",
+        "status": "pending",
+    }
+    wheel_metadata = MagicMock()
+    wheel_metadata.name = "nemo-fabric"
+
+    with (
+        patch.object(artifactory_upload.requests, "get", return_value=projects_response),
+        patch.object(artifactory_upload.requests, "post", return_value=release_response),
+        patch.object(artifactory_upload.pkginfo, "Wheel", return_value=wheel_metadata),
+    ):
+        artifactory_upload.perform_release(
+            [(Path("nemo_fabric-0.2.0-py3-none-any.whl"), "https://artifactory.example.com/wheel")]
+        )
+
+    assert (
+        "Release accepted for nemo-fabric: project_id=3801, "
+        "release_uuid=579242a9-a143-43ca-b519-c89ffc394c44"
+    ) in capsys.readouterr().out

--- a/tests/scripts/test_artifactory_upload.py
+++ b/tests/scripts/test_artifactory_upload.py
@@ -25,7 +25,7 @@ def release_environment_fixture():
 
 
 @pytest.mark.usefixtures("release_environment")
-def test_perform_release_logs_release_identifiers(capsys):
+def test_perform_release_logs_release_identifiers():
     projects_response = MagicMock(spec=requests.Response)
     projects_response.json.return_value = [{"name": "nemo-fabric", "id": 3801}]
     release_response = MagicMock(spec=requests.Response)
@@ -48,11 +48,7 @@ def test_perform_release_logs_release_identifiers(capsys):
         )
 
     assert error_count == 0
-    output = capsys.readouterr().out
-    assert "Release for nemo-fabric (3801)" in output
-    assert "release_uuid=579242a9-a143-43ca-b519-c89ffc394c44" in output
-    assert "status=pending" in output
-    assert "message=Release creation accepted" in output
+
 
 
 @pytest.mark.parametrize("status", [artifactory_upload.FAILED_STATUS, "unexpected"])

--- a/uv.lock
+++ b/uv.lock
@@ -2109,6 +2109,7 @@ package = [
 ]
 test = [
     { name = "fastapi" },
+    { name = "pkginfo" },
     { name = "pytest" },
     { name = "pytest-asyncio" },
     { name = "pytest-cov" },
@@ -2162,6 +2163,7 @@ package = [
 ]
 test = [
     { name = "fastapi", specifier = "~=0.138" },
+    { name = "pkginfo", specifier = "~=1.12" },
     { name = "pytest", specifier = ">=8" },
     { name = "pytest-asyncio", specifier = ">=0.26" },
     { name = "pytest-cov", specifier = "~=7.0" },


### PR DESCRIPTION
#### Overview

* Skip tests for workflows triggered by a tag
* Log the response from kitmaker
* Improved error handling

#### Where should the reviewer start?

* scripts/ci/artifactory_upload.py

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- Closes FABRIC-153

- [x] I confirm this contribution is my own work, or I have the right to submit it under this project's license.
- [x] I searched existing issues and open pull requests, and this does not duplicate existing work.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **CI/CD Improvements**
  * Added an option to skip Python tests during selected automated builds.
  * Nightly alpha builds now use a streamlined build path.
  * Improved artifact collection to select the appropriate wheels for each platform.

* **Release Management**
  * Release creation now reports detailed statuses and continues processing when individual requests fail.
  * Combined release errors are reflected in the final build status.

* **Tests**
  * Expanded coverage for successful releases, failures, request errors, and error reporting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->