### PR TITLE
fix: wait for Relay ATIF finalization

### DIFF
--- a/adapters/claude/src/nemo_fabric_adapters/claude/adapter.py
+++ b/adapters/claude/src/nemo_fabric_adapters/claude/adapter.py
@@ -32,6 +32,7 @@ from claude_agent_sdk import ResultMessage
 from claude_agent_sdk import HookMatcher
 from claude_agent_sdk._errors import MessageParseError
 from nemo_fabric_adapters.common import lifecycle
+from nemo_fabric_adapters.common import relay_artifacts
 from nemo_fabric_adapters.common import relay_gateway
 from nemo_fabric_adapters.common import relay_hooks
 from nemo_fabric_adapters.common import utils as common_utils
@@ -882,7 +883,7 @@ class ClaudeRuntime:
         if self._unusable:
             return _failure(
                 "claude_runtime_unavailable",
-                "Claude runtime cannot accept another invocation after an SDK failure",
+                "Claude runtime cannot accept another invocation after a runtime failure",
             )
 
         try:
@@ -891,12 +892,38 @@ class ClaudeRuntime:
         except ClaudeAdapterError as error:
             output = adapter_failure(error)
         else:
+            relay = self._relay
+            atif_before = (
+                relay_artifacts.snapshot_atif_paths(relay.plugin_config)
+                if relay is not None
+                and relay_artifacts.expects_local_atif(relay.plugin_config)
+                else None
+            )
             output = await self._run_query(
                 payload,
                 client,
                 prompt,
                 invocation_timeout,
             )
+            if (
+                output.get("completed")
+                and relay is not None
+                and atif_before is not None
+            ):
+                finalized = await relay_artifacts.wait_for_finalized_atif(
+                    relay.plugin_config, atif_before
+                )
+                if finalized is None:
+                    self._unusable = True
+                    output = adapter_failure(
+                        AdapterRelayError(
+                            "claude_relay_atif_timeout",
+                            "NeMo Relay did not finalize an ATIF artifact before the deadline",
+                            metadata={
+                                "timeout_seconds": relay_artifacts.ATIF_FINALIZATION_TIMEOUT_SECONDS,
+                            },
+                        )
+                    )
 
         if self._relay is not None:
             output = _relay_output(output, self._relay)

