### PR TITLE
docs: consumer integration skill for CI

### DIFF
--- a/skills/nemo-fabric-integrate/SKILL.md
+++ b/skills/nemo-fabric-integrate/SKILL.md
@@ -16,7 +16,7 @@ lifecycle, and normalized results.
 
 ## Integration Boundary
 
-Stay on the public, in-memory contract. These rules keep a consumer integration
+Use the public, in-memory contract. These rules keep a consumer integration
 supported and upgrade-safe:
 
 - Import only from the public `nemo_fabric` package. Never import `_native` or


### PR DESCRIPTION
#### Overview

Clarifies the NVIDIA NeMo Fabric consumer skill's integration boundary with a direct imperative. This intentionally trivial documentation change provides a consumer skill delta for validating the NVCARPS CI path.

No public SDK behavior changes or breaking changes are introduced.

#### Details

- Replaces "Stay on the public, in-memory contract" with "Use the public, in-memory contract."
- Leaves the supported integration boundary and all technical guidance unchanged.

#### Validation

- `.venv/bin/python /Users/aenemark/.codex/skills/.system/skill-creator/scripts/quick_validate.py skills/nemo-fabric-integrate` (`Skill is valid!`)
- `jq empty skills/nemo-fabric-integrate/evals/evals.json`
- `git diff --check`

Broader documentation and runtime tests were not run because this is a one-line prose-only skill change.

#### Where should the reviewer start?

`skills/nemo-fabric-integrate/SKILL.md`, in the opening sentence under `Integration Boundary`.

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- Relates to: none

- [x] I confirm this contribution is my own work, or I have the right to submit it under this project's license.
- [x] I searched existing issues and open pull requests, and this does not duplicate existing work.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated integration guidance to clearly instruct users to use the public, in-memory contract.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->