### PR TITLE
fix: reject colliding tool definition extensions

### DIFF
--- a/python/src/nemo_fabric/models.py
+++ b/python/src/nemo_fabric/models.py
@@ -982,11 +982,18 @@ class ToolsConfig(FabricBaseModel):
 
         if not name.strip():
             raise ValueError("tool definition names must not be empty")
+        extras = dict(extra_fields or {})
+        overlap = {"kind", "ref", "settings"}.intersection(extras)
+        if overlap:
+            raise ValueError(
+                "extra_fields duplicates known fields: "
+                + ", ".join(sorted(overlap))
+            )
         value = {
             "kind": kind,
             "ref": ref,
             "settings": dict(settings or {}),
-            **dict(extra_fields or {}),
+            **extras,
         }
         self.definitions[name] = ToolDefinitionConfig.model_validate(value)
         return self

--- a/tests/python/test_sdk_contract.py
+++ b/tests/python/test_sdk_contract.py
@@ -763,6 +763,19 @@ def test_typed_tool_definition_omits_empty_settings():
     }
 
 
+@pytest.mark.parametrize("field", ["kind", "ref", "settings"])
+def test_typed_tool_definition_rejects_known_extra_field_collisions(field: str):
+    tools = ToolsConfig()
+
+    with pytest.raises(ValueError, match="extra_fields duplicates known fields"):
+        tools.add_definition(
+            "web",
+            kind="function_group",
+            ref="web_tools",
+            extra_fields={field: "replacement"},
+        )
+
+
 def test_run_plan_snapshot_removes_named_definition():
     config = _FabricConfigSnapshot.from_mapping(
         {


### PR DESCRIPTION
#### Overview

Prevents `ToolsConfig.add_definition()` from silently allowing `extra_fields` to overwrite normalized `kind`, `ref`, or `settings` values.

- [x] I confirm this contribution is my own work, or I have the right to submit it under this project's license.
- [x] I searched existing issues and open pull requests, and this does not duplicate existing work.

#### Details

- Reject extension fields named `kind`, `ref`, or `settings` before constructing the typed tool definition.
- Add parameterized coverage for all three collisions.

#### Validation

- `uv run --no-sync pytest tests/python/test_sdk_contract.py -k typed_tool_definition`
- `just test-python`
- `uvx ruff format --check python/src/nemo_fabric/models.py tests/python/test_sdk_contract.py`
- `git diff --check`

#### Where should the reviewer start?

Start with `ToolsConfig.add_definition()` in `python/src/nemo_fabric/models.py`; the regression test is directly below the existing typed-tool-definition coverage.

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- Relates to: none