### PR TITLE
feat: add per-server MCP tool filters

### DIFF
--- a/.agents/skills/contribute-adapter/SKILL.md
+++ b/.agents/skills/contribute-adapter/SKILL.md
@@ -137,7 +137,7 @@ cannot implement and test end to end.
 | --- | --- | --- |
 | Models | `config.models` and selected alias | Map supported provider settings and credential-variable names; reject unsupported providers. |
 | Tool policy | `config.tools.blocked` and `capability_plan.tools` | Claim `tools.blocked` only when every harness tool path enforces it. |
-| MCP | `capability_plan.native.mcp_servers` | Claim `mcp` only for supported native transports; reject unsupported routes or fields. |
+| MCP | `capability_plan.native.mcp_servers` | Claim `mcp` only for supported native transports. Claim `mcp.tool_filters` only when every configured server enforces `allowed_tools` and `blocked_tools`; reject unsupported routes or fields. |
 | Skills | `capability_plan.native.skill_paths` | Validate and stage skill paths without cross-runtime collisions. |
 | Telemetry | `telemetry_plan` and normalized telemetry config | Declare only providers, outputs, and integration modes the adapter implements. |
 | Environment and lifecycle | `runtime_context` | Use resolved workspace, runtime ID, telemetry, and artifact context; claim only lifecycle operations implemented end to end. |

--- a/crates/fabric-core/src/config.rs
+++ b/crates/fabric-core/src/config.rs
@@ -2716,37 +2716,49 @@ mod tests {
 
     #[test]
     fn mcp_tool_filters_require_an_explicit_adapter_claim() {
-        let mut config = typed_config("nvidia.fabric.claude");
-        config.mcp = Some(McpConfig {
-            servers: BTreeMap::from([(
-                "docs".to_string(),
-                McpServerConfig {
-                    transport: "streamable-http".to_string(),
-                    url: "https://mcp.example".to_string(),
-                    exposure: McpExposure::HarnessNative,
-                    allowed_tools: Some(vec!["search".to_string()]),
-                    blocked_tools: Vec::new(),
-                    extensions: BTreeMap::new(),
-                },
-            )]),
-            extensions: BTreeMap::new(),
-        });
+        for (allowed_tools, blocked_tools, expected_field) in [
+            (
+                Some(vec!["search".to_string()]),
+                Vec::new(),
+                "mcp.servers.docs.allowed_tools",
+            ),
+            (
+                None,
+                vec!["delete".to_string()],
+                "mcp.servers.docs.blocked_tools",
+            ),
+        ] {
+            let mut config = typed_config("nvidia.fabric.claude");
+            config.mcp = Some(McpConfig {
+                servers: BTreeMap::from([(
+                    "docs".to_string(),
+                    McpServerConfig {
+                        transport: "streamable-http".to_string(),
+                        url: "https://mcp.example".to_string(),
+                        exposure: McpExposure::HarnessNative,
+                        allowed_tools,
+                        blocked_tools,
+                        extensions: BTreeMap::new(),
+                    },
+                )]),
+                extensions: BTreeMap::new(),
+            });
 
-        let error = resolve_run_plan_from_config(
-            config,
-            ResolveContext::new("/tmp/fabric-unsupported-mcp-filters"),
-        )
-        .expect_err("Claude does not advertise per-server MCP tool filters");
+            let error = resolve_run_plan_from_config(
+                config,
+                ResolveContext::new("/tmp/fabric-unsupported-mcp-filters"),
+            )
+            .expect_err("Claude does not advertise per-server MCP tool filters");
 
-        assert!(matches!(
-            error,
-            FabricError::AdapterCompatibility {
-                adapter_id,
-                field,
-                ..
-            } if adapter_id == "nvidia.fabric.claude"
-                && field == "mcp.servers.docs.allowed_tools"
-        ));
+            assert!(matches!(
+                error,
+                FabricError::AdapterCompatibility {
+                    adapter_id,
+                    field,
+                    ..
+                } if adapter_id == "nvidia.fabric.claude" && field == expected_field
+            ));
+        }
     }
 
     #[test]

--- a/crates/fabric-core/src/config.rs
+++ b/crates/fabric-core/src/config.rs
@@ -415,6 +415,9 @@ pub enum AdapterConfigField {
     /// Harness-native MCP servers.
     #[serde(rename = "mcp")]
     Mcp,
+    /// Per-server MCP tool allowlists and blocklists.
+    #[serde(rename = "mcp.tool_filters")]
+    McpToolFilters,
     /// Harness-native skills.
     #[serde(rename = "skills")]
     Skills,
@@ -619,6 +622,12 @@ pub struct McpServerConfig {
     pub url: String,
     /// How NeMo Fabric exposes the MCP capability to the harness.
     pub exposure: McpExposure,
+    /// MCP tool names to expose. `None` exposes every tool discovered from the server.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub allowed_tools: Option<Vec<String>>,
+    /// MCP tool names to block after applying the optional allowlist.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub blocked_tools: Vec<String>,
     /// Additive MCP server fields.
     #[serde(default, flatten)]
     pub extensions: BTreeMap<String, Value>,
@@ -1183,6 +1192,24 @@ fn validate_config(config: &FabricConfig) -> Result<()> {
         }
         validate_names("tools.blocked", &tools.blocked)?;
     }
+    if let Some(mcp) = &config.mcp {
+        for (server_name, server) in &mcp.servers {
+            let field = format!("mcp.servers.{server_name}");
+            if let Some(allowed_tools) = &server.allowed_tools {
+                validate_names(&format!("{field}.allowed_tools"), allowed_tools)?;
+                if let Some(name) = allowed_tools
+                    .iter()
+                    .find(|name| server.blocked_tools.contains(name))
+                {
+                    return invalid_config(
+                        field,
+                        format!("`{name}` cannot be both allowed and blocked"),
+                    );
+                }
+            }
+            validate_names(&format!("{field}.blocked_tools"), &server.blocked_tools)?;
+        }
+    }
     Ok(())
 }
 
@@ -1430,6 +1457,23 @@ pub(crate) fn adapter_config_compatibility_issues(
                 format!("models.{role}.temperature"),
                 "the adapter does not declare an equivalent native mapping".to_string(),
             ));
+        }
+    }
+    if accepts(AdapterConfigField::Mcp) && !accepts(AdapterConfigField::McpToolFilters) {
+        for (name, server) in config.mcp.iter().flat_map(|mcp| mcp.servers.iter()) {
+            let field = if server.allowed_tools.is_some() {
+                Some("allowed_tools")
+            } else if !server.blocked_tools.is_empty() {
+                Some("blocked_tools")
+            } else {
+                None
+            };
+            if let Some(field) = field {
+                issues.push(incompatible(
+                    format!("mcp.servers.{name}.{field}"),
+                    "the adapter does not declare per-server MCP tool-filter support".to_string(),
+                ));
+            }
         }
     }
     issues
