### PR TITLE
fix: preserve NAT stdio MCP arguments and environment

### DIFF
--- a/external/nat/README.md
+++ b/external/nat/README.md
@@ -50,6 +50,12 @@ The adapter consumes the routed `capability_plan.native.mcp_servers` entries,
 including the normalized per-server filters. NeMo Fabric MCP tool names remain bare
 server-local names; NAT exposes a selected member as `<server>__<tool>`.
 
+For a `stdio` server, the adapter expands `$VAR` references in `url`, splits the
+result using shell quoting rules, and uses the first token as the NAT command.
+It appends structured `args` after arguments parsed from `url` and forwards `env`
+to the NAT process environment. Variable expansion applies only to `url`; `args`
+and `env` values are used literally.
+
 | NeMo Fabric server policy | Generated NAT function group |
 | --- | --- |
 | `allowed_tools` omitted and `blocked_tools=[]` | No `include` or `exclude`; expose all discovered tools |

--- a/external/nat/README.md
+++ b/external/nat/README.md
@@ -50,11 +50,9 @@ The adapter consumes the routed `capability_plan.native.mcp_servers` entries,
 including the normalized per-server filters. NeMo Fabric MCP tool names remain bare
 server-local names; NAT exposes a selected member as `<server>__<tool>`.
 
-For a `stdio` server, the adapter expands `$VAR` references in `url`, splits the
-result using shell quoting rules, and uses the first token as the NAT command.
-It appends structured `args` after arguments parsed from `url` and forwards `env`
-to the NAT process environment. Variable expansion applies only to `url`; `args`
-and `env` values are used literally.
+For `stdio` servers, NeMo Fabric expands `$VAR` references in `url`, parses the
+command and inline arguments, appends structured `args`, and forwards `env` to
+NAT. Only `url` supports variable expansion; `args` and `env` values are literal.
 
 | NeMo Fabric server policy | Generated NAT function group |
 | --- | --- |

--- a/external/nat/src/nemo_fabric_adapters/nat/adapter.py
+++ b/external/nat/src/nemo_fabric_adapters/nat/adapter.py
@@ -340,8 +340,11 @@ def nat_mcp_server_config(name: str, server: Any) -> dict[str, Any]:
             "transport": "stdio",
             "command": command[0],
         }
-        if command[1:]:
-            result["args"] = command[1:]
+        args = [*command[1:], *common_utils.normalize_list(server.get("args"))]
+        if args:
+            result["args"] = args
+        if env := server.get("env"):
+            result["env"] = env
         return result
 
     if transport in {"http", "streamablehttp"}:

--- a/tests/adapters/test_external_nat_adapter.py
+++ b/tests/adapters/test_external_nat_adapter.py
@@ -995,7 +995,7 @@ def test_mcp_server_normalizes_streamable_http_aliases(transport: str):
     }
 
 
-def test_mcp_stdio_expands_environment_and_parses_quoted_arguments(
+def test_mcp_stdio_expands_command_and_maps_structured_args_and_env(
     monkeypatch: pytest.MonkeyPatch,
 ):
     monkeypatch.setenv("NAT_TEST_MCP_COMMAND", "/opt/nat/bin/mcp-server")
@@ -1005,13 +1005,23 @@ def test_mcp_stdio_expands_environment_and_parses_quoted_arguments(
         {
             "transport": "stdio",
             "url": "$NAT_TEST_MCP_COMMAND --label 'safe mode' --port 9000",
+            "args": ["--trace", "--request-timeout=10"],
+            "env": {"NAT_MCP_TOKEN": "test-token"},
         },
     )
 
     assert result == {
         "transport": "stdio",
         "command": "/opt/nat/bin/mcp-server",
-        "args": ["--label", "safe mode", "--port", "9000"],
+        "args": [
+            "--label",
+            "safe mode",
+            "--port",
+            "9000",
+            "--trace",
+            "--request-timeout=10",
+        ],
+        "env": {"NAT_MCP_TOKEN": "test-token"},
     }
 
 


### PR DESCRIPTION
#### Overview

Fix NAT stdio MCP configuration so the structured `args` and `env` fields in the capability plan are forwarded to NAT instead of being silently dropped. Document the resulting command, argument, and environment mapping in the NAT adapter README.

The NAT adapter is now on `main` through #175; this draft contains the focused fix, regression coverage, and its adapter documentation.

- [x] I confirm this contribution is my own work, or I have the right to submit it under this project's license.
- [x] I searched existing issues and open pull requests, and this does not duplicate existing work.

#### Details

- Appends structured MCP arguments to any legacy arguments parsed from the stdio command.
- Preserves configured process environment values in the NAT MCP server mapping.
- Documents argument ordering, environment forwarding, and URL-only variable expansion.
- Extends the stdio MCP regression test to cover inline arguments, structured arguments, and environment variables together.

#### Validation

- `uv run --no-sync pytest -q tests/adapters/test_external_nat_adapter.py` — 52 passed, 2 skipped after rebasing.
- `pre-commit run --files external/nat/README.md`.
- `just test-python` — full Python suite passed before rebasing; the rebase introduced no code conflicts.
- `uv run --with ruff ruff check ...`.
- `git diff --check`.

#### Where should the reviewer start?

Start with `nat_mcp_server_config` in `external/nat/src/nemo_fabric_adapters/nat/adapter.py`; the README directly below the MCP routing section and the regression coverage in `tests/adapters/test_external_nat_adapter.py` explain and test the behavior.

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- Relates to #175


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added NeMo Fabric integration for configuring and running NAT workflows.
  * Supports models, tools, MCP servers, function groups, system instructions, and tool policies.
  * Added asynchronous workflow execution with persistent runtime and session management.
  * MCP stdio servers now support command arguments and environment variables.

* **Reliability**
  * Added validation for configurations, runtime requests, invocations, and workflow results.
  * Errors are reported in a structured, non-retryable format with sensitive values redacted.

* **Documentation**
  * Documented MCP stdio URL expansion, argument handling, and environment forwarding.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->