### PR TITLE
docs: clarify workflow extension ownership

### DIFF
--- a/.agents/skills/contribute-adapter/SKILL.md
+++ b/.agents/skills/contribute-adapter/SKILL.md
@@ -90,9 +90,11 @@ Decide the following before implementation:
   `harness.settings` for adapter-wide harness behavior. When the adapter exposes
   selectable executables, use `FabricConfig.workflow` for the adapter-owned
   entry point and immutable construction settings, and declare a
-  `workflow_schema` that validates the complete block. The schema must reject
-  unsupported entry-point kinds, references, and settings before runtime
-  startup; include `null` only when the adapter provides a default workflow.
+  `workflow_schema` that validates the complete block. Workflow and entry-point
+  extensions are adapter-owned: declare every accepted field in the schema. The
+  schema must reject unsupported entry-point kinds, references, settings, and
+  extensions before runtime startup; include `null` only when the adapter
+  provides a default workflow.
 - Apply precedence in this order: normalized `config`; Fabric-resolved plans and
   runtime context; harness-specific settings; descriptor and adapter defaults.
   Let intentional overlaps layer by this order. Reject conflicting duplicate

--- a/skills/integrations/consumer/nemo-fabric-integrate/references/config-mapping.md
+++ b/skills/integrations/consumer/nemo-fabric-integrate/references/config-mapping.md
@@ -125,9 +125,12 @@ package or job layout, so nothing depends on the process working directory.
   `workflow.entrypoint.ref` identifies the workflow, and `workflow.settings`
   contains only its construction settings. Planning validates the complete
   block against the selected descriptor's `workflow_schema`. A configured
-  workflow fails when the descriptor does not declare that schema.
-- Use `metadata` and extension fields for caller-owned annotations NeMo Fabric carries
-  but does not interpret. Config `metadata` is not echoed into
+  workflow fails when the descriptor does not declare that schema. Workflow and
+  entry-point extensions are adapter-owned and must be declared by that schema;
+  a closed schema rejects undeclared fields. Do not use them for caller-owned
+  annotations.
+- Use `metadata` and extension fields outside `workflow` for caller-owned
+  annotations NeMo Fabric carries but does not interpret. Config `metadata` is not echoed into
   `RunResult.metadata`: the name surfaces as `RunResult.agent_name`, and for
   caller-owned correlation on a specific invocation set `RunRequest.request_id`,
   which is returned as `RunResult.request_id`.


### PR DESCRIPTION
#### Overview

Clarify that extensions within `FabricConfig.workflow` and `workflow.entrypoint` are adapter-owned when a descriptor validates the workflow. A closed `workflow_schema` rejects fields that it does not declare, so those extension points cannot carry caller-owned annotations.

#### Details

- Update the adapter-authoring skill to require declaring accepted workflow and entry-point extension fields in `workflow_schema`.
- Update the consumer config-mapping reference to distinguish workflow extensions from caller-owned annotations.

#### Validation

- Inspected `validate_workflow`, which serializes and validates the complete workflow object against the resolved descriptor schema.
- Confirmed the workflow test fixture closes both workflow and entry-point schemas with `additionalProperties: false`.
- `git diff --check`
- Not run: `just docs` and focused Python tests; `just` and `uv` are unavailable in this environment. This change does not modify the docs site, generated references, or runtime code.

#### Where should the reviewer start?

Start with `.agents/skills/contribute-adapter/SKILL.md`, then review `skills/integrations/consumer/nemo-fabric-integrate/references/config-mapping.md` for the caller-facing clarification.

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- Relates to: none

- [x] I confirm this contribution is my own work, or I have the right to submit it under this project's license.
- [x] I searched existing issues and open pull requests, and this does not duplicate existing work.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified adapter workflow guidance to require schema validation for workflow and entry-point extensions.
  * Documented that unsupported workflow fields are rejected by closed schemas.
  * Directed caller-owned annotations to metadata or supported extension fields.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->