@@ -1731,6 +1775,8 @@ fn resolve_capability_plan(
                             transport: server.transport.clone(),
                             url: server.url.clone(),
                             exposure: server.exposure,
+                            allowed_tools: server.allowed_tools.clone(),
+                            blocked_tools: server.blocked_tools.clone(),
                         },
                     )
                 })
@@ -1815,7 +1861,9 @@ fn resolve_capability_plan(
     }
 
     for (name, server) in &mcp_servers {
+        let filters_configured = server.allowed_tools.is_some() || !server.blocked_tools.is_empty();
         let can_map_native = accepts(AdapterConfigField::Mcp)
+            && (!filters_configured || accepts(AdapterConfigField::McpToolFilters))
             && matches!(server.exposure, McpExposure::HarnessNative);
         if can_map_native {
             native.mcp_servers.insert(name.clone(), server.clone());
@@ -1837,6 +1885,12 @@ fn resolve_capability_plan(
                 reason: match server.exposure {
                     McpExposure::FabricManaged => {
                         "MCP server explicitly requests NeMo Fabric-managed exposure but NeMo Fabric-managed MCP is not implemented".to_string()
+                    }
+                    _ if accepts(AdapterConfigField::Mcp)
+                        && filters_configured
+                        && !accepts(AdapterConfigField::McpToolFilters) =>
+                    {
+                        "MCP server configures tool filters but the selected adapter does not declare native MCP tool-filter support".to_string()
                     }
                     _ => "selected adapter does not declare native MCP support and NeMo Fabric-managed MCP is not implemented".to_string(),
                 },
@@ -2165,6 +2219,12 @@ pub struct McpServerPlan {
     pub url: String,
     /// Exposure strategy.
     pub exposure: McpExposure,
+    /// MCP tool names to expose. `None` exposes every discovered tool.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub allowed_tools: Option<Vec<String>>,
+    /// MCP tool names to block after applying the optional allowlist.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub blocked_tools: Vec<String>,
 }
 
 /// Resolved telemetry plan.
@@ -2582,6 +2642,8 @@ mod tests {
                     transport: "streamable-http".to_string(),
                     url: "https://mcp.example".to_string(),
                     exposure: McpExposure::FabricManaged,
+                    allowed_tools: None,
+                    blocked_tools: Vec::new(),
                     extensions: BTreeMap::new(),
                 },
             )]),
@@ -2602,6 +2664,162 @@ mod tests {
                 ..
             } if adapter_id == "nvidia.fabric.claude" && field == "mcp.servers.docs"
         ));
+    }
+
+    #[test]
+    fn mcp_tool_filters_survive_capability_planning() {
+        let path = repository_root().join("adapters/claude/fabric-adapter.json");
+        let mut descriptor = load_adapter_descriptor(&path).expect("Claude descriptor");
+        descriptor
+            .config
+            .accepts
+            .push(AdapterConfigField::McpToolFilters);
+        let resolved = ResolvedAdapterDescriptor {
+            descriptor,
+            source: AdapterDescriptorSource::Repository,
+            path: path.clone(),
+            root: path.parent().expect("descriptor directory").to_path_buf(),
+        };
+        let mut config = typed_config("nvidia.fabric.claude");
+        config.mcp = Some(McpConfig {
+            servers: BTreeMap::from([(
+                "docs".to_string(),
+                McpServerConfig {
+                    transport: "streamable-http".to_string(),
+                    url: "https://mcp.example".to_string(),
+                    exposure: McpExposure::HarnessNative,
+                    allowed_tools: Some(Vec::new()),
+                    blocked_tools: vec!["delete".to_string()],
+                    extensions: BTreeMap::new(),
+                },
+            )]),
+            extensions: BTreeMap::new(),
+        });
+
+        let plan = resolve_capability_plan(
+            &config,
+            Path::new("/tmp/fabric-mcp-filters"),
+            Some(&resolved),
+        );
+        let server = plan
+            .native
+            .mcp_servers
+            .get("docs")
+            .expect("native MCP server");
+
+        assert_eq!(server.allowed_tools, Some(Vec::new()));
+        assert_eq!(server.blocked_tools, vec!["delete".to_string()]);
+        let value = serde_json::to_value(server).expect("MCP server plan JSON");
+        assert_eq!(value["allowed_tools"], serde_json::json!([]));
+        assert_eq!(value["blocked_tools"], serde_json::json!(["delete"]));
+    }
+
+    #[test]
+    fn mcp_tool_filters_require_an_explicit_adapter_claim() {
+        let mut config = typed_config("nvidia.fabric.claude");
+        config.mcp = Some(McpConfig {
+            servers: BTreeMap::from([(
+                "docs".to_string(),
+                McpServerConfig {
+                    transport: "streamable-http".to_string(),
+                    url: "https://mcp.example".to_string(),
+                    exposure: McpExposure::HarnessNative,
+                    allowed_tools: Some(vec!["search".to_string()]),
+                    blocked_tools: Vec::new(),
+                    extensions: BTreeMap::new(),
+                },
+            )]),
+            extensions: BTreeMap::new(),
+        });
+
+        let error = resolve_run_plan_from_config(
+            config,
+            ResolveContext::new("/tmp/fabric-unsupported-mcp-filters"),
+        )
+        .expect_err("Claude does not advertise per-server MCP tool filters");
+
+        assert!(matches!(
+            error,
+            FabricError::AdapterCompatibility {
+                adapter_id,
+                field,
+                ..
+            } if adapter_id == "nvidia.fabric.claude"
+                && field == "mcp.servers.docs.allowed_tools"
+        ));
+    }
+
+    #[test]
+    fn overlapping_mcp_tool_policy_is_invalid() {
+        let mut config = typed_config("nvidia.fabric.hermes");
+        config.mcp = Some(McpConfig {
+            servers: BTreeMap::from([(
+                "docs".to_string(),
+                McpServerConfig {
+                    transport: "streamable-http".to_string(),
+                    url: "https://mcp.example".to_string(),
+                    exposure: McpExposure::HarnessNative,
+                    allowed_tools: Some(vec!["search".to_string()]),
+                    blocked_tools: vec!["search".to_string()],
+                    extensions: BTreeMap::new(),
+                },
+            )]),
+            extensions: BTreeMap::new(),
+        });
+
+        let error = resolve_run_plan_from_config(
+            config,
+            ResolveContext::new("/tmp/fabric-invalid-mcp-filters"),
+        )
+        .expect_err("overlapping MCP tool policy");
+
+        assert!(matches!(
+            error,
+            FabricError::InvalidConfig { field, .. } if field == "mcp.servers.docs"
+        ));
+    }
+
+    #[test]
+    fn empty_mcp_tool_names_are_invalid() {
+        for (allowed_tools, blocked_tools, expected_field) in [
+            (
+                Some(vec!["".to_string()]),
+                Vec::new(),
+                "mcp.servers.docs.allowed_tools",
+            ),
+            (
+                None,
+                vec!["  ".to_string()],
+                "mcp.servers.docs.blocked_tools",
+            ),
+        ] {
+            let mut config = typed_config("nvidia.fabric.hermes");
+            config.mcp = Some(McpConfig {
+                servers: BTreeMap::from([(
+                    "docs".to_string(),
+                    McpServerConfig {
+                        transport: "streamable-http".to_string(),
+                        url: "https://mcp.example".to_string(),
+                        exposure: McpExposure::HarnessNative,
+                        allowed_tools,
+                        blocked_tools,
+                        extensions: BTreeMap::new(),
+                    },
+                )]),
+                extensions: BTreeMap::new(),
+            });
+
+            let error = resolve_run_plan_from_config(
+                config,
+                ResolveContext::new("/tmp/fabric-invalid-mcp-tool-name"),
+            )
+            .expect_err("empty MCP tool name");
+
+            assert!(matches!(
+                error,
+                FabricError::InvalidConfig { field, .. } if field == expected_field
+            ));
+        }
     }
 
     #[test]

--- a/docs/reference/api/python-library-reference/nemo_fabric.models.md
+++ b/docs/reference/api/python-library-reference/nemo_fabric.models.md
@@ -698,6 +698,8 @@ The model defines the following fields:
 | `transport` | `str` | Yes | — | `MinLen(min_length=1)` | — |
 | `url` | `str` | Yes | — | `MinLen(min_length=1)` | — |
 | `exposure` | `Literal['harness_native', 'fabric_managed']` | No | `'harness_native'` | — | — |
+| `allowed_tools` | `list[str] \| None` | No | `None` | — | MCP tools to expose. None exposes every discovered tool; an empty list exposes no tools. |
+| `blocked_tools` | `list[str]` | No | `list()` | — | MCP tools to block after applying the optional allowlist. |
 
 ---
 
@@ -749,7 +751,7 @@ Validate a mapping using this Pydantic model.
 def to_mapping() -> dict[str, Any]
 ```
 
-Return a detached JSON-compatible mapping for Rust/core calls.
+Return the server mapping without collapsing an explicit empty allowlist.
 
 
 ---
@@ -811,6 +813,8 @@ def add_server(
     transport: str,
     url: str,
     exposure: Literal['harness_native', 'fabric_managed'] = 'harness_native',
+    allowed_tools: Sequence[str] | None = None,
+    blocked_tools: Sequence[str] = (),
     extra_fields: Mapping[str, Any] | None = None,
 ) -> Self
 ```
@@ -1990,6 +1994,8 @@ def add_mcp_server(
     transport: str,
     url: str,
     exposure: Literal['harness_native', 'fabric_managed'] = 'harness_native',
+    allowed_tools: Sequence[str] | None = None,
+    blocked_tools: Sequence[str] = (),
     extra_fields: Mapping[str, Any] | None = None,
 ) -> Self
 ```

--- a/docs/reference/api/rust-library-reference/nemo-fabric-core/config/enum-adapterconfigfield.mdx
+++ b/docs/reference/api/rust-library-reference/nemo-fabric-core/config/enum-adapterconfigfield.mdx
@@ -19,6 +19,7 @@ pub enum AdapterConfigField {
     EnabledTools,
     BlockedTools,
     Mcp,
+    McpToolFilters,
     Skills,
 }
 ```
@@ -74,6 +75,12 @@ Adapter-native tool names to block.
 <pre className="rust-signature"><code dangerouslySetInnerHTML={{"__html": "Mcp"}} /></pre>
 
 Harness-native MCP servers.
+
+### `McpToolFilters`
+
+<pre className="rust-signature"><code dangerouslySetInnerHTML={{"__html": "McpToolFilters"}} /></pre>
+
+Per-server MCP tool allowlists and blocklists.
 
 ### `Skills`
 

--- a/docs/reference/api/rust-library-reference/nemo-fabric-core/config/struct-mcpserverconfig.mdx
+++ b/docs/reference/api/rust-library-reference/nemo-fabric-core/config/struct-mcpserverconfig.mdx
@@ -9,7 +9,7 @@ SPDX-License-Identifier: Apache-2.0 */}
 
 Generated from `cargo doc --no-deps -p nemo-fabric-core`.
 
-<pre className="rust-signature"><code dangerouslySetInnerHTML={{"__html": "pub struct McpServerConfig &#123;\n    pub transport: <a href=\"https://doc.rust-lang.org/1.93.0/alloc/string/struct.String.html\">String</a>,\n    pub url: <a href=\"https://doc.rust-lang.org/1.93.0/alloc/string/struct.String.html\">String</a>,\n    pub exposure: <a href=\"enum-mcpexposure.mdx\">McpExposure</a>,\n    pub extensions: <a href=\"https://doc.rust-lang.org/1.93.0/alloc/collections/btree/map/struct.BTreeMap.html\">BTreeMap</a>&lt;<a href=\"https://doc.rust-lang.org/1.93.0/alloc/string/struct.String.html\">String</a>, <a href=\"https://docs.rs/serde_json/1.0.150/serde_json/value/enum.Value.html\">Value</a>&gt;,\n&#125;"}} /></pre>
+<pre className="rust-signature"><code dangerouslySetInnerHTML={{"__html": "pub struct McpServerConfig &#123;\n    pub transport: <a href=\"https://doc.rust-lang.org/1.93.0/alloc/string/struct.String.html\">String</a>,\n    pub url: <a href=\"https://doc.rust-lang.org/1.93.0/alloc/string/struct.String.html\">String</a>,\n    pub exposure: <a href=\"enum-mcpexposure.mdx\">McpExposure</a>,\n    pub allowed_tools: <a href=\"https://doc.rust-lang.org/1.93.0/core/option/enum.Option.html\">Option</a>&lt;<a href=\"https://doc.rust-lang.org/1.93.0/alloc/vec/struct.Vec.html\">Vec</a>&lt;<a href=\"https://doc.rust-lang.org/1.93.0/alloc/string/struct.String.html\">String</a>&gt;&gt;,\n    pub blocked_tools: <a href=\"https://doc.rust-lang.org/1.93.0/alloc/vec/struct.Vec.html\">Vec</a>&lt;<a href=\"https://doc.rust-lang.org/1.93.0/alloc/string/struct.String.html\">String</a>&gt;,\n    pub extensions: <a href=\"https://doc.rust-lang.org/1.93.0/alloc/collections/btree/map/struct.BTreeMap.html\">BTreeMap</a>&lt;<a href=\"https://doc.rust-lang.org/1.93.0/alloc/string/struct.String.html\">String</a>, <a href=\"https://docs.rs/serde_json/1.0.150/serde_json/value/enum.Value.html\">Value</a>&gt;,\n&#125;"}} /></pre>
 
 MCP server configuration.
 
@@ -26,6 +26,14 @@ MCP server URL or process command, depending on transport.
 ### `exposure: McpExposure`
 
 How NeMo Fabric exposes the MCP capability to the harness.
+
+### `allowed_tools: Option<Vec<String>>`
+
+MCP tool names to expose. `None` exposes every tool discovered from the server.
+
+### `blocked_tools: Vec<String>`
+
+MCP tool names to block after applying the optional allowlist.
 
 ### `extensions: BTreeMap<String, Value>`
 