--- a/adapters/claude/src/nemo_fabric_adapters/claude/adapter.py
+++ b/adapters/claude/src/nemo_fabric_adapters/claude/adapter.py
@@ -894,7 +894,7 @@ class ClaudeRuntime:
         else:
             relay = self._relay
             atif_before = (
-                relay_artifacts.snapshot_atif_paths(relay.plugin_config)
+                relay_artifacts.snapshot_atif_files(relay.plugin_config)
                 if relay is not None
                 and relay_artifacts.expects_local_atif(relay.plugin_config)
                 else None

--- a/adapters/claude/src/nemo_fabric_adapters/claude/adapter.py
+++ b/adapters/claude/src/nemo_fabric_adapters/claude/adapter.py
@@ -727,6 +727,8 @@ def child_environment(
 def _relay_output(
     output: dict[str, Any],
     relay: ClaudeRelaySettings,
+    *,
+    artifacts: list[dict[str, str]] | None = None,
 ) -> dict[str, Any]:
     output["relay_runtime"] = {
         "enabled": True,
@@ -736,8 +738,10 @@ def _relay_output(
         "gateway_url": relay.gateway.url,
         "gateway_log_path": str(relay.gateway.log_path),
     }
-    output["relay_artifacts"] = common_utils.collect_relay_artifacts(
-        relay.plugin_config
+    output["relay_artifacts"] = (
+        common_utils.collect_relay_artifacts(relay.plugin_config)
+        if artifacts is None
+        else artifacts
     )
     return output
 
@@ -915,14 +919,18 @@ class ClaudeRuntime:
                 )
                 if finalized is None:
                     self._unusable = True
-                    output = adapter_failure(
-                        AdapterRelayError(
-                            "claude_relay_atif_timeout",
-                            "NeMo Relay did not finalize an ATIF artifact before the deadline",
-                            metadata={
-                                "timeout_seconds": relay_artifacts.ATIF_FINALIZATION_TIMEOUT_SECONDS,
-                            },
-                        )
+                    return _relay_output(
+                        adapter_failure(
+                            AdapterRelayError(
+                                "claude_relay_atif_timeout",
+                                "NeMo Relay did not finalize an ATIF artifact before the deadline",
+                                metadata={
+                                    "timeout_seconds": relay_artifacts.ATIF_FINALIZATION_TIMEOUT_SECONDS,
+                                },
+                            )
+                        ),
+                        relay,
+                        artifacts=[],
                     )
 
         if self._relay is not None:

--- a/adapters/codex/src/nemo_fabric_adapters/codex/adapter.py
+++ b/adapters/codex/src/nemo_fabric_adapters/codex/adapter.py
@@ -1078,7 +1078,7 @@ class CodexRuntime:
             _output_schema(payload)
             relay = self._relay
             atif_before = (
-                relay_artifacts.snapshot_atif_paths(relay.plugin_config)
+                relay_artifacts.snapshot_atif_files(relay.plugin_config)
                 if relay is not None
                 and relay_artifacts.expects_local_atif(relay.plugin_config)
                 else None

--- a/adapters/codex/src/nemo_fabric_adapters/codex/adapter.py
+++ b/adapters/codex/src/nemo_fabric_adapters/codex/adapter.py
@@ -1065,11 +1065,10 @@ class CodexRuntime:
             "request": invocation.get("request"),
         }
         if self._unusable:
-            output = _failure(
+            return _failure(
                 "codex_runtime_unavailable",
                 "Codex runtime cannot accept another invocation after a runtime failure",
             )
-            return _relay_output(output, self._relay) if self._relay else output
 
         try:
             request_prompt(payload)

--- a/adapters/codex/src/nemo_fabric_adapters/codex/adapter.py
+++ b/adapters/codex/src/nemo_fabric_adapters/codex/adapter.py
@@ -923,7 +923,12 @@ async def _invoke_thread(
         return sdk_failure(error), False
 
 
-def _relay_output(output: dict[str, Any], relay: CodexRelaySettings) -> dict[str, Any]:
+def _relay_output(
+    output: dict[str, Any],
+    relay: CodexRelaySettings,
+    *,
+    artifacts: list[dict[str, str]] | None = None,
+) -> dict[str, Any]:
     output["relay_runtime"] = {
         "enabled": True,
         "emitter": "codex-sdk/nemo-relay",
@@ -932,8 +937,10 @@ def _relay_output(output: dict[str, Any], relay: CodexRelaySettings) -> dict[str
         "gateway_url": relay.gateway.url,
         "gateway_log_path": str(relay.gateway.log_path),
     }
-    output["relay_artifacts"] = common_utils.collect_relay_artifacts(
-        relay.plugin_config
+    output["relay_artifacts"] = (
+        common_utils.collect_relay_artifacts(relay.plugin_config)
+        if artifacts is None
+        else artifacts
     )
     return output
 
@@ -1092,12 +1099,19 @@ class CodexRuntime:
                     relay.plugin_config, atif_before
                 )
                 if finalized is None:
-                    raise AdapterRelayError(
-                        "codex_relay_atif_timeout",
-                        "NeMo Relay did not finalize an ATIF artifact before the deadline",
-                        metadata={
-                            "timeout_seconds": relay_artifacts.ATIF_FINALIZATION_TIMEOUT_SECONDS,
-                        },
+                    self._unusable = True
+                    return _relay_output(
+                        adapter_failure(
+                            AdapterRelayError(
+                                "codex_relay_atif_timeout",
+                                "NeMo Relay did not finalize an ATIF artifact before the deadline",
+                                metadata={
+                                    "timeout_seconds": relay_artifacts.ATIF_FINALIZATION_TIMEOUT_SECONDS,
+                                },
+                            )
+                        ),
+                        relay,
+                        artifacts=[],
                     )
         except AdapterRelayError as error:
             output = adapter_failure(error)

--- a/adapters/codex/src/nemo_fabric_adapters/codex/adapter.py
+++ b/adapters/codex/src/nemo_fabric_adapters/codex/adapter.py
@@ -7,7 +7,6 @@
 from __future__ import annotations
 
 import asyncio
-import hashlib
 import json
 import logging
 import math
@@ -33,14 +32,13 @@ from openai_codex.types import Personality, ReasoningEffort, TurnStatus
 
 import nemo_fabric_adapters.common.relay_gateway as relay_gateway
 import nemo_fabric_adapters.common.relay_hooks as relay_hooks
+import nemo_fabric_adapters.common.relay_artifacts as relay_artifacts
 import nemo_fabric_adapters.common.utils as common_utils
 from nemo_fabric_adapters.common import lifecycle
 
 
 DEFAULT_TIMEOUT_SECONDS = 1800.0
 INTERRUPT_TIMEOUT_SECONDS = 5.0
-RELAY_ATIF_FINALIZATION_TIMEOUT_SECONDS = 5.0
-RELAY_ATIF_POLL_INTERVAL_SECONDS = 0.05
 SANDBOXES = {
     "read-only": Sandbox.read_only,
     "workspace-write": Sandbox.workspace_write,
@@ -940,83 +938,6 @@ def _relay_output(output: dict[str, Any], relay: CodexRelaySettings) -> dict[str
     return output
 
 
-def _relay_atif_enabled(plugin_config: dict[str, Any]) -> bool:
-    for component in plugin_config.get("components", []):
-        if (
-            not isinstance(component, dict)
-            or component.get("kind") != "observability"
-            or component.get("enabled", True) is False
-        ):
-            continue
-        config = component.get("config")
-        if not isinstance(config, dict):
-            continue
-        atif = config.get("atif")
-        if isinstance(atif, dict) and atif.get("enabled"):
-            return True
-    return False
-
-
-def _relay_atif_snapshot(plugin_config: dict[str, Any]) -> dict[Path, bytes]:
-    """Fingerprint runtime-scoped ATIF files before a Codex turn starts."""
-
-    snapshot: dict[Path, bytes] = {}
-    for artifact in common_utils.collect_relay_artifacts(plugin_config):
-        if artifact.get("kind") != "atif":
-            continue
-        path = Path(artifact["path"])
-        try:
-            contents = path.read_bytes()
-        except (OSError, RuntimeError, ValueError):
-            continue
-        snapshot[path] = hashlib.sha256(contents).digest()
-    return snapshot
-
-
-def _relay_has_finalized_atif(
-    plugin_config: dict[str, Any], before: dict[Path, bytes]
-) -> bool:
-    """Return whether a new or changed ATIF file is complete JSON."""
-
-    for artifact in common_utils.collect_relay_artifacts(plugin_config):
-        if artifact.get("kind") != "atif":
-            continue
-        path = Path(artifact["path"])
-        try:
-            contents = path.read_bytes()
-        except (OSError, RuntimeError, ValueError):
-            continue
-        if before.get(path) == hashlib.sha256(contents).digest():
-            continue
-        try:
-            document = json.loads(contents)
-        except (UnicodeDecodeError, json.JSONDecodeError):
-            continue
-        if isinstance(document, dict):
-            return True
-    return False
-
-
-async def _wait_for_relay_atif(
-    plugin_config: dict[str, Any], before: dict[Path, bytes]
-) -> None:
-    """Bound the gap between Codex turn completion and Relay subscriber output."""
-
-    loop = asyncio.get_running_loop()
-    deadline = loop.time() + RELAY_ATIF_FINALIZATION_TIMEOUT_SECONDS
-    while not _relay_has_finalized_atif(plugin_config, before):
-        remaining = deadline - loop.time()
-        if remaining <= 0:
-            raise AdapterRelayError(
-                "codex_relay_atif_timeout",
-                "NeMo Relay did not finalize an ATIF artifact before the deadline",
-                metadata={
-                    "timeout_seconds": RELAY_ATIF_FINALIZATION_TIMEOUT_SECONDS,
-                },
-            )
-        await asyncio.sleep(min(RELAY_ATIF_POLL_INTERVAL_SECONDS, remaining))
-
-
 def _start_relay_gateway(
     payload: dict[str, Any], relay: CodexRelaySettings | None
 ) -> subprocess.Popen[Any] | None:
@@ -1146,7 +1067,7 @@ class CodexRuntime:
         if self._unusable:
             output = _failure(
                 "codex_runtime_unavailable",
-                "Codex runtime cannot accept another invocation after an SDK failure",
+                "Codex runtime cannot accept another invocation after a runtime failure",
             )
             return _relay_output(output, self._relay) if self._relay else output
 
@@ -1157,8 +1078,9 @@ class CodexRuntime:
             _output_schema(payload)
             relay = self._relay
             atif_before = (
-                _relay_atif_snapshot(relay.plugin_config)
-                if relay is not None and _relay_atif_enabled(relay.plugin_config)
+                relay_artifacts.snapshot_atif_paths(relay.plugin_config)
+                if relay is not None
+                and relay_artifacts.expects_local_atif(relay.plugin_config)
                 else None
             )
             output, usable = await _invoke_thread(payload, self._thread)
@@ -1167,7 +1089,20 @@ class CodexRuntime:
                 and relay is not None
                 and atif_before is not None
             ):
-                await _wait_for_relay_atif(relay.plugin_config, atif_before)
+                finalized = await relay_artifacts.wait_for_finalized_atif(
+                    relay.plugin_config, atif_before
+                )
+                if finalized is None:
+                    raise AdapterRelayError(
+                        "codex_relay_atif_timeout",
+                        "NeMo Relay did not finalize an ATIF artifact before the deadline",
+                        metadata={
+                            "timeout_seconds": relay_artifacts.ATIF_FINALIZATION_TIMEOUT_SECONDS,
+                        },
+                    )
+        except AdapterRelayError as error:
+            output = adapter_failure(error)
+            usable = False
         except CodexAdapterError as error:
             output = adapter_failure(error)
             usable = True

--- a/adapters/codex/src/nemo_fabric_adapters/codex/adapter.py
+++ b/adapters/codex/src/nemo_fabric_adapters/codex/adapter.py
@@ -7,6 +7,7 @@
 from __future__ import annotations
 
 import asyncio
+import hashlib
 import json
 import logging
 import math
@@ -38,6 +39,8 @@ from nemo_fabric_adapters.common import lifecycle
 
 DEFAULT_TIMEOUT_SECONDS = 1800.0
 INTERRUPT_TIMEOUT_SECONDS = 5.0
+RELAY_ATIF_FINALIZATION_TIMEOUT_SECONDS = 5.0
+RELAY_ATIF_POLL_INTERVAL_SECONDS = 0.05
 SANDBOXES = {
     "read-only": Sandbox.read_only,
     "workspace-write": Sandbox.workspace_write,
@@ -937,6 +940,83 @@ def _relay_output(output: dict[str, Any], relay: CodexRelaySettings) -> dict[str
     return output
 
 
+def _relay_atif_enabled(plugin_config: dict[str, Any]) -> bool:
+    for component in plugin_config.get("components", []):
+        if (
+            not isinstance(component, dict)
+            or component.get("kind") != "observability"
+            or component.get("enabled", True) is False
+        ):
+            continue
+        config = component.get("config")
+        if not isinstance(config, dict):
+            continue
+        atif = config.get("atif")
+        if isinstance(atif, dict) and atif.get("enabled"):
+            return True
+    return False
+
+
+def _relay_atif_snapshot(plugin_config: dict[str, Any]) -> dict[Path, bytes]:
+    """Fingerprint runtime-scoped ATIF files before a Codex turn starts."""
+
+    snapshot: dict[Path, bytes] = {}
+    for artifact in common_utils.collect_relay_artifacts(plugin_config):
+        if artifact.get("kind") != "atif":
+            continue
+        path = Path(artifact["path"])
+        try:
+            contents = path.read_bytes()
+        except (OSError, RuntimeError, ValueError):
+            continue
+        snapshot[path] = hashlib.sha256(contents).digest()
+    return snapshot
+
+
+def _relay_has_finalized_atif(
+    plugin_config: dict[str, Any], before: dict[Path, bytes]
+) -> bool:
+    """Return whether a new or changed ATIF file is complete JSON."""
+
+    for artifact in common_utils.collect_relay_artifacts(plugin_config):
+        if artifact.get("kind") != "atif":
+            continue
+        path = Path(artifact["path"])
+        try:
+            contents = path.read_bytes()
+        except (OSError, RuntimeError, ValueError):
+            continue
+        if before.get(path) == hashlib.sha256(contents).digest():
+            continue
+        try:
+            document = json.loads(contents)
+        except (UnicodeDecodeError, json.JSONDecodeError):
+            continue
+        if isinstance(document, dict):
+            return True
+    return False
+
+
+async def _wait_for_relay_atif(
+    plugin_config: dict[str, Any], before: dict[Path, bytes]
+) -> None:
+    """Bound the gap between Codex turn completion and Relay subscriber output."""
+
+    loop = asyncio.get_running_loop()
+    deadline = loop.time() + RELAY_ATIF_FINALIZATION_TIMEOUT_SECONDS
+    while not _relay_has_finalized_atif(plugin_config, before):
+        remaining = deadline - loop.time()
+        if remaining <= 0:
+            raise AdapterRelayError(
+                "codex_relay_atif_timeout",
+                "NeMo Relay did not finalize an ATIF artifact before the deadline",
+                metadata={
+                    "timeout_seconds": RELAY_ATIF_FINALIZATION_TIMEOUT_SECONDS,
+                },
+            )
+        await asyncio.sleep(min(RELAY_ATIF_POLL_INTERVAL_SECONDS, remaining))
+
+
 def _start_relay_gateway(
     payload: dict[str, Any], relay: CodexRelaySettings | None
 ) -> subprocess.Popen[Any] | None:
@@ -1075,7 +1155,19 @@ class CodexRuntime:
             timeout_seconds(payload)
             _reasoning_effort(payload)
             _output_schema(payload)
+            relay = self._relay
+            atif_before = (
+                _relay_atif_snapshot(relay.plugin_config)
+                if relay is not None and _relay_atif_enabled(relay.plugin_config)
+                else None
+            )
             output, usable = await _invoke_thread(payload, self._thread)
+            if (
+                output.get("completed")
+                and relay is not None
+                and atif_before is not None
+            ):
+                await _wait_for_relay_atif(relay.plugin_config, atif_before)
         except CodexAdapterError as error:
             output = adapter_failure(error)
             usable = True

--- a/adapters/common/src/nemo_fabric_adapters/common/relay_artifacts.py
+++ b/adapters/common/src/nemo_fabric_adapters/common/relay_artifacts.py
@@ -1,0 +1,93 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Readiness checks for artifacts written asynchronously by NeMo Relay."""
+
+from __future__ import annotations
+
+import asyncio
+import json
+from collections.abc import Collection
+from pathlib import Path
+from typing import Any
+
+from nemo_fabric_adapters.common import utils as common_utils
+
+ATIF_FINALIZATION_TIMEOUT_SECONDS = 5.0
+ATIF_POLL_INTERVAL_SECONDS = 0.05
+
+
+def expects_local_atif(plugin_config: dict[str, Any]) -> bool:
+    """Return whether Relay is configured to write ATIF to the local runtime.
+
+    Relay treats a non-empty storage list as remote-only, so there is no local
+    artifact for an adapter to await in that configuration.
+    """
+
+    for component in plugin_config.get("components", []):
+        if (
+            not isinstance(component, dict)
+            or component.get("kind") != "observability"
+            or component.get("enabled", True) is False
+        ):
+            continue
+        config = component.get("config")
+        if not isinstance(config, dict):
+            continue
+        atif = config.get("atif")
+        if isinstance(atif, dict) and atif.get("enabled") and not atif.get("storage"):
+            return True
+    return False
+
+
+def snapshot_atif_paths(plugin_config: dict[str, Any]) -> frozenset[Path]:
+    """Capture ATIF paths that existed before an adapter invocation.
+
+    Relay requires ``{session_id}`` in the ATIF filename template and creates a
+    new session scope for each turn. Existing paths therefore cannot satisfy a
+    later invocation, even if another process modifies them.
+    """
+
+    return frozenset(
+        Path(artifact["path"])
+        for artifact in common_utils.collect_relay_artifacts(plugin_config)
+        if artifact.get("kind") == "atif"
+    )
+
+
+def _finalized_atif_path(
+    plugin_config: dict[str, Any], before: Collection[Path]
+) -> Path | None:
+    """Find a newly created ATIF path containing a complete JSON object."""
+
+    current = snapshot_atif_paths(plugin_config)
+    for path in sorted(current.difference(before)):
+        try:
+            # Relay writes directly to the final path, so existence alone does
+            # not prove that the JSON payload has been written completely.
+            document = json.loads(path.read_bytes())
+        except (OSError, UnicodeDecodeError, json.JSONDecodeError):
+            continue
+        if isinstance(document, dict):
+            return path
+    return None
+
+
+async def wait_for_finalized_atif(
+    plugin_config: dict[str, Any],
+    before: Collection[Path],
+    *,
+    timeout_seconds: float = ATIF_FINALIZATION_TIMEOUT_SECONDS,
+    poll_interval_seconds: float = ATIF_POLL_INTERVAL_SECONDS,
+) -> Path | None:
+    """Wait for one new, complete ATIF file until a monotonic deadline."""
+
+    loop = asyncio.get_running_loop()
+    deadline = loop.time() + timeout_seconds
+    while True:
+        if path := _finalized_atif_path(plugin_config, before):
+            return path
+        remaining = deadline - loop.time()
+        if remaining <= 0:
+            return None
+        await asyncio.sleep(min(poll_interval_seconds, remaining))

--- a/adapters/common/src/nemo_fabric_adapters/common/relay_artifacts.py
+++ b/adapters/common/src/nemo_fabric_adapters/common/relay_artifacts.py
@@ -7,7 +7,6 @@ from __future__ import annotations
 
 import asyncio
 import json
-from collections.abc import Collection
 from pathlib import Path
 from typing import Any
 
@@ -15,6 +14,8 @@ from nemo_fabric_adapters.common import utils as common_utils
 
 ATIF_FINALIZATION_TIMEOUT_SECONDS = 5.0
 ATIF_POLL_INTERVAL_SECONDS = 0.05
+AtifFileFingerprint = tuple[int, int, int, int]
+AtifSnapshot = dict[Path, AtifFileFingerprint]
 
 
 def expects_local_atif(plugin_config: dict[str, Any]) -> bool:
@@ -40,28 +41,43 @@ def expects_local_atif(plugin_config: dict[str, Any]) -> bool:
     return False
 
 
-def snapshot_atif_paths(plugin_config: dict[str, Any]) -> frozenset[Path]:
-    """Capture ATIF paths that existed before an adapter invocation.
+def _atif_fingerprint(path: Path) -> AtifFileFingerprint | None:
+    try:
+        status = path.stat()
+    except (OSError, RuntimeError, ValueError):
+        return None
+    return (status.st_dev, status.st_ino, status.st_size, status.st_mtime_ns)
+
+
+def snapshot_atif_files(plugin_config: dict[str, Any]) -> AtifSnapshot:
+    """Capture ATIF file metadata before an adapter invocation.
 
     Relay requires ``{session_id}`` in the ATIF filename template and creates a
-    new session scope for each turn. Existing paths therefore cannot satisfy a
-    later invocation, even if another process modifies them.
+    new session scope for each turn, so a new path is the normal case. Metadata
+    fingerprints also detect a writer that rewrites an existing path without
+    reading or hashing artifacts from prior turns.
     """
 
-    return frozenset(
-        Path(artifact["path"])
-        for artifact in common_utils.collect_relay_artifacts(plugin_config)
-        if artifact.get("kind") == "atif"
-    )
+    snapshot: AtifSnapshot = {}
+    for artifact in common_utils.collect_relay_artifacts(plugin_config):
+        if artifact.get("kind") != "atif":
+            continue
+        path = Path(artifact["path"])
+        fingerprint = _atif_fingerprint(path)
+        if fingerprint is not None:
+            snapshot[path] = fingerprint
+    return snapshot
 
 
 def _finalized_atif_path(
-    plugin_config: dict[str, Any], before: Collection[Path]
+    plugin_config: dict[str, Any], before: AtifSnapshot
 ) -> Path | None:
-    """Find a newly created ATIF path containing a complete JSON object."""
+    """Find a new or changed ATIF path containing a complete JSON object."""
 
-    current = snapshot_atif_paths(plugin_config)
-    for path in sorted(current.difference(before)):
+    current = snapshot_atif_files(plugin_config)
+    for path in sorted(current):
+        if before.get(path) == current[path]:
+            continue
         try:
             # Relay writes directly to the final path, so existence alone does
             # not prove that the JSON payload has been written completely.
@@ -75,12 +91,12 @@ def _finalized_atif_path(
 
 async def wait_for_finalized_atif(
     plugin_config: dict[str, Any],
-    before: Collection[Path],
+    before: AtifSnapshot,
     *,
     timeout_seconds: float = ATIF_FINALIZATION_TIMEOUT_SECONDS,
     poll_interval_seconds: float = ATIF_POLL_INTERVAL_SECONDS,
 ) -> Path | None:
-    """Wait for one new, complete ATIF file until a monotonic deadline."""
+    """Wait for one new or changed, complete ATIF file until a deadline."""
 
     loop = asyncio.get_running_loop()
     deadline = loop.time() + timeout_seconds

--- a/tests/adapters/test_adapters_common_relay_artifacts.py
+++ b/tests/adapters/test_adapters_common_relay_artifacts.py
@@ -51,7 +51,7 @@ def test_expects_local_atif_requires_enabled_local_output(tmp_path):
     assert relay_artifacts.expects_local_atif({"components": []}) is False
 
 
-async def test_wait_for_finalized_atif_ignores_existing_and_partial_files(
+async def test_wait_for_finalized_atif_ignores_unchanged_and_partial_files(
     tmp_path, monkeypatch
 ):
     atif_dir = tmp_path / "atif"
@@ -60,7 +60,7 @@ async def test_wait_for_finalized_atif_ignores_existing_and_partial_files(
     candidate = atif_dir / "trajectory-current.atif.json"
     existing.write_text('{"schema_version":"ATIF-v1.7"}', encoding="utf-8")
     plugin_config = atif_plugin_config(atif_dir)
-    before = relay_artifacts.snapshot_atif_paths(plugin_config)
+    before = relay_artifacts.snapshot_atif_files(plugin_config)
     reads: list[Path] = []
     read_bytes = Path.read_bytes
 
@@ -71,7 +71,6 @@ async def test_wait_for_finalized_atif_ignores_existing_and_partial_files(
     monkeypatch.setattr(Path, "read_bytes", record_read)
 
     async def finish_candidate():
-        existing.write_text('{"schema_version":"changed"}', encoding="utf-8")
         candidate.write_text("{", encoding="utf-8")
         await asyncio.sleep(0.02)
         candidate.write_text(
@@ -88,9 +87,31 @@ async def test_wait_for_finalized_atif_ignores_existing_and_partial_files(
     )
     await writer
 
-    assert before == frozenset({existing.resolve()})
+    assert set(before) == {existing.resolve()}
     assert finalized == candidate.resolve()
     assert set(reads) == {candidate.resolve()}
+
+
+async def test_wait_for_finalized_atif_accepts_modified_existing_path(tmp_path):
+    atif_dir = tmp_path / "atif"
+    atif_dir.mkdir()
+    existing = atif_dir / "trajectory-existing.atif.json"
+    existing.write_text('{"schema_version":"ATIF-v1.7"}', encoding="utf-8")
+    plugin_config = atif_plugin_config(atif_dir)
+    before = relay_artifacts.snapshot_atif_files(plugin_config)
+    existing.write_text(
+        json.dumps({"schema_version": "ATIF-v1.7", "steps": [{"step_id": 1}]}),
+        encoding="utf-8",
+    )
+
+    finalized = await relay_artifacts.wait_for_finalized_atif(
+        plugin_config,
+        before,
+        timeout_seconds=0.5,
+        poll_interval_seconds=0.001,
+    )
+
+    assert finalized == existing.resolve()
 
 
 async def test_wait_for_finalized_atif_has_a_hard_deadline(tmp_path):
@@ -100,7 +121,7 @@ async def test_wait_for_finalized_atif_has_a_hard_deadline(tmp_path):
 
     finalized = await relay_artifacts.wait_for_finalized_atif(
         plugin_config,
-        relay_artifacts.snapshot_atif_paths(plugin_config),
+        relay_artifacts.snapshot_atif_files(plugin_config),
         timeout_seconds=0.01,
         poll_interval_seconds=0.001,
     )
@@ -129,13 +150,13 @@ async def test_wait_for_finalized_atif_isolated_by_runtime_directory(tmp_path):
     second_writer = asyncio.create_task(write_atif(second_dir, "second", 0.01))
     first_wait = relay_artifacts.wait_for_finalized_atif(
         first_config,
-        relay_artifacts.snapshot_atif_paths(first_config),
+        relay_artifacts.snapshot_atif_files(first_config),
         timeout_seconds=0.5,
         poll_interval_seconds=0.001,
     )
     second_wait = relay_artifacts.wait_for_finalized_atif(
         second_config,
-        relay_artifacts.snapshot_atif_paths(second_config),
+        relay_artifacts.snapshot_atif_files(second_config),
         timeout_seconds=0.5,
         poll_interval_seconds=0.001,
     )

--- a/tests/adapters/test_adapters_common_relay_artifacts.py
+++ b/tests/adapters/test_adapters_common_relay_artifacts.py
@@ -1,0 +1,148 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+import asyncio
+import json
+from pathlib import Path
+from typing import Any
+
+import pytest
+from nemo_fabric_adapters.common import relay_artifacts
+
+
+def atif_plugin_config(
+    output_directory: Path,
+    *,
+    component_enabled: bool = True,
+    storage: list[dict[str, Any]] | None = None,
+) -> dict[str, Any]:
+    atif: dict[str, Any] = {
+        "enabled": True,
+        "output_directory": str(output_directory),
+        "filename_template": "trajectory-{session_id}.atif.json",
+    }
+    if storage is not None:
+        atif["storage"] = storage
+    return {
+        "version": 1,
+        "components": [
+            {
+                "kind": "observability",
+                "enabled": component_enabled,
+                "config": {"atif": atif},
+            }
+        ],
+    }
+
+
+def test_expects_local_atif_requires_enabled_local_output(tmp_path):
+    local = atif_plugin_config(tmp_path / "local")
+    disabled = atif_plugin_config(tmp_path / "disabled", component_enabled=False)
+    remote = atif_plugin_config(
+        tmp_path / "remote",
+        storage=[{"type": "http", "endpoint": "https://example.test/atif"}],
+    )
+
+    assert relay_artifacts.expects_local_atif(local) is True
+    assert relay_artifacts.expects_local_atif(disabled) is False
+    assert relay_artifacts.expects_local_atif(remote) is False
+    assert relay_artifacts.expects_local_atif({"components": []}) is False
+
+
+async def test_wait_for_finalized_atif_ignores_existing_and_partial_files(
+    tmp_path, monkeypatch
+):
+    atif_dir = tmp_path / "atif"
+    atif_dir.mkdir()
+    existing = atif_dir / "trajectory-existing.atif.json"
+    candidate = atif_dir / "trajectory-current.atif.json"
+    existing.write_text('{"schema_version":"ATIF-v1.7"}', encoding="utf-8")
+    plugin_config = atif_plugin_config(atif_dir)
+    before = relay_artifacts.snapshot_atif_paths(plugin_config)
+    reads: list[Path] = []
+    read_bytes = Path.read_bytes
+
+    def record_read(path: Path) -> bytes:
+        reads.append(path)
+        return read_bytes(path)
+
+    monkeypatch.setattr(Path, "read_bytes", record_read)
+
+    async def finish_candidate():
+        existing.write_text('{"schema_version":"changed"}', encoding="utf-8")
+        candidate.write_text("{", encoding="utf-8")
+        await asyncio.sleep(0.02)
+        candidate.write_text(
+            json.dumps({"schema_version": "ATIF-v1.7", "steps": []}),
+            encoding="utf-8",
+        )
+
+    writer = asyncio.create_task(finish_candidate())
+    finalized = await relay_artifacts.wait_for_finalized_atif(
+        plugin_config,
+        before,
+        timeout_seconds=0.5,
+        poll_interval_seconds=0.001,
+    )
+    await writer
+
+    assert before == frozenset({existing.resolve()})
+    assert finalized == candidate.resolve()
+    assert set(reads) == {candidate.resolve()}
+
+
+async def test_wait_for_finalized_atif_has_a_hard_deadline(tmp_path):
+    atif_dir = tmp_path / "atif"
+    atif_dir.mkdir()
+    plugin_config = atif_plugin_config(atif_dir)
+
+    finalized = await relay_artifacts.wait_for_finalized_atif(
+        plugin_config,
+        relay_artifacts.snapshot_atif_paths(plugin_config),
+        timeout_seconds=0.01,
+        poll_interval_seconds=0.001,
+    )
+
+    assert finalized is None
+
+
+async def test_wait_for_finalized_atif_isolated_by_runtime_directory(tmp_path):
+    first_dir = tmp_path / "runtime-1"
+    second_dir = tmp_path / "runtime-2"
+    first_dir.mkdir()
+    second_dir.mkdir()
+    first_config = atif_plugin_config(first_dir)
+    second_config = atif_plugin_config(second_dir)
+
+    async def write_atif(directory: Path, session_id: str, delay: float):
+        await asyncio.sleep(delay)
+        path = directory / f"trajectory-{session_id}.atif.json"
+        path.write_text(
+            json.dumps({"schema_version": "ATIF-v1.7", "steps": []}),
+            encoding="utf-8",
+        )
+        return path.resolve()
+
+    first_writer = asyncio.create_task(write_atif(first_dir, "first", 0.02))
+    second_writer = asyncio.create_task(write_atif(second_dir, "second", 0.01))
+    first_wait = relay_artifacts.wait_for_finalized_atif(
+        first_config,
+        relay_artifacts.snapshot_atif_paths(first_config),
+        timeout_seconds=0.5,
+        poll_interval_seconds=0.001,
+    )
+    second_wait = relay_artifacts.wait_for_finalized_atif(
+        second_config,
+        relay_artifacts.snapshot_atif_paths(second_config),
+        timeout_seconds=0.5,
+        poll_interval_seconds=0.001,
+    )
+
+    first_finalized, second_finalized, first_path, second_path = await asyncio.gather(
+        first_wait, second_wait, first_writer, second_writer
+    )
+
+    assert first_finalized == first_path
+    assert second_finalized == second_path

--- a/tests/adapters/test_claude_adapter.py
+++ b/tests/adapters/test_claude_adapter.py
@@ -752,10 +752,33 @@ async def test_claude_runtime_owns_one_relay_gateway_until_stop(
     assert not relay.plugin_path.exists()
 
 
-async def test_runtime_reports_relay_artifacts(relay_payload, monkeypatch, tmp_path):
+def atif_plugin_config(output_directory: Path) -> dict[str, Any]:
+    return {
+        "version": 1,
+        "components": [
+            {
+                "kind": "observability",
+                "enabled": True,
+                "config": {
+                    "atif": {
+                        "enabled": True,
+                        "output_directory": str(output_directory),
+                        "filename_template": "trajectory-{session_id}.atif.json",
+                    }
+                },
+            }
+        ],
+    }
+
+
+def relay_settings(
+    tmp_path: Path, plugin_config: dict[str, Any]
+) -> adapter.ClaudeRelaySettings:
     executable = tmp_path / "nemo-relay"
     executable.touch()
-    relay = adapter.ClaudeRelaySettings(
+    plugin_path = tmp_path / "relay-plugin"
+    plugin_path.mkdir()
+    return adapter.ClaudeRelaySettings(
         gateway=adapter.relay_gateway.RelayGatewayLaunch(
             executable=executable,
             config_path=tmp_path / "relay-config" / "config.toml",
@@ -763,40 +786,48 @@ async def test_runtime_reports_relay_artifacts(relay_payload, monkeypatch, tmp_p
             url="http://127.0.0.1:43210",
             log_path=tmp_path / "relay-config" / "gateway.log",
         ),
-        plugin_config={
-            "version": 1,
-            "components": [
-                {
-                    "kind": "observability",
-                    "enabled": True,
-                    "config": {
-                        "atif": {
-                            "enabled": True,
-                            "output_directory": str(tmp_path / "atif"),
-                            "filename_template": "trajectory-{session_id}.atif.json",
-                        }
-                    },
-                }
-            ],
-        },
-        plugin_path=tmp_path / "relay-plugin",
+        plugin_config=plugin_config,
+        plugin_path=plugin_path,
     )
-    relay.plugin_path.mkdir()
+
+
+def install_mock_relay(
+    monkeypatch: pytest.MonkeyPatch, relay: adapter.ClaudeRelaySettings
+) -> tuple[MagicMock, MagicMock, MagicMock]:
     relay.gateway.log_path.parent.mkdir()
     relay.gateway.log_path.write_text("gateway started\n", encoding="utf-8")
-    atif_path = tmp_path / "atif" / "trajectory-session.atif.json"
-    atif_path.parent.mkdir()
-    atif_path.write_text("{}", encoding="utf-8")
     process = MagicMock()
     mock_start = MagicMock(return_value=process)
     mock_stop = MagicMock()
     monkeypatch.setattr(adapter, "prepare_claude_relay", MagicMock(return_value=relay))
     monkeypatch.setattr(adapter.relay_gateway, "start_relay_gateway", mock_start)
     monkeypatch.setattr(adapter.relay_gateway, "stop_relay_gateway", mock_stop)
+    return process, mock_start, mock_stop
+
+
+async def test_runtime_waits_for_delayed_relay_artifact(
+    relay_payload, monkeypatch, tmp_path
+):
+    atif_dir = tmp_path / "atif"
+    atif_dir.mkdir()
+    atif_path = atif_dir / "trajectory-session.atif.json"
+    relay = relay_settings(tmp_path, atif_plugin_config(atif_dir))
+    process, mock_start, mock_stop = install_mock_relay(monkeypatch, relay)
+    write_task = None
 
     async def responses(client) -> AsyncIterator[ResultMessage]:
+        nonlocal write_task
         assert client.options.env["ANTHROPIC_BASE_URL"] == relay.gateway.url
         assert Path(client.options.plugins[-1]["path"]) == relay.plugin_path
+
+        async def write_atif():
+            await asyncio.sleep(0.05)
+            atif_path.write_text(
+                json.dumps({"schema_version": "ATIF-v1.7", "steps": []}),
+                encoding="utf-8",
+            )
+
+        write_task = asyncio.create_task(write_atif())
         yield ResultMessage(
             subtype="success",
             duration_ms=10,
@@ -815,8 +846,12 @@ async def test_runtime_reports_relay_artifacts(relay_payload, monkeypatch, tmp_p
         key: value for key, value in relay_payload.items() if key != "request"
     }
     await runtime.start(start_payload)
-    output = await runtime.invoke(lifecycle_invocation(relay_payload))
-    await runtime.stop()
+    try:
+        output = await runtime.invoke(lifecycle_invocation(relay_payload))
+        assert write_task is not None
+        await write_task
+    finally:
+        await runtime.stop()
 
     assert output["relay_runtime"] == {
         "enabled": True,
@@ -833,6 +868,57 @@ async def test_runtime_reports_relay_artifacts(relay_payload, monkeypatch, tmp_p
     )
     mock_stop.assert_called_once_with(process)
     assert not relay.plugin_path.exists()
+
+
+async def test_relay_atif_timeout_fails_successful_turn_explicitly(
+    relay_payload, monkeypatch, tmp_path
+):
+    atif_dir = tmp_path / "atif"
+    atif_dir.mkdir()
+    stale_atif = atif_dir / "trajectory-existing.atif.json"
+    stale_atif.write_text("{}", encoding="utf-8")
+    relay = relay_settings(tmp_path, atif_plugin_config(atif_dir))
+    install_mock_relay(monkeypatch, relay)
+    wait_for_atif = AsyncMock(return_value=None)
+    monkeypatch.setattr(
+        adapter.relay_artifacts, "wait_for_finalized_atif", wait_for_atif
+    )
+
+    async def responses(_client) -> AsyncIterator[ResultMessage]:
+        yield ResultMessage(
+            subtype="success",
+            duration_ms=10,
+            duration_api_ms=8,
+            is_error=False,
+            num_turns=1,
+            session_id="claude-session",
+            total_cost_usd=0.01,
+            usage={"input_tokens": 1, "output_tokens": 1},
+            result="done",
+        )
+
+    install_fake_client(monkeypatch, responses)
+    runtime = adapter.ClaudeRuntime()
+    start_payload = {
+        key: value for key, value in relay_payload.items() if key != "request"
+    }
+    await runtime.start(start_payload)
+    try:
+        output = await runtime.invoke(lifecycle_invocation(relay_payload))
+        unavailable = await runtime.invoke(lifecycle_invocation(relay_payload))
+    finally:
+        await runtime.stop()
+
+    assert output["error"] == {
+        "code": "claude_relay_atif_timeout",
+        "message": "NeMo Relay did not finalize an ATIF artifact before the deadline",
+        "retryable": False,
+        "metadata": {
+            "timeout_seconds": adapter.relay_artifacts.ATIF_FINALIZATION_TIMEOUT_SECONDS
+        },
+    }
+    wait_for_atif.assert_awaited_once()
+    assert unavailable["error"]["code"] == "claude_runtime_unavailable"
 
 
 async def test_runtime_stop_reports_relay_gateway_failure(

--- a/tests/adapters/test_claude_adapter.py
+++ b/tests/adapters/test_claude_adapter.py
@@ -919,7 +919,11 @@ async def test_relay_atif_timeout_fails_successful_turn_explicitly(
         },
     }
     wait_for_atif.assert_awaited_once()
+    assert output["relay_runtime"]["enabled"] is True
+    assert output["relay_artifacts"] == []
     assert unavailable["error"]["code"] == "claude_runtime_unavailable"
+    assert "relay_runtime" not in unavailable
+    assert "relay_artifacts" not in unavailable
 
 
 async def test_runtime_stop_reports_relay_gateway_failure(

--- a/tests/adapters/test_claude_adapter.py
+++ b/tests/adapters/test_claude_adapter.py
@@ -909,6 +909,7 @@ async def test_relay_atif_timeout_fails_successful_turn_explicitly(
     finally:
         await runtime.stop()
 
+    assert output["failed"] is True
     assert output["error"] == {
         "code": "claude_relay_atif_timeout",
         "message": "NeMo Relay did not finalize an ATIF artifact before the deadline",

--- a/tests/adapters/test_codex_adapter.py
+++ b/tests/adapters/test_codex_adapter.py
@@ -641,8 +641,7 @@ async def test_relay_atif_timeout_fails_successful_turn_explicitly(
     }
     atif_dir = tmp_path / "relay" / "atif"
     atif_dir.mkdir(parents=True)
-    stale_atif = atif_dir / "trajectory-session.atif.json"
-    stale_atif.write_text('{"schema_version":"ATIF-v1.7","steps":[]}', encoding="utf-8")
+    late_atif = atif_dir / "trajectory-late.atif.json"
     relay = relay_settings(tmp_path, atif_plugin_config(atif_dir))
     install_mock_relay(monkeypatch, relay)
     wait_for_atif = AsyncMock(return_value=None)
@@ -654,6 +653,9 @@ async def test_relay_atif_timeout_fails_successful_turn_explicitly(
     await runtime.start(lifecycle_start_payload(codex_payload))
     try:
         output = await runtime.invoke(lifecycle_invocation(codex_payload))
+        late_atif.write_text(
+            '{"schema_version":"ATIF-v1.7","steps":[]}', encoding="utf-8"
+        )
         unavailable = await runtime.invoke(lifecycle_invocation(codex_payload))
     finally:
         await runtime.stop()
@@ -669,6 +671,8 @@ async def test_relay_atif_timeout_fails_successful_turn_explicitly(
     }
     wait_for_atif.assert_awaited_once()
     assert unavailable["error"]["code"] == "codex_runtime_unavailable"
+    assert "relay_runtime" not in unavailable
+    assert "relay_artifacts" not in unavailable
 
 
 def test_failed_sdk_turn_is_normalized_and_transport_is_closed(

--- a/tests/adapters/test_codex_adapter.py
+++ b/tests/adapters/test_codex_adapter.py
@@ -632,26 +632,6 @@ async def test_relay_waits_for_delayed_atif_before_collecting_artifacts(
     assert output["relay_artifacts"] == [{"kind": "atif", "path": str(atif_file)}]
 
 
-def test_relay_atif_finalization_requires_new_or_changed_valid_json(tmp_path):
-    atif_dir = tmp_path / "atif"
-    atif_dir.mkdir()
-    atif_file = atif_dir / "trajectory-session.atif.json"
-    plugin_config = atif_plugin_config(atif_dir)
-    atif_file.write_text('{"schema_version":"ATIF-v1.7","steps":[]}', encoding="utf-8")
-    before = adapter._relay_atif_snapshot(plugin_config)
-
-    assert adapter._relay_has_finalized_atif(plugin_config, before) is False
-
-    atif_file.write_text("{", encoding="utf-8")
-    assert adapter._relay_has_finalized_atif(plugin_config, before) is False
-
-    atif_file.write_text(
-        '{"schema_version":"ATIF-v1.7","steps":[{"step_id":1}]}',
-        encoding="utf-8",
-    )
-    assert adapter._relay_has_finalized_atif(plugin_config, before) is True
-
-
 async def test_relay_atif_timeout_fails_successful_turn_explicitly(
     codex_payload, mock_codex, monkeypatch, tmp_path
 ):
@@ -665,13 +645,16 @@ async def test_relay_atif_timeout_fails_successful_turn_explicitly(
     stale_atif.write_text('{"schema_version":"ATIF-v1.7","steps":[]}', encoding="utf-8")
     relay = relay_settings(tmp_path, atif_plugin_config(atif_dir))
     install_mock_relay(monkeypatch, relay)
-    monkeypatch.setattr(adapter, "RELAY_ATIF_FINALIZATION_TIMEOUT_SECONDS", 0.01)
-    monkeypatch.setattr(adapter, "RELAY_ATIF_POLL_INTERVAL_SECONDS", 0.001)
+    wait_for_atif = AsyncMock(return_value=None)
+    monkeypatch.setattr(
+        adapter.relay_artifacts, "wait_for_finalized_atif", wait_for_atif
+    )
     runtime = adapter.CodexRuntime()
 
     await runtime.start(lifecycle_start_payload(codex_payload))
     try:
         output = await runtime.invoke(lifecycle_invocation(codex_payload))
+        unavailable = await runtime.invoke(lifecycle_invocation(codex_payload))
     finally:
         await runtime.stop()
 
@@ -680,45 +663,12 @@ async def test_relay_atif_timeout_fails_successful_turn_explicitly(
         "code": "codex_relay_atif_timeout",
         "message": "NeMo Relay did not finalize an ATIF artifact before the deadline",
         "retryable": False,
-        "metadata": {"timeout_seconds": 0.01},
+        "metadata": {
+            "timeout_seconds": adapter.relay_artifacts.ATIF_FINALIZATION_TIMEOUT_SECONDS
+        },
     }
-
-
-async def test_relay_atif_waits_are_isolated_by_runtime_directory(tmp_path):
-    first_dir = tmp_path / "runtime-1"
-    second_dir = tmp_path / "runtime-2"
-    first_dir.mkdir()
-    second_dir.mkdir()
-    first_config = atif_plugin_config(first_dir)
-    second_config = atif_plugin_config(second_dir)
-    first_before = adapter._relay_atif_snapshot(first_config)
-    second_before = adapter._relay_atif_snapshot(second_config)
-
-    async def write_atif(directory: Path, session_id: str, delay: float):
-        await asyncio.sleep(delay)
-        (directory / f"trajectory-{session_id}.atif.json").write_text(
-            json.dumps({"schema_version": "ATIF-v1.7", "steps": []}),
-            encoding="utf-8",
-        )
-
-    writers = [
-        asyncio.create_task(write_atif(first_dir, "first", 0.02)),
-        asyncio.create_task(write_atif(second_dir, "second", 0.01)),
-    ]
-    await asyncio.gather(
-        adapter._wait_for_relay_atif(first_config, first_before),
-        adapter._wait_for_relay_atif(second_config, second_before),
-    )
-    await asyncio.gather(*writers)
-
-    assert {
-        Path(artifact["path"]).parent
-        for artifact in adapter.common_utils.collect_relay_artifacts(first_config)
-    } == {first_dir}
-    assert {
-        Path(artifact["path"]).parent
-        for artifact in adapter.common_utils.collect_relay_artifacts(second_config)
-    } == {second_dir}
+    wait_for_atif.assert_awaited_once()
+    assert unavailable["error"]["code"] == "codex_runtime_unavailable"
 
 
 def test_failed_sdk_turn_is_normalized_and_transport_is_closed(

--- a/tests/adapters/test_codex_adapter.py
+++ b/tests/adapters/test_codex_adapter.py
@@ -641,6 +641,8 @@ async def test_relay_atif_timeout_fails_successful_turn_explicitly(
     }
     atif_dir = tmp_path / "relay" / "atif"
     atif_dir.mkdir(parents=True)
+    stale_atif = atif_dir / "trajectory-existing.atif.json"
+    stale_atif.write_text('{"schema_version":"ATIF-v1.7","steps":[]}', encoding="utf-8")
     late_atif = atif_dir / "trajectory-late.atif.json"
     relay = relay_settings(tmp_path, atif_plugin_config(atif_dir))
     install_mock_relay(monkeypatch, relay)
@@ -670,6 +672,8 @@ async def test_relay_atif_timeout_fails_successful_turn_explicitly(
         },
     }
     wait_for_atif.assert_awaited_once()
+    assert output["relay_runtime"]["enabled"] is True
+    assert output["relay_artifacts"] == []
     assert unavailable["error"]["code"] == "codex_runtime_unavailable"
     assert "relay_runtime" not in unavailable
     assert "relay_artifacts" not in unavailable

--- a/tests/adapters/test_codex_adapter.py
+++ b/tests/adapters/test_codex_adapter.py
@@ -136,6 +136,47 @@ def mock_thread(thread_id, result=None):
     return mock_sdk_thread
 
 
+def atif_plugin_config(output_directory: Path) -> dict[str, Any]:
+    return {
+        "version": 1,
+        "components": [
+            {
+                "kind": "observability",
+                "config": {
+                    "atif": {
+                        "enabled": True,
+                        "output_directory": str(output_directory),
+                        "filename_template": "trajectory-{session_id}.atif.json",
+                    }
+                },
+            }
+        ],
+    }
+
+
+def relay_settings(tmp_path: Path, plugin_config: dict[str, Any]):
+    return adapter.CodexRelaySettings(
+        gateway=adapter.relay_gateway.RelayGatewayLaunch(
+            executable=tmp_path / "nemo-relay",
+            config_path=tmp_path / "relay" / "config.toml",
+            bind="127.0.0.1:43210",
+            url="http://127.0.0.1:43210",
+            log_path=tmp_path / "relay" / "gateway.log",
+        ),
+        plugin_config=plugin_config,
+    )
+
+
+def install_mock_relay(monkeypatch, relay: adapter.CodexRelaySettings):
+    monkeypatch.setattr(adapter, "prepare_codex_relay", MagicMock(return_value=relay))
+    monkeypatch.setattr(
+        adapter.relay_gateway,
+        "start_relay_gateway",
+        MagicMock(return_value=MagicMock()),
+    )
+    monkeypatch.setattr(adapter.relay_gateway, "stop_relay_gateway", MagicMock())
+
+
 @pytest.fixture(name="mock_codex")
 def mock_codex_fixture(monkeypatch):
     mock_codex = MagicMock(spec=AsyncCodex)
@@ -545,6 +586,139 @@ async def test_persistent_runtime_owns_one_relay_gateway(
         cwd=Path(codex_payload["runtime_context"]["environment"]["workspace"]),
     )
     stop_gateway.assert_called_once_with(process)
+
+
+async def test_relay_waits_for_delayed_atif_before_collecting_artifacts(
+    codex_payload, mock_codex, monkeypatch, tmp_path
+):
+    codex_payload["telemetry_plan"] = {
+        "providers": ["relay"],
+        "relay_enabled": True,
+    }
+    atif_dir = tmp_path / "relay" / "atif"
+    atif_dir.mkdir(parents=True)
+    atif_file = atif_dir / "trajectory-session.atif.json"
+    relay = relay_settings(tmp_path, atif_plugin_config(atif_dir))
+    install_mock_relay(monkeypatch, relay)
+    mock_sdk_thread = mock_thread("thread-123")
+    write_task = None
+
+    async def finish_turn():
+        nonlocal write_task
+
+        async def write_atif():
+            await asyncio.sleep(0.05)
+            atif_file.write_text(
+                json.dumps({"schema_version": "ATIF-v1.7", "steps": []}),
+                encoding="utf-8",
+            )
+
+        write_task = asyncio.create_task(write_atif())
+        return successful_result()
+
+    mock_sdk_thread.handle.run.side_effect = finish_turn
+    mock_codex.next_thread = mock_sdk_thread
+    runtime = adapter.CodexRuntime()
+
+    await runtime.start(lifecycle_start_payload(codex_payload))
+    try:
+        output = await runtime.invoke(lifecycle_invocation(codex_payload))
+        assert write_task is not None
+        await write_task
+    finally:
+        await runtime.stop()
+
+    assert output["completed"] is True
+    assert output["relay_artifacts"] == [{"kind": "atif", "path": str(atif_file)}]
+
+
+def test_relay_atif_finalization_requires_new_or_changed_valid_json(tmp_path):
+    atif_dir = tmp_path / "atif"
+    atif_dir.mkdir()
+    atif_file = atif_dir / "trajectory-session.atif.json"
+    plugin_config = atif_plugin_config(atif_dir)
+    atif_file.write_text('{"schema_version":"ATIF-v1.7","steps":[]}', encoding="utf-8")
+    before = adapter._relay_atif_snapshot(plugin_config)
+
+    assert adapter._relay_has_finalized_atif(plugin_config, before) is False
+
+    atif_file.write_text("{", encoding="utf-8")
+    assert adapter._relay_has_finalized_atif(plugin_config, before) is False
+
+    atif_file.write_text(
+        '{"schema_version":"ATIF-v1.7","steps":[{"step_id":1}]}',
+        encoding="utf-8",
+    )
+    assert adapter._relay_has_finalized_atif(plugin_config, before) is True
+
+
+async def test_relay_atif_timeout_fails_successful_turn_explicitly(
+    codex_payload, mock_codex, monkeypatch, tmp_path
+):
+    codex_payload["telemetry_plan"] = {
+        "providers": ["relay"],
+        "relay_enabled": True,
+    }
+    atif_dir = tmp_path / "relay" / "atif"
+    atif_dir.mkdir(parents=True)
+    stale_atif = atif_dir / "trajectory-session.atif.json"
+    stale_atif.write_text('{"schema_version":"ATIF-v1.7","steps":[]}', encoding="utf-8")
+    relay = relay_settings(tmp_path, atif_plugin_config(atif_dir))
+    install_mock_relay(monkeypatch, relay)
+    monkeypatch.setattr(adapter, "RELAY_ATIF_FINALIZATION_TIMEOUT_SECONDS", 0.01)
+    monkeypatch.setattr(adapter, "RELAY_ATIF_POLL_INTERVAL_SECONDS", 0.001)
+    runtime = adapter.CodexRuntime()
+
+    await runtime.start(lifecycle_start_payload(codex_payload))
+    try:
+        output = await runtime.invoke(lifecycle_invocation(codex_payload))
+    finally:
+        await runtime.stop()
+
+    assert output["failed"] is True
+    assert output["error"] == {
+        "code": "codex_relay_atif_timeout",
+        "message": "NeMo Relay did not finalize an ATIF artifact before the deadline",
+        "retryable": False,
+        "metadata": {"timeout_seconds": 0.01},
+    }
+
+
+async def test_relay_atif_waits_are_isolated_by_runtime_directory(tmp_path):
+    first_dir = tmp_path / "runtime-1"
+    second_dir = tmp_path / "runtime-2"
+    first_dir.mkdir()
+    second_dir.mkdir()
+    first_config = atif_plugin_config(first_dir)
+    second_config = atif_plugin_config(second_dir)
+    first_before = adapter._relay_atif_snapshot(first_config)
+    second_before = adapter._relay_atif_snapshot(second_config)
+
+    async def write_atif(directory: Path, session_id: str, delay: float):
+        await asyncio.sleep(delay)
+        (directory / f"trajectory-{session_id}.atif.json").write_text(
+            json.dumps({"schema_version": "ATIF-v1.7", "steps": []}),
+            encoding="utf-8",
+        )
+
+    writers = [
+        asyncio.create_task(write_atif(first_dir, "first", 0.02)),
+        asyncio.create_task(write_atif(second_dir, "second", 0.01)),
+    ]
+    await asyncio.gather(
+        adapter._wait_for_relay_atif(first_config, first_before),
+        adapter._wait_for_relay_atif(second_config, second_before),
+    )
+    await asyncio.gather(*writers)
+
+    assert {
+        Path(artifact["path"]).parent
+        for artifact in adapter.common_utils.collect_relay_artifacts(first_config)
+    } == {first_dir}
+    assert {
+        Path(artifact["path"]).parent
+        for artifact in adapter.common_utils.collect_relay_artifacts(second_config)
+    } == {second_dir}
 
 
 def test_failed_sdk_turn_is_normalized_and_transport_is_closed(

--- a/tests/e2e/test_claude.py
+++ b/tests/e2e/test_claude.py
@@ -73,6 +73,7 @@ def fabric_config(
     *,
     cli_path=None,
     relay=False,
+    atif=True,
     nemo_relay_command=None,
 ):
     tmp_path.mkdir(parents=True, exist_ok=True)
@@ -133,7 +134,7 @@ def fabric_config(
                     enabled=True,
                     sinks=[RelayAtofFileSinkConfig()],
                 ),
-                atif=RelayAtifConfig(enabled=True),
+                atif=RelayAtifConfig(enabled=atif),
             )
         )
     return config
@@ -182,10 +183,12 @@ async def test_fabric_claude_relay_supervises_gateway_and_injects_plugin(tmp_pat
     mock_relay = tmp_path / "nemo-relay"
     relay_args_path = tmp_path / "relay-args.json"
     write_mock_relay_gateway(mock_relay, relay_args_path)
+    # This fake implements gateway lifecycle only, not subscriber artifact writes.
     config = fabric_config(
         tmp_path,
         cli_path=MOCK_CLAUDE_CLI,
         relay=True,
+        atif=False,
         nemo_relay_command=mock_relay,
     )
 


### PR DESCRIPTION
#### Overview

Forward-port the Relay ATIF finalization fix from #181 to main.

Relay can report an agent turn complete before its asynchronous ATIF subscriber
has finished writing the trajectory. Codex and Claude previously collected
Relay artifacts immediately after that terminal result, so a successful
invocation could include ATOF while missing its ATIF.

This PR adds a shared finalization barrier for Codex and Claude. It does not
change package versions, dependency constraints, manifests, lockfiles, or the
observability schema.

#### Details

- Snapshot cheap filesystem fingerprints (device, inode, size, and nanosecond
  modification time) for runtime-scoped ATIF files before each invocation.
- After a successful Codex or Claude turn, inspect only new or changed
  candidates and accept one when it contains a complete JSON object.
- Preserve support for new files, atomic replacement, overwrite, and append
  without reading unchanged trajectories from earlier turns.
- Use a five-second condition-based deadline rather than a fixed sleep.
- On timeout, return a non-retryable adapter error with no Relay artifacts,
  mark the persistent runtime unavailable, and bypass later directory
  rescanning so a late ATIF cannot be attributed to another response.
- Skip the local-file wait for remote-only ATIF storage.
- Preserve streaming, ATOF collection, persistent SDK sessions, and the
  runtime-owned Relay gateway.
- Leave Deep Agents and Hermes behavior unchanged; their existing lifecycle
  boundaries already finalize Relay output before collection.

No public API or configuration contract changes, and there are no breaking
changes.

#### Validation

- just test-python — 662 passed, 17 skipped.
- Ruff formatting check on all changed Python files — passed.
- Pre-commit on all files — passed, including copyright, Ruff, GitHub Actions
  lint, Cargo/uv lock freshness, both attribution checks, and dependency
  license diff.
- git diff --check upstream/main...HEAD — passed.
- Platform evaluator on the installed main packages at parallelism 10:
  Codex 10/10 and Claude 10/10, with 20 isolated runtime-scoped ATIF
  directories and zero contract failures.
- Platform non-target regression at parallelism 5: Deep Agents 5/5 and Hermes
  5/5, with ten isolated directories, valid ATIF-v1.7 trajectories, and zero
  contract failures.

Rust tests were not rerun because this PR changes only Python adapter behavior
and tests. Documentation is unchanged because public configuration and API
contracts are unchanged.

#### Where should the reviewer start?

Start with
adapters/common/src/nemo_fabric_adapters/common/relay_artifacts.py, then the
calls from CodexRuntime.invoke() and ClaudeRuntime.invoke(). The focused tests
cover delayed and partial writes, new and changed paths, remote-only storage,
timeout behavior, late-file exclusion, unusable runtimes, and parallel
runtime-directory isolation.

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- Relates to #181 and the NeMo Platform ATIF release blocker.

- [x] I confirm this contribution is my own work, or I have the right to submit it under this project's license.
- [x] I searched existing issues and open pull requests, and this does not duplicate existing work.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added reliable collection of Relay-generated ATIF artifacts for Claude and Codex interactions.
  * Delayed artifact creation is now detected and finalized before results are returned.

* **Bug Fixes**
  * Incomplete or unchanged artifacts are ignored.
  * Artifact finalization timeouts now produce clear, non-retryable failures and prevent further use of the affected runtime.

* **Tests**
  * Added coverage for delayed artifacts, timeout handling, modified files, and runtime isolation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->