--- a/docs/reference/api/rust-library-reference/nemo-fabric-core/config/struct-mcpserverplan.mdx
+++ b/docs/reference/api/rust-library-reference/nemo-fabric-core/config/struct-mcpserverplan.mdx
@@ -9,7 +9,7 @@ SPDX-License-Identifier: Apache-2.0 */}
 
 Generated from `cargo doc --no-deps -p nemo-fabric-core`.
 
-<pre className="rust-signature"><code dangerouslySetInnerHTML={{"__html": "pub struct McpServerPlan &#123;\n    pub transport: <a href=\"https://doc.rust-lang.org/1.93.0/alloc/string/struct.String.html\">String</a>,\n    pub url: <a href=\"https://doc.rust-lang.org/1.93.0/alloc/string/struct.String.html\">String</a>,\n    pub exposure: <a href=\"enum-mcpexposure.mdx\">McpExposure</a>,\n&#125;"}} /></pre>
+<pre className="rust-signature"><code dangerouslySetInnerHTML={{"__html": "pub struct McpServerPlan &#123;\n    pub transport: <a href=\"https://doc.rust-lang.org/1.93.0/alloc/string/struct.String.html\">String</a>,\n    pub url: <a href=\"https://doc.rust-lang.org/1.93.0/alloc/string/struct.String.html\">String</a>,\n    pub exposure: <a href=\"enum-mcpexposure.mdx\">McpExposure</a>,\n    pub allowed_tools: <a href=\"https://doc.rust-lang.org/1.93.0/core/option/enum.Option.html\">Option</a>&lt;<a href=\"https://doc.rust-lang.org/1.93.0/alloc/vec/struct.Vec.html\">Vec</a>&lt;<a href=\"https://doc.rust-lang.org/1.93.0/alloc/string/struct.String.html\">String</a>&gt;&gt;,\n    pub blocked_tools: <a href=\"https://doc.rust-lang.org/1.93.0/alloc/vec/struct.Vec.html\">Vec</a>&lt;<a href=\"https://doc.rust-lang.org/1.93.0/alloc/string/struct.String.html\">String</a>&gt;,\n&#125;"}} /></pre>
 
 Resolved MCP server exposure.
 
@@ -26,6 +26,14 @@ MCP URL or command.
 ### `exposure: McpExposure`
 
 Exposure strategy.
+
+### `allowed_tools: Option<Vec<String>>`
+
+MCP tool names to expose. `None` exposes every discovered tool.
+
+### `blocked_tools: Vec<String>`
+
+MCP tool names to block after applying the optional allowlist.
 
 ## Trait Implementations
 

--- a/docs/sdk/python.mdx
+++ b/docs/sdk/python.mdx
@@ -190,6 +190,7 @@ by adapter:
 | `tools.enabled`, `.blocked` | Yes | No | Yes | Yes; native selectors are Hermes toolset names |
 | `skills.paths` | Yes | Yes | Yes | Yes |
 | `mcp.servers.<name>.transport`, `.url` with `harness_native` exposure | Yes | Yes | Yes | Yes |
+| `mcp.servers.<name>.allowed_tools`, `.blocked_tools` | No | No | No | No |
 | `mcp.servers.<name>.exposure = "fabric_managed"` | No; not implemented | No; not implemented | No; not implemented | No; not implemented |
 | `telemetry.providers.relay` | Yes | Yes | Yes | Yes |
 | `telemetry.providers.native` | No | Yes; OpenTelemetry | Yes; OpenTelemetry and OpenInference | No |
@@ -226,6 +227,27 @@ capability_config.enable_relay(
     output_dir="./artifacts/relay",
 )
 ```
+
+MCP tool policy is scoped to one server and uses the tool names that server
+advertises. `allowed_tools=None` exposes every discovered tool, while an empty
+allowlist exposes none. `blocked_tools` is then removed from the allowed or
+discovered set, and the same tool cannot appear in both lists:
+
+```python
+capability_config.add_mcp_server(
+    "github",
+    transport="streamable-http",
+    url="${GITHUB_MCP_URL}",
+    exposure="harness_native",
+    allowed_tools=["issues.read", "pull_requests.read"],
+    blocked_tools=["issues.delete"],
+)
+```
+
+An adapter must declare both `mcp` and `mcp.tool_filters` support before
+planning accepts these fields. The bundled adapters currently support
+unfiltered MCP servers only. Per-server MCP policy is distinct from the root
+`ToolsConfig`, which controls adapter-native tools across the harness.
 
 Tool names are adapter-native selectors. NeMo Fabric does not define a portable
 catalog that translates names between harnesses. Configure an allowlist, a

--- a/python/src/nemo_fabric/models.py
+++ b/python/src/nemo_fabric/models.py
@@ -332,9 +332,9 @@ class McpConfig(FabricBaseModel):
         """Add or replace a named MCP server."""
 
         if isinstance(allowed_tools, str):
-            raise ValueError("allowed_tools must be a sequence of strings, not a string")
+            raise TypeError("allowed_tools must be a sequence of strings, not a string")
         if isinstance(blocked_tools, str):
-            raise ValueError("blocked_tools must be a sequence of strings, not a string")
+            raise TypeError("blocked_tools must be a sequence of strings, not a string")
 
         self.servers[name] = McpServerConfig(
             transport=transport,

--- a/python/src/nemo_fabric/models.py
+++ b/python/src/nemo_fabric/models.py
@@ -24,7 +24,9 @@ from typing import Self
 from pydantic import BaseModel
 from pydantic import ConfigDict
 from pydantic import Field
+from pydantic import SerializerFunctionWrapHandler
 from pydantic import field_validator
+from pydantic import model_serializer
 from pydantic import model_validator
 
 
@@ -269,13 +271,22 @@ class McpServerConfig(FabricBaseModel):
             "MCP tools to expose. None exposes every discovered tool; an empty "
             "list exposes no tools."
         ),
-        exclude_if=lambda value: value is None,
     )
     blocked_tools: list[str] = Field(
         default_factory=list,
         description="MCP tools to block after applying the optional allowlist.",
-        exclude_if=lambda value: not value,
     )
+
+    @model_serializer(mode="wrap")
+    def _serialize_tool_policy(
+        self, handler: SerializerFunctionWrapHandler
+    ) -> dict[str, Any]:
+        data = handler(self)
+        if self.allowed_tools is None:
+            data.pop("allowed_tools", None)
+        if not self.blocked_tools:
+            data.pop("blocked_tools", None)
+        return data
 
     @field_validator("allowed_tools", "blocked_tools")
     @classmethod
@@ -319,6 +330,11 @@ class McpConfig(FabricBaseModel):
         extra_fields: Mapping[str, Any] | None = None,
     ) -> Self:
         """Add or replace a named MCP server."""
+
+        if isinstance(allowed_tools, str):
+            raise ValueError("allowed_tools must be a sequence of strings, not a string")
+        if isinstance(blocked_tools, str):
+            raise ValueError("blocked_tools must be a sequence of strings, not a string")
 
         self.servers[name] = McpServerConfig(
             transport=transport,

--- a/python/src/nemo_fabric/models.py
+++ b/python/src/nemo_fabric/models.py
@@ -263,6 +263,43 @@ class McpServerConfig(FabricBaseModel):
     transport: str = Field(min_length=1)
     url: str = Field(min_length=1)
     exposure: Literal["harness_native", "fabric_managed"] = "harness_native"
+    allowed_tools: list[str] | None = Field(
+        default=None,
+        description=(
+            "MCP tools to expose. None exposes every discovered tool; an empty "
+            "list exposes no tools."
+        ),
+        exclude_if=lambda value: value is None,
+    )
+    blocked_tools: list[str] = Field(
+        default_factory=list,
+        description="MCP tools to block after applying the optional allowlist.",
+        exclude_if=lambda value: not value,
+    )
+
+    @field_validator("allowed_tools", "blocked_tools")
+    @classmethod
+    def _validate_tool_names(cls, value: list[str] | None) -> list[str] | None:
+        if value is not None and any(not tool.strip() for tool in value):
+            raise ValueError("MCP tool names must not be empty")
+        return value
+
+    @model_validator(mode="after")
+    def _validate_tool_policy(self) -> Self:
+        if self.allowed_tools is not None:
+            overlap = set(self.allowed_tools).intersection(self.blocked_tools)
+            if overlap:
+                name = sorted(overlap)[0]
+                raise ValueError(f"MCP tool {name!r} cannot be both allowed and blocked")
+        return self
+
+    def to_mapping(self) -> dict[str, Any]:
+        """Return the server mapping without collapsing an explicit empty allowlist."""
+
+        data = super().to_mapping()
+        if self.allowed_tools == []:
+            data["allowed_tools"] = []
+        return data
 
 
 class McpConfig(FabricBaseModel):
@@ -277,6 +314,8 @@ class McpConfig(FabricBaseModel):
         transport: str,
         url: str,
         exposure: Literal["harness_native", "fabric_managed"] = "harness_native",
+        allowed_tools: Sequence[str] | None = None,
+        blocked_tools: Sequence[str] = (),
         extra_fields: Mapping[str, Any] | None = None,
     ) -> Self:
         """Add or replace a named MCP server."""
@@ -285,6 +324,8 @@ class McpConfig(FabricBaseModel):
             transport=transport,
             url=url,
             exposure=exposure,
+            allowed_tools=None if allowed_tools is None else list(allowed_tools),
+            blocked_tools=list(blocked_tools),
             **dict(extra_fields or {}),
         )
         return self
@@ -553,6 +594,8 @@ class FabricConfig(FabricBaseModel):
         transport: str,
         url: str,
         exposure: Literal["harness_native", "fabric_managed"] = "harness_native",
+        allowed_tools: Sequence[str] | None = None,
+        blocked_tools: Sequence[str] = (),
         extra_fields: Mapping[str, Any] | None = None,
     ) -> Self:
         """Add or replace a named MCP server and return this config."""
@@ -564,6 +607,8 @@ class FabricConfig(FabricBaseModel):
             transport=transport,
             url=url,
             exposure=exposure,
+            allowed_tools=allowed_tools,
+            blocked_tools=blocked_tools,
             extra_fields=extra_fields,
         )
         return self

--- a/python/src/nemo_fabric/types.py
+++ b/python/src/nemo_fabric/types.py
@@ -556,6 +556,8 @@ class _McpConfig(_ConfigMapping):
         transport: str,
         url: str,
         exposure: str = "harness_native",
+        allowed_tools: Sequence[str] | None = None,
+        blocked_tools: Sequence[str] = (),
         extra_fields: Mapping[str, Any] | None = None,
     ) -> "_McpConfig":
         """Add or replace a named MCP server."""
@@ -563,11 +565,39 @@ class _McpConfig(_ConfigMapping):
         if exposure not in self._EXPOSURES:
             allowed = ", ".join(sorted(self._EXPOSURES))
             raise FabricConfigError(f"mcp exposure must be one of: {allowed}")
-        server = {
+        for policy, tools in (
+            ("allowed_tools", allowed_tools),
+            ("blocked_tools", blocked_tools),
+        ):
+            if tools is not None and (
+                isinstance(tools, (str, bytes)) or not isinstance(tools, Sequence)
+            ):
+                raise FabricConfigError(
+                    f"mcp {policy} must be an ordered sequence of strings"
+                )
+        allowed_values = (
+            None
+            if allowed_tools is None
+            else [_required_text(tool, "allowed MCP tool") for tool in allowed_tools]
+        )
+        blocked_values = [
+            _required_text(tool, "blocked MCP tool") for tool in blocked_tools
+        ]
+        overlap = set(allowed_values or []).intersection(blocked_values)
+        if overlap:
+            tool = sorted(overlap)[0]
+            raise FabricConfigError(
+                f"MCP tool {tool!r} cannot be both allowed and blocked"
+            )
+        server: dict[str, Any] = {
             "transport": _required_text(transport, "mcp transport"),
             "url": _required_text(url, "mcp url"),
             "exposure": exposure,
         }
+        if allowed_values is not None:
+            server["allowed_tools"] = allowed_values
+        if blocked_values:
+            server["blocked_tools"] = blocked_values
         server.update(
             _mapping(
                 {} if extra_fields is None else extra_fields,
@@ -845,6 +875,8 @@ class _FabricConfigSnapshot(_ConfigMapping):
         transport: str,
         url: str,
         exposure: str = "harness_native",
+        allowed_tools: Sequence[str] | None = None,
+        blocked_tools: Sequence[str] = (),
         extra_fields: Mapping[str, Any] | None = None,
     ) -> "_FabricConfigSnapshot":
         """Add or replace a named MCP server and return this config."""
@@ -854,6 +886,8 @@ class _FabricConfigSnapshot(_ConfigMapping):
             transport=transport,
             url=url,
             exposure=exposure,
+            allowed_tools=allowed_tools,
+            blocked_tools=blocked_tools,
             extra_fields=extra_fields,
         )
         return self

--- a/python/src/nemo_fabric/types.py
+++ b/python/src/nemo_fabric/types.py
@@ -529,6 +529,9 @@ class _McpConfig(_ConfigMapping):
     _fields = frozenset({"servers"})
     _omit_if_empty = frozenset({"servers"})
     _EXPOSURES = frozenset({"harness_native", "fabric_managed"})
+    _SERVER_FIELDS = frozenset(
+        {"transport", "url", "exposure", "allowed_tools", "blocked_tools"}
+    )
 
     def __init__(
         self,
@@ -598,12 +601,17 @@ class _McpConfig(_ConfigMapping):
             server["allowed_tools"] = allowed_values
         if blocked_values:
             server["blocked_tools"] = blocked_values
-        server.update(
-            _mapping(
-                {} if extra_fields is None else extra_fields,
-                "mcp server extra_fields",
-            )
+        extensions = _mapping(
+            {} if extra_fields is None else extra_fields,
+            "mcp server extra_fields",
         )
+        reserved = self._SERVER_FIELDS.intersection(extensions)
+        if reserved:
+            field = sorted(reserved)[0]
+            raise FabricConfigError(
+                f"mcp server extra_fields must not contain reserved field {field!r}"
+            )
+        server.update(extensions)
         servers = dict(self.get("servers", {}))
         servers[_required_text(name, "mcp server name")] = server
         self["servers"] = servers

--- a/schemas/adapter-descriptor.schema.json
+++ b/schemas/adapter-descriptor.schema.json
@@ -44,6 +44,11 @@
           "type": "string"
         },
         {
+          "const": "mcp.tool_filters",
+          "description": "Per-server MCP tool allowlists and blocklists.",
+          "type": "string"
+        },
+        {
           "const": "skills",
           "description": "Harness-native skills.",
           "type": "string"

--- a/schemas/agent.schema.json
+++ b/schemas/agent.schema.json
@@ -205,6 +205,23 @@
       "additionalProperties": true,
       "description": "MCP server configuration.",
       "properties": {
+        "allowed_tools": {
+          "description": "MCP tool names to expose. `None` exposes every tool discovered from the server.",
+          "items": {
+            "type": "string"
+          },
+          "type": [
+            "array",
+            "null"
+          ]
+        },
+        "blocked_tools": {
+          "description": "MCP tool names to block after applying the optional allowlist.",
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
         "exposure": {
           "$ref": "#/$defs/McpExposure",
           "description": "How NeMo Fabric exposes the MCP capability to the harness."

--- a/schemas/run-plan.schema.json
+++ b/schemas/run-plan.schema.json
@@ -44,6 +44,11 @@
           "type": "string"
         },
         {
+          "const": "mcp.tool_filters",
+          "description": "Per-server MCP tool allowlists and blocklists.",
+          "type": "string"
+        },
+        {
           "const": "skills",
           "description": "Harness-native skills.",
           "type": "string"
@@ -786,6 +791,23 @@
       "additionalProperties": true,
       "description": "MCP server configuration.",
       "properties": {
+        "allowed_tools": {
+          "description": "MCP tool names to expose. `None` exposes every tool discovered from the server.",
+          "items": {
+            "type": "string"
+          },
+          "type": [
+            "array",
+            "null"
+          ]
+        },
+        "blocked_tools": {
+          "description": "MCP tool names to block after applying the optional allowlist.",
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
         "exposure": {
           "$ref": "#/$defs/McpExposure",
           "description": "How NeMo Fabric exposes the MCP capability to the harness."
@@ -809,6 +831,23 @@
     "McpServerPlan": {
       "description": "Resolved MCP server exposure.",
       "properties": {
+        "allowed_tools": {
+          "description": "MCP tool names to expose. `None` exposes every discovered tool.",
+          "items": {
+            "type": "string"
+          },
+          "type": [
+            "array",
+            "null"
+          ]
+        },
+        "blocked_tools": {
+          "description": "MCP tool names to block after applying the optional allowlist.",
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
         "exposure": {
           "$ref": "#/$defs/McpExposure",
           "description": "Exposure strategy."

--- a/skills/integrations/consumer/nemo-fabric-integrate/SKILL.md
+++ b/skills/integrations/consumer/nemo-fabric-integrate/SKILL.md
@@ -142,9 +142,9 @@ def to_fabric_config(job) -> FabricConfig:
 - Shape capabilities with `ToolsConfig`, `block_tools`, `add_skill_path`,
   `remove_skill_path`,
   `add_mcp_server`, `remove_mcp_server`, and `enable_relay`.
-- Use `allowed_tools` and `blocked_tools` on `add_mcp_server` for server-local
-  MCP policy only when the selected adapter declares both `mcp` and
-  `mcp.tool_filters`.
+- Use a restricted `allowed_tools` list or non-empty `blocked_tools` on
+  `add_mcp_server` only when the selected adapter declares both `mcp` and
+  `mcp.tool_filters`. An unfiltered server requires only `mcp`.
   `allowed_tools=None` exposes every discovered tool, while an empty list
   exposes none; blocked tools are removed after applying that allowlist. A tool
   cannot appear in both lists; planning rejects overlapping policies.

--- a/skills/integrations/consumer/nemo-fabric-integrate/SKILL.md
+++ b/skills/integrations/consumer/nemo-fabric-integrate/SKILL.md
@@ -143,9 +143,11 @@ def to_fabric_config(job) -> FabricConfig:
   `remove_skill_path`,
   `add_mcp_server`, `remove_mcp_server`, and `enable_relay`.
 - Use `allowed_tools` and `blocked_tools` on `add_mcp_server` for server-local
-  MCP policy only when the selected adapter declares `mcp.tool_filters`.
+  MCP policy only when the selected adapter declares both `mcp` and
+  `mcp.tool_filters`.
   `allowed_tools=None` exposes every discovered tool, while an empty list
-  exposes none; blocked tools are removed after applying that allowlist.
+  exposes none; blocked tools are removed after applying that allowlist. A tool
+  cannot appear in both lists; planning rejects overlapping policies.
 - Create deployment or evaluation variants with `model_copy(deep=True)` and
   ordinary Python functions; each copy plans and runs independently.
 - Pass `base_dir=...` to any `Fabric` call when the config uses relative paths,

--- a/skills/integrations/consumer/nemo-fabric-integrate/SKILL.md
+++ b/skills/integrations/consumer/nemo-fabric-integrate/SKILL.md
@@ -142,6 +142,10 @@ def to_fabric_config(job) -> FabricConfig:
 - Shape capabilities with `ToolsConfig`, `block_tools`, `add_skill_path`,
   `remove_skill_path`,
   `add_mcp_server`, `remove_mcp_server`, and `enable_relay`.
+- Use `allowed_tools` and `blocked_tools` on `add_mcp_server` for server-local
+  MCP policy only when the selected adapter declares `mcp.tool_filters`.
+  `allowed_tools=None` exposes every discovered tool, while an empty list
+  exposes none; blocked tools are removed after applying that allowlist.
 - Create deployment or evaluation variants with `model_copy(deep=True)` and
   ordinary Python functions; each copy plans and runs independently.
 - Pass `base_dir=...` to any `Fabric` call when the config uses relative paths,

--- a/skills/integrations/consumer/nemo-fabric-integrate/SKILL.md
+++ b/skills/integrations/consumer/nemo-fabric-integrate/SKILL.md
@@ -146,8 +146,9 @@ def to_fabric_config(job) -> FabricConfig:
   `add_mcp_server` only when the selected adapter declares both `mcp` and
   `mcp.tool_filters`. An unfiltered server requires only `mcp`.
   `allowed_tools=None` exposes every discovered tool, while an empty list
-  exposes none; blocked tools are removed after applying that allowlist. A tool
-  cannot appear in both lists; planning rejects overlapping policies.
+  exposes none; blocked tools are removed after applying that allowlist. Tool
+  names must be non-blank, and planning rejects a tool that appears in both
+  lists.
 - Create deployment or evaluation variants with `model_copy(deep=True)` and
   ordinary Python functions; each copy plans and runs independently.
 - Pass `base_dir=...` to any `Fabric` call when the config uses relative paths,

--- a/skills/integrations/consumer/nemo-fabric-integrate/references/config-mapping.md
+++ b/skills/integrations/consumer/nemo-fabric-integrate/references/config-mapping.md
@@ -44,11 +44,12 @@ methods that edit the typed config in place and return it:
 - `ToolsConfig(enabled=..., blocked=...)` for tool policy
 - `block_tools(...)` for additive deny policy
 
-Per-server MCP tool policies require adapter support for both `mcp` and
-`mcp.tool_filters`. `allowed_tools=None` exposes every discovered tool, while
-`allowed_tools=[]` exposes none. NeMo Fabric removes `blocked_tools` after
-applying the allowlist and rejects a tool that appears in both lists during
-planning.
+Filtered per-server MCP configurations require adapter support for both `mcp`
+and `mcp.tool_filters`. An unfiltered server with `allowed_tools=None` and an
+empty or omitted `blocked_tools` list requires only `mcp`. `allowed_tools=None`
+exposes every discovered tool, while `allowed_tools=[]` exposes none. NeMo
+Fabric removes `blocked_tools` after applying the allowlist and rejects a tool
+that appears in both lists during planning.
 
 ```python
 config = FabricConfig(

--- a/skills/integrations/consumer/nemo-fabric-integrate/references/config-mapping.md
+++ b/skills/integrations/consumer/nemo-fabric-integrate/references/config-mapping.md
@@ -48,8 +48,8 @@ Filtered per-server MCP configurations require adapter support for both `mcp`
 and `mcp.tool_filters`. An unfiltered server with `allowed_tools=None` and an
 empty or omitted `blocked_tools` list requires only `mcp`. `allowed_tools=None`
 exposes every discovered tool, while `allowed_tools=[]` exposes none. NeMo
-Fabric removes `blocked_tools` after applying the allowlist and rejects a tool
-that appears in both lists during planning.
+Fabric removes `blocked_tools` after applying the allowlist. Tool names in both
+lists must be non-blank, and planning rejects a tool that appears in both lists.
 
 ```python
 config = FabricConfig(

--- a/skills/integrations/consumer/nemo-fabric-integrate/references/config-mapping.md
+++ b/skills/integrations/consumer/nemo-fabric-integrate/references/config-mapping.md
@@ -44,6 +44,11 @@ methods that edit the typed config in place and return it:
 - `ToolsConfig(enabled=..., blocked=...)` for tool policy
 - `block_tools(...)` for additive deny policy
 
+Per-server MCP tool policies require adapter support for both `mcp` and
+`mcp.tool_filters`. `allowed_tools=None` exposes every discovered tool, while
+`allowed_tools=[]` exposes none. Fabric removes `blocked_tools` after applying
+the allowlist and rejects a tool that appears in both lists during planning.
+
 ```python
 config = FabricConfig(
     metadata=MetadataConfig(name=job.name),

--- a/skills/integrations/consumer/nemo-fabric-integrate/references/config-mapping.md
+++ b/skills/integrations/consumer/nemo-fabric-integrate/references/config-mapping.md
@@ -23,7 +23,7 @@ Import these from the top-level `nemo_fabric` package:
 | `RuntimeConfig` | Input/output labels, artifact location, invocation timeout, and harness turn limit. |
 | `EnvironmentConfig` | Execution environment, workspace, and harness-visible variables. |
 | `ToolsConfig` | Adapter-native tool selection and blocking policy. |
-| `McpConfig` / `McpServerConfig` | MCP servers and exposure. |
+| `McpConfig` / `McpServerConfig` | MCP servers, exposure, and optional per-server tool policy. |
 | `SkillConfig` | Skill directories. |
 | `TelemetryConfig` | Telemetry providers. |
 | `RelayConfig` and `Relay*Config` | NVIDIA NeMo Relay observability under the top-level `relay` block. |
@@ -39,7 +39,7 @@ Construct the nested config directly, then adjust capabilities with helper
 methods that edit the typed config in place and return it:
 
 - `add_skill_path(path)` / `remove_skill_path(path)`
-- `add_mcp_server(name, *, transport, url, exposure, ...)` / `remove_mcp_server(name)`
+- `add_mcp_server(name, *, transport, url, exposure, allowed_tools, blocked_tools, ...)` / `remove_mcp_server(name)`
 - `enable_relay(...)` for NVIDIA NeMo Relay observability in the `relay` block
 - `ToolsConfig(enabled=..., blocked=...)` for tool policy
 - `block_tools(...)` for additive deny policy

--- a/skills/integrations/consumer/nemo-fabric-integrate/references/config-mapping.md
+++ b/skills/integrations/consumer/nemo-fabric-integrate/references/config-mapping.md
@@ -46,8 +46,9 @@ methods that edit the typed config in place and return it:
 
 Per-server MCP tool policies require adapter support for both `mcp` and
 `mcp.tool_filters`. `allowed_tools=None` exposes every discovered tool, while
-`allowed_tools=[]` exposes none. Fabric removes `blocked_tools` after applying
-the allowlist and rejects a tool that appears in both lists during planning.
+`allowed_tools=[]` exposes none. NeMo Fabric removes `blocked_tools` after
+applying the allowlist and rejects a tool that appears in both lists during
+planning.
 
 ```python
 config = FabricConfig(

--- a/tests/python/test_sdk_contract.py
+++ b/tests/python/test_sdk_contract.py
@@ -224,7 +224,7 @@ def test_mcp_server_tool_policy_preserves_empty_allowlist():
 @pytest.mark.parametrize("field", ["allowed_tools", "blocked_tools"])
 def test_mcp_config_rejects_string_tool_policy(field: str):
     with pytest.raises(
-        ValueError,
+        TypeError,
         match=rf"{field} must be a sequence of strings, not a string",
     ):
         McpConfig().add_server(
@@ -345,6 +345,26 @@ def test_run_plan_config_block_tools_emits_canonical_shape():
     config.block_tools("browser", "shell", "browser")
 
     assert config.to_mapping()["tools"] == {"blocked": ["browser", "shell"]}
+
+
+def test_run_plan_config_add_mcp_server_emits_tool_filters():
+    config = _FabricConfigSnapshot.from_mapping(_plan()["config"])
+
+    config.add_mcp_server(
+        "docs",
+        transport="streamable-http",
+        url="https://mcp.example.test",
+        allowed_tools=["search"],
+        blocked_tools=["delete"],
+    )
+
+    assert config.to_mapping()["mcp"]["servers"]["docs"] == {
+        "transport": "streamable-http",
+        "url": "https://mcp.example.test",
+        "exposure": "harness_native",
+        "allowed_tools": ["search"],
+        "blocked_tools": ["delete"],
+    }
 
 
 def test_run_plan_config_preserves_normalized_tools_and_execution_fields():

--- a/tests/python/test_sdk_contract.py
+++ b/tests/python/test_sdk_contract.py
@@ -367,6 +367,22 @@ def test_run_plan_config_add_mcp_server_emits_tool_filters():
     }
 
 
+@pytest.mark.parametrize(
+    "reserved_field",
+    ["transport", "url", "exposure", "allowed_tools", "blocked_tools"],
+)
+def test_run_plan_config_rejects_reserved_mcp_extra_field(reserved_field: str):
+    config = _FabricConfigSnapshot.from_mapping(_plan()["config"])
+
+    with pytest.raises(FabricConfigError, match="reserved field"):
+        config.add_mcp_server(
+            "docs",
+            transport="streamable-http",
+            url="https://mcp.example.test",
+            extra_fields={reserved_field: "override"},
+        )
+
+
 def test_run_plan_config_preserves_normalized_tools_and_execution_fields():
     raw = _plan()["config"]
     raw.update(

--- a/tests/python/test_sdk_contract.py
+++ b/tests/python/test_sdk_contract.py
@@ -208,12 +208,31 @@ def test_mcp_server_tool_policy_preserves_empty_allowlist():
         allowed_tools=[],
     )
 
-    assert server.to_mapping() == {
+    expected = {
         "transport": "streamable-http",
         "url": "https://mcp.example.test",
         "exposure": "harness_native",
         "allowed_tools": [],
     }
+    assert server.model_dump(mode="python") == expected
+    assert McpConfig(servers={"docs": server}).model_dump(mode="python") == {
+        "servers": {"docs": expected}
+    }
+    assert server.to_mapping() == expected
+
+
+@pytest.mark.parametrize("field", ["allowed_tools", "blocked_tools"])
+def test_mcp_config_rejects_string_tool_policy(field: str):
+    with pytest.raises(
+        ValueError,
+        match=rf"{field} must be a sequence of strings, not a string",
+    ):
+        McpConfig().add_server(
+            "docs",
+            transport="streamable-http",
+            url="https://mcp.example.test",
+            **{field: "search"},  # type: ignore[arg-type]
+        )
 
 
 @pytest.mark.parametrize(

--- a/tests/python/test_sdk_contract.py
+++ b/tests/python/test_sdk_contract.py
@@ -29,6 +29,7 @@ from nemo_fabric import HarnessConfig
 from nemo_fabric import InstructionConfig
 from nemo_fabric import InstructionsConfig
 from nemo_fabric import McpConfig
+from nemo_fabric import McpServerConfig
 from nemo_fabric import MetadataConfig
 from nemo_fabric import RelayAtifConfig
 from nemo_fabric import RelayAtofConfig
@@ -141,6 +142,8 @@ def test_typed_config_authoring_helpers_emit_schema_shape():
         transport="streamable-http",
         url="${GITHUB_MCP_URL}",
         exposure="fabric_managed",
+        allowed_tools=["issues.read", "pull_requests.read"],
+        blocked_tools=["issues.delete"],
     )
     config.enable_relay(
         project="fabric-tests",
@@ -166,6 +169,8 @@ def test_typed_config_authoring_helpers_emit_schema_shape():
                 "transport": "streamable-http",
                 "url": "${GITHUB_MCP_URL}",
                 "exposure": "fabric_managed",
+                "allowed_tools": ["issues.read", "pull_requests.read"],
+                "blocked_tools": ["issues.delete"],
             }
         }
     }
@@ -194,6 +199,43 @@ def test_typed_config_authoring_helpers_emit_schema_shape():
         )
     with pytest.raises(ValidationError, match="providers"):
         TelemetryConfig(providers={"sideways": {}})
+
+
+def test_mcp_server_tool_policy_preserves_empty_allowlist():
+    server = McpServerConfig(
+        transport="streamable-http",
+        url="https://mcp.example.test",
+        allowed_tools=[],
+    )
+
+    assert server.to_mapping() == {
+        "transport": "streamable-http",
+        "url": "https://mcp.example.test",
+        "exposure": "harness_native",
+        "allowed_tools": [],
+    }
+
+
+@pytest.mark.parametrize(
+    ("allowed_tools", "blocked_tools", "message"),
+    [
+        (["search"], ["search"], "cannot be both allowed and blocked"),
+        ([""], [], "MCP tool names must not be empty"),
+        (None, ["  "], "MCP tool names must not be empty"),
+    ],
+)
+def test_mcp_server_tool_policy_rejects_invalid_names_and_overlap(
+    allowed_tools: list[str] | None,
+    blocked_tools: list[str],
+    message: str,
+):
+    with pytest.raises(ValidationError, match=message):
+        McpServerConfig(
+            transport="streamable-http",
+            url="https://mcp.example.test",
+            allowed_tools=allowed_tools,
+            blocked_tools=blocked_tools,
+        )
 
 
 def test_typed_tools_config_serializes_blocked_policy():


### PR DESCRIPTION
#### Overview

Add normalized per-server MCP tool allowlists and blocklists without widening the existing `mcp` adapter capability claim. An adapter must explicitly claim `mcp.tool_filters` before Fabric routes a filtered server to it; otherwise planning fails rather than silently exposing the server's full inventory.

#### Details

- Add `allowed_tools: list[str] | None` and `blocked_tools: list[str]` to the Rust and Python `McpServerConfig` surfaces and propagate them into `McpServerPlan`.
- Preserve the configured semantics: omitted or `null` allowlist exposes all discovered tools, an empty allowlist exposes none, and blocked tools are removed from the selected inventory.
- Reject blank names and overlap between the allowlist and blocklist.
- Add the `mcp.tool_filters` descriptor claim so existing adapters retain unfiltered MCP support without claiming filter enforcement.
- Regenerate schemas and API references, and update SDK and adapter-authoring guidance.

#### Validation

- `cargo fmt --all -- --check`
- `just test-rust`
- `just test-python` (`583 passed, 15 skipped`)
- `just docs` (passed with the expected unauthenticated Fern redirect warning)
- `uv run --with pre-commit pre-commit run --all-files --show-diff-on-failure`
- `git diff --check`

#### Where should the reviewer start?

Start with `McpServerConfig`, `adapter_config_compatibility_issues`, and `resolve_capability_plan` in `crates/fabric-core/src/config.rs`. The key design decision is the separate `mcp.tool_filters` claim, which prevents current adapters from silently accepting a policy they do not enforce.

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- Closes [FABRIC-171](https://linear.app/nvidia/issue/FABRIC-171/add-normalized-per-server-mcp-allowed-and-blocked-tools)

- [x] I confirm this contribution is my own work, or I have the right to submit it under this project's license.
- [x] I searched existing issues and open pull requests, and this does not duplicate existing work.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added per-server MCP tool allowlists and blocklists.
  * Added options to expose all tools, selected tools, or no tools.
  * Applied blocklists after allowlist filtering.

* **Bug Fixes**
  * Added validation for blank tool names and overlapping policies.
  * Rejects unsupported filtering configurations.

* **Documentation**
  * Updated SDK, API, schema, and integration documentation with MCP filtering guidance and adapter requirements.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->