### PR TITLE
feat: move Hermes agent adapter to v1alpha2

### DIFF
--- a/adapters/common/src/nemo_fabric_adapters/common/utils.py
+++ b/adapters/common/src/nemo_fabric_adapters/common/utils.py
@@ -84,12 +84,6 @@ def runtime_id(payload: dict[str, Any]) -> str:
     return str(value)
 
 
-def runtime_state_directory(base: str | Path, payload: dict[str, Any]) -> Path:
-    """Return a harness-owned state directory isolated to one NeMo Fabric runtime."""
-
-    return Path(base).joinpath("runtimes", runtime_id(payload))
-
-
 def environment_payload(payload: dict[str, Any]) -> dict[str, Any]:
     return (
         runtime_context(payload).get("environment")

--- a/adapters/hermes/fabric-adapter.json
+++ b/adapters/hermes/fabric-adapter.json
@@ -62,6 +62,7 @@
     "additionalProperties": false
   },
   "config": {
+    "input": "agent_config",
     "accepts": [
       "models",
       "models.base_url",

--- a/adapters/hermes/pyproject.toml
+++ b/adapters/hermes/pyproject.toml
@@ -26,6 +26,7 @@ readme = "pypi.md"
 # Hermes Agent does not currently support Python 3.14 or later.
 requires-python = ">=3.11,<3.14"
 dependencies = [
+  "nemo-fabric-adapter-contract == 0.2.0",
   "nemo-fabric-adapters-common == 0.2.0",
 ]
 
@@ -55,4 +56,5 @@ include = ["nemo_fabric_adapters.hermes*"]
 "share/nemo-fabric/adapters/hermes" = ["fabric-adapter.json"]
 
 [tool.uv.sources]
+nemo-fabric-adapter-contract = { path = "../../adapter-contract", editable = true }
 nemo-fabric-adapters-common = { path = "../common", editable = true }

--- a/adapters/hermes/src/nemo_fabric_adapters/hermes/adapter.py
+++ b/adapters/hermes/src/nemo_fabric_adapters/hermes/adapter.py
@@ -20,6 +20,9 @@ from io import StringIO
 from pathlib import Path
 from typing import Any
 
+from nemo_fabric_adapter_contract.models import AgentConfig
+from nemo_fabric_adapter_contract.models import AgentMcpServerConfig
+from nemo_fabric_adapter_contract.models import AgentModelConfig
 from nemo_fabric_adapters.common import lifecycle
 import nemo_fabric_adapters.common.utils as common_utils
 
@@ -37,15 +40,45 @@ PROVIDER_DEFAULT_API_KEY_ENV = {
 }
 
 
-def _api_key_env(model_config: dict[str, Any]) -> str:
-    explicit = model_config.get("api_key_env")
-    if isinstance(explicit, str) and explicit:
-        return explicit
-    provider = str(model_config.get("provider") or "").lower()
-    default = PROVIDER_DEFAULT_API_KEY_ENV.get(provider)
+def _settings(config: AgentConfig) -> dict[str, Any]:
+    return config.harness.settings if config.harness is not None else {}
+
+
+def _selected_model(config: AgentConfig) -> AgentModelConfig:
+    model = config.models.get("default")
+    if model is None and len(config.models) == 1:
+        model = next(iter(config.models.values()))
+    if model is None:
+        raise ValueError("Hermes requires a default model or exactly one model")
+    return model
+
+
+def _system_instruction(config: AgentConfig) -> str | None:
+    if config.instructions is None or config.instructions.system is None:
+        return None
+    return config.instructions.system.content
+
+
+def _max_turns(config: AgentConfig) -> int | None:
+    return config.runtime.max_turns if config.runtime is not None else None
+
+
+def _workspace(payload: dict[str, Any]) -> str:
+    environment = common_utils.runtime_context(payload).get("environment") or {}
+    if not isinstance(environment, dict):
+        return "."
+    workspace = environment.get("workspace")
+    return str(workspace) if workspace else "."
+
+
+def _api_key_env(model_config: AgentModelConfig) -> str:
+    if model_config.api_key_env:
+        return model_config.api_key_env
+    default = PROVIDER_DEFAULT_API_KEY_ENV.get(model_config.provider)
     if default is None:
         raise ValueError(
-            f"selected model api_key_env is required for provider {provider!r}"
+            "selected model api_key_env is required for provider "
+            f"{model_config.provider!r}"
         )
     return default
 
@@ -76,52 +109,55 @@ def validate_hermes_telemetry_provider(payload: dict[str, Any]) -> None:
         raise ValueError("only relay telemetry is supported for Hermes")
 
 
-def disabled_toolsets(payload: dict[str, Any]) -> list[str]:
-    return common_utils.blocked_tools(payload)
+def disabled_toolsets(config: AgentConfig) -> list[str]:
+    return config.tools.blocked if config.tools is not None else []
 
 
 def build_hermes_config(
-    payload: dict[str, Any], *, relay_enabled: bool = False
+    agent_config: AgentConfig,
+    *,
+    workspace: str = ".",
+    relay_enabled: bool = False,
 ) -> dict[str, Any]:
-    settings = common_utils.settings_payload(payload)
-    model_config = common_utils.selected_model_config(payload)
-    native = common_utils.capability_plan(payload).get("native") or {}
-    environment = common_utils.environment_payload(payload)
-
-    model_name = model_config.get("model", "")
-    provider = model_config.get("provider")
-    base_url = common_utils.get_base_url(model_config)
-    blocked_toolsets = disabled_toolsets(payload)
-    enabled_toolsets = common_utils.enabled_tools(payload)
+    settings = _settings(agent_config)
+    model_config = _selected_model(agent_config)
+    blocked_toolsets = disabled_toolsets(agent_config)
+    enabled_toolsets = (
+        agent_config.tools.enabled if agent_config.tools is not None else None
+    )
 
     config: dict[str, Any] = {
         "model": common_utils.without_none(
             {
-                "provider": provider,
-                "default": model_name,
-                "base_url": base_url,
+                "provider": model_config.provider,
+                "default": model_config.model,
+                "base_url": model_config.base_url,
             }
         ),
         "agent": common_utils.without_none(
             {
-                "max_turns": common_utils.max_turns(payload),
+                "max_turns": _max_turns(agent_config),
                 "disabled_toolsets": blocked_toolsets or None,
             }
         ),
         "terminal": common_utils.without_none(
             {
                 "backend": "local",
-                "cwd": str(environment.get("workspace") or "."),
+                "cwd": workspace,
                 "timeout": settings.get("terminal_timeout", 60),
             }
         ),
     }
 
-    skill_dirs = [str(path) for path in native.get("skill_paths", [])]
+    skill_dirs = (
+        [str(path) for path in agent_config.skills.paths]
+        if agent_config.skills is not None
+        else []
+    )
     if skill_dirs:
         config["skills"] = {"external_dirs": skill_dirs}
 
-    mcp_servers = native.get("mcp_servers") or {}
+    mcp_servers = agent_config.mcp.servers if agent_config.mcp is not None else {}
     if mcp_servers:
         config["mcp_servers"] = {
             name: hermes_mcp_server_config(server)
@@ -141,22 +177,26 @@ def build_hermes_config(
 
 
 def write_hermes_config(
-    payload: dict[str, Any],
+    agent_config: AgentConfig,
     hermes_home: Path,
     *,
+    workspace: str = ".",
     relay_enabled: bool = False,
 ) -> tuple[Path, dict[str, Any]]:
     hermes_home.mkdir(parents=True, exist_ok=True)
-    config = build_hermes_config(payload, relay_enabled=relay_enabled)
+    config = build_hermes_config(
+        agent_config,
+        workspace=workspace,
+        relay_enabled=relay_enabled,
+    )
     config_path = hermes_home / "config.yaml"
     config_path.write_text(common_utils.dump_yaml(config), encoding="utf-8")
     return config_path, config
 
 
-def hermes_mcp_server_config(server: dict[str, Any]) -> dict[str, Any]:
-    transport = str(server.get("transport") or "").strip().lower()
-    raw_target = server.get("url")
-    target = os.path.expandvars(str(raw_target or "")).strip()
+def hermes_mcp_server_config(server: AgentMcpServerConfig) -> dict[str, Any]:
+    transport = server.transport.strip().lower()
+    target = os.path.expandvars(server.url).strip()
     if not target:
         raise ValueError("MCP server mapping requires a URL")
 
@@ -165,8 +205,8 @@ def hermes_mcp_server_config(server: dict[str, Any]) -> dict[str, Any]:
             {
                 "enabled": True,
                 "command": target,
-                "args": common_utils.normalize_list(server.get("args")) or None,
-                "env": server.get("env"),
+                "args": server.args or None,
+                "env": server.env or None,
             }
         )
 
@@ -188,13 +228,13 @@ def summarize_hermes_config(config: dict[str, Any]) -> dict[str, Any]:
 def main() -> None:
     """Serve the persistent local-host lifecycle protocol."""
 
-    lifecycle.serve(HermesRuntime)
+    lifecycle.serve(HermesRuntime, config_loader=AgentConfig.from_mapping)
 
 
 def resolve_hermes_toolsets(
-    payload: dict[str, Any], config: dict[str, Any]
+    agent_config: AgentConfig, config: dict[str, Any]
 ) -> list[str] | None:
-    enabled = common_utils.enabled_tools(payload)
+    enabled = agent_config.tools.enabled if agent_config.tools is not None else None
     if enabled is not None:
         return enabled
 
@@ -219,10 +259,10 @@ class HermesRuntime:
 
     def __init__(self) -> None:
         self._started = False
-        self._start_payload: dict[str, Any] | None = None
+        self._agent_config: AgentConfig | None = None
         self._runtime_id: str | None = None
         self._settings: dict[str, Any] = {}
-        self._model_config: dict[str, Any] = {}
+        self._model_config: AgentModelConfig | None = None
         self._base_url: str | None = None
         self._hermes_home: Path | None = None
         self._hermes_config_path: Path | None = None
@@ -250,8 +290,15 @@ class HermesRuntime:
             self._relay_session_pending = False
             self._relay_finalize_hook_invoked = False
             validate_hermes_telemetry_provider(payload)
-            self._settings = common_utils.settings_payload(payload)
-            self._model_config = common_utils.selected_model_config(payload)
+            agent_config = payload.get("config")
+            if not isinstance(agent_config, AgentConfig):
+                raise lifecycle.LifecycleError(
+                    "hermes_invalid_config",
+                    "Hermes requires a validated AgentConfig",
+                )
+            self._agent_config = agent_config
+            self._settings = _settings(agent_config)
+            self._model_config = _selected_model(agent_config)
             self._runtime_id = common_utils.runtime_id(payload)
             self._hermes_home = common_utils.runtime_state_directory(
                 _artifact_root(payload) / ".fabric" / "hermes", payload
@@ -270,8 +317,9 @@ class HermesRuntime:
 
             relay_enabled = common_utils.relay_enabled(payload)
             if relay_enabled:
+                relay_payload = {**payload, "config": agent_config.to_mapping()}
                 self._relay_plugin_config = common_utils.load_relay_plugin_config(
-                    payload
+                    relay_payload
                 )
                 from nemo_relay import plugin
 
@@ -280,16 +328,17 @@ class HermesRuntime:
                 self._relay_context_entered = True
 
             self._hermes_config_path, self._hermes_config = write_hermes_config(
-                payload,
+                agent_config,
                 self._hermes_home,
+                workspace=_workspace(payload),
                 relay_enabled=relay_enabled,
             )
             api_key_env = _api_key_env(self._model_config)
             api_key = os.environ.get(api_key_env)
             if not api_key:
                 raise RuntimeError(f"{api_key_env} is required for Hermes mode")
-            self._base_url = common_utils.get_base_url(self._model_config)
-            self._relay_model_name = common_utils.relay_model_name(payload)
+            self._base_url = self._model_config.base_url
+            self._relay_model_name = self._model_config.model
 
             from hermes_cli.config import load_config
             from hermes_cli.plugins import discover_plugins
@@ -307,27 +356,28 @@ class HermesRuntime:
                 # asyncio.to_thread to avoid blocking the loop.
                 if self._hermes_config.get("mcp_servers"):
                     from tools.mcp_tool import discover_mcp_tools
+
                     await asyncio.to_thread(discover_mcp_tools)
 
                 self._enabled_toolsets = resolve_hermes_toolsets(
-                    payload, loaded_hermes_config
+                    agent_config, loaded_hermes_config
                 )
                 self._session_db = SessionDB()
                 self._conversation_history = None
-                max_iterations = common_utils.max_turns(payload)
+                max_iterations = _max_turns(agent_config)
                 if max_iterations is None:
                     max_iterations = DEFAULT_MAX_ITERATIONS
-                temperature = self._model_config.get("temperature")
+                temperature = self._model_config.temperature
                 self._agent = AIAgent(
                     **filter_supported_kwargs(
                         AIAgent,
                         base_url=self._base_url,
                         api_key=api_key,
-                        provider=self._model_config.get("provider"),
-                        model=self._model_config.get("model", ""),
+                        provider=self._model_config.provider,
+                        model=self._model_config.model,
                         max_iterations=int(max_iterations),
                         enabled_toolsets=self._enabled_toolsets,
-                        disabled_toolsets=disabled_toolsets(payload) or None,
+                        disabled_toolsets=disabled_toolsets(agent_config) or None,
                         quiet_mode=True,
                         skip_context_files=True,
                         skip_memory=True,
@@ -349,15 +399,20 @@ class HermesRuntime:
                     )
                 )
             self._invoke_hook = invoke_hook
-            self._start_payload = payload
             self._started = True
         except BaseException:
             await self.stop()
             raise
 
     async def invoke(self, invocation: dict[str, Any]) -> dict[str, Any]:
-        start_payload = self._start_payload
-        if not self._started or self._agent is None or start_payload is None:
+        agent_config = self._agent_config
+        model_config = self._model_config
+        if (
+            not self._started
+            or self._agent is None
+            or agent_config is None
+            or model_config is None
+        ):
             raise lifecycle.LifecycleError(
                 "hermes_runtime_not_started",
                 "Hermes runtime is not started",
@@ -368,12 +423,7 @@ class HermesRuntime:
                 "Hermes invocation does not match the active runtime",
             )
 
-        payload = {
-            **start_payload,
-            "runtime_context": invocation.get("runtime_context"),
-            "request": invocation.get("request"),
-        }
-        request = common_utils.request_payload(payload)
+        request = common_utils.request_payload(invocation)
         user_message = request.get("input") or ""
         if not isinstance(user_message, str):
             user_message = json.dumps(user_message, sort_keys=True)
@@ -381,7 +431,7 @@ class HermesRuntime:
         def invoke_turn() -> tuple[dict[str, Any], str]:
             return _invoke_hermes_turn(
                 agent=self._agent,
-                system_prompt=common_utils.system_instruction(start_payload),
+                system_prompt=_system_instruction(agent_config),
                 user_message=user_message,
                 conversation_history=self._conversation_history,
             )
@@ -420,7 +470,7 @@ class HermesRuntime:
             "harness": "hermes",
             "adapter": "python",
             "mode": "hermes",
-            "model": self._model_config.get("model"),
+            "model": model_config.model,
             "base_url": self._base_url,
             "response": result.get("response") or result.get("final_response"),
             "completed": bool(result.get("completed")),
@@ -486,10 +536,10 @@ class HermesRuntime:
                 errors.append(error)
         self._agent = None
         self._session_db = None
-        self._start_payload = None
+        self._agent_config = None
         self._runtime_id = None
         self._settings = {}
-        self._model_config = {}
+        self._model_config = None
         self._base_url = None
         self._hermes_home = None
         self._hermes_config_path = None

--- a/adapters/hermes/src/nemo_fabric_adapters/hermes/adapter.py
+++ b/adapters/hermes/src/nemo_fabric_adapters/hermes/adapter.py
@@ -105,7 +105,7 @@ def disabled_toolsets(config: AgentConfig) -> list[str]:
 def build_hermes_config(
     agent_config: AgentConfig,
     *,
-    workspace: str = ".",
+    workspace: str,
     relay_enabled: bool = False,
 ) -> dict[str, Any]:
     settings = _settings(agent_config)
@@ -169,7 +169,7 @@ def write_hermes_config(
     agent_config: AgentConfig,
     hermes_home: Path,
     *,
-    workspace: str = ".",
+    workspace: str,
     relay_enabled: bool = False,
 ) -> tuple[Path, dict[str, Any]]:
     hermes_home.mkdir(parents=True, exist_ok=True)

--- a/adapters/hermes/src/nemo_fabric_adapters/hermes/adapter.py
+++ b/adapters/hermes/src/nemo_fabric_adapters/hermes/adapter.py
@@ -54,18 +54,8 @@ def _selected_model(config: AgentConfig) -> AgentModelConfig:
     return model
 
 
-def _system_instruction(config: AgentConfig) -> str | None:
-    if config.instructions is None or config.instructions.system is None:
-        return None
-    return config.instructions.system.content
-
-
 def _max_turns(config: AgentConfig) -> int | None:
     return config.runtime.max_turns if config.runtime is not None else None
-
-
-def _workspace(runtime_context: RuntimeContext) -> str:
-    return str(runtime_context.environment.workspace or ".")
 
 
 def _api_key_env(model_config: AgentModelConfig) -> str:
@@ -258,9 +248,7 @@ class HermesRuntime:
         self._started = False
         self._agent_config: AgentConfig | None = None
         self._runtime_id: str | None = None
-        self._settings: dict[str, Any] = {}
         self._model_config: AgentModelConfig | None = None
-        self._base_url: str | None = None
         self._hermes_home: Path | None = None
         self._hermes_config_path: Path | None = None
         self._hermes_config: dict[str, Any] = {}
@@ -284,8 +272,6 @@ class HermesRuntime:
             )
 
         try:
-            self._relay_session_pending = False
-            self._relay_finalize_hook_invoked = False
             agent_config = payload.get("config")
             if not isinstance(agent_config, AgentConfig):
                 raise lifecycle.LifecycleError(
@@ -295,8 +281,9 @@ class HermesRuntime:
             runtime_context = RuntimeContext.from_mapping(payload.get("runtime_context"))
             validate_hermes_telemetry_provider(runtime_context)
             self._agent_config = agent_config
-            self._settings = _settings(agent_config)
-            self._model_config = _selected_model(agent_config)
+            settings = _settings(agent_config)
+            model_config = _selected_model(agent_config)
+            self._model_config = model_config
             self._runtime_id = runtime_context.runtime_id
             self._hermes_home = (
                 _artifact_root(runtime_context, common_utils.base_dir(payload))
@@ -314,7 +301,7 @@ class HermesRuntime:
             os.environ["TERMINAL_ENV"] = "local"
             os.environ.setdefault(
                 "TERMINAL_TIMEOUT",
-                str(self._settings.get("terminal_timeout", 60)),
+                str(settings.get("terminal_timeout", 60)),
             )
 
             relay_enabled = bool(
@@ -334,15 +321,14 @@ class HermesRuntime:
             self._hermes_config_path, self._hermes_config = write_hermes_config(
                 agent_config,
                 self._hermes_home,
-                workspace=_workspace(runtime_context),
+                workspace=str(runtime_context.environment.workspace or "."),
                 relay_enabled=relay_enabled,
             )
-            api_key_env = _api_key_env(self._model_config)
+            api_key_env = _api_key_env(model_config)
             api_key = os.environ.get(api_key_env)
             if not api_key:
                 raise RuntimeError(f"{api_key_env} is required for Hermes mode")
-            self._base_url = self._model_config.base_url
-            self._relay_model_name = self._model_config.model
+            self._relay_model_name = model_config.model
 
             from hermes_cli.config import load_config
             from hermes_cli.plugins import discover_plugins
@@ -367,18 +353,17 @@ class HermesRuntime:
                     agent_config, loaded_hermes_config
                 )
                 self._session_db = SessionDB()
-                self._conversation_history = None
                 max_iterations = _max_turns(agent_config)
                 if max_iterations is None:
                     max_iterations = DEFAULT_MAX_ITERATIONS
-                temperature = self._model_config.temperature
+                temperature = model_config.temperature
                 self._agent = AIAgent(
                     **filter_supported_kwargs(
-                        AIAgent,
-                        base_url=self._base_url,
+                        AIAgent.__init__,
+                        base_url=model_config.base_url,
                         api_key=api_key,
-                        provider=self._model_config.provider,
-                        model=self._model_config.model,
+                        provider=model_config.provider,
+                        model=model_config.model,
                         max_iterations=int(max_iterations),
                         enabled_toolsets=self._enabled_toolsets,
                         disabled_toolsets=disabled_toolsets(agent_config) or None,
@@ -386,15 +371,15 @@ class HermesRuntime:
                         skip_context_files=True,
                         skip_memory=True,
                         save_trajectories=bool(
-                            self._settings.get("save_trajectories", False)
+                            settings.get("save_trajectories", False)
                         ),
-                        max_tokens=self._settings.get("max_tokens", 512),
+                        max_tokens=settings.get("max_tokens", 512),
                         request_overrides=(
                             {"temperature": temperature}
                             if temperature is not None
                             else None
                         ),
-                        reasoning_config=self._settings.get(
+                        reasoning_config=settings.get(
                             "reasoning_config", {"effort": "none"}
                         ),
                         platform="fabric",
@@ -432,11 +417,15 @@ class HermesRuntime:
         user_message = request.get("input") or ""
         if not isinstance(user_message, str):
             user_message = json.dumps(user_message, sort_keys=True)
+        instructions = agent_config.instructions
+        system_prompt = (
+            instructions.system.content if instructions and instructions.system else None
+        )
 
         def invoke_turn() -> tuple[dict[str, Any], str]:
             return _invoke_hermes_turn(
                 agent=self._agent,
-                system_prompt=_system_instruction(agent_config),
+                system_prompt=system_prompt,
                 user_message=user_message,
                 conversation_history=self._conversation_history,
             )
@@ -476,7 +465,7 @@ class HermesRuntime:
             "adapter": "python",
             "mode": "hermes",
             "model": model_config.model,
-            "base_url": self._base_url,
+            "base_url": model_config.base_url,
             "response": result.get("response") or result.get("final_response"),
             "completed": bool(result.get("completed")),
             "failed": bool(result.get("failed")),
@@ -543,9 +532,7 @@ class HermesRuntime:
         self._session_db = None
         self._agent_config = None
         self._runtime_id = None
-        self._settings = {}
         self._model_config = None
-        self._base_url = None
         self._hermes_home = None
         self._hermes_config_path = None
         self._hermes_config = {}
@@ -608,7 +595,7 @@ def _invoke_hermes_turn(
 ) -> tuple[dict[str, Any], str]:
     hermes_stdout = StringIO()
     with redirect_stdout(hermes_stdout):
-        conversation_kwargs = filter_supported_call_kwargs(
+        conversation_kwargs = filter_supported_kwargs(
             agent.run_conversation,
             system_message=system_prompt,
             conversation_history=conversation_history,
@@ -622,13 +609,7 @@ def _invoke_hermes_turn(
     return result, hermes_stdout.getvalue()
 
 
-def filter_supported_kwargs(callable_obj: Any, **kwargs: Any) -> dict[str, Any]:
-    signature = inspect.signature(callable_obj.__init__)
-    supported = set(signature.parameters)
-    return {key: value for key, value in kwargs.items() if key in supported}
-
-
-def filter_supported_call_kwargs(func: Any, **kwargs: Any) -> dict[str, Any]:
+def filter_supported_kwargs(func: Any, **kwargs: Any) -> dict[str, Any]:
     signature = inspect.signature(func)
     supported = set(signature.parameters)
     return {key: value for key, value in kwargs.items() if key in supported}

--- a/adapters/hermes/src/nemo_fabric_adapters/hermes/adapter.py
+++ b/adapters/hermes/src/nemo_fabric_adapters/hermes/adapter.py
@@ -322,6 +322,7 @@ class HermesRuntime:
             self._hermes_config_path, self._hermes_config = write_hermes_config(
                 agent_config,
                 self._hermes_home,
+                # Workspace belongs to the per-runtime context, not AgentConfig.
                 workspace=str(runtime_context.environment.workspace or "."),
                 relay_enabled=relay_enabled,
             )

--- a/adapters/hermes/src/nemo_fabric_adapters/hermes/adapter.py
+++ b/adapters/hermes/src/nemo_fabric_adapters/hermes/adapter.py
@@ -59,13 +59,14 @@ def _max_turns(config: AgentConfig) -> int | None:
 
 
 def _api_key_env(model_config: AgentModelConfig) -> str:
-    if model_config.api_key_env:
-        return model_config.api_key_env
-    default = PROVIDER_DEFAULT_API_KEY_ENV.get(model_config.provider)
+    explicit = model_config.api_key_env
+    if isinstance(explicit, str) and explicit:
+        return explicit
+    provider = str(model_config.provider or "").lower()
+    default = PROVIDER_DEFAULT_API_KEY_ENV.get(provider)
     if default is None:
         raise ValueError(
-            "selected model api_key_env is required for provider "
-            f"{model_config.provider!r}"
+            f"selected model api_key_env is required for provider {provider!r}"
         )
     return default
 

--- a/adapters/hermes/src/nemo_fabric_adapters/hermes/adapter.py
+++ b/adapters/hermes/src/nemo_fabric_adapters/hermes/adapter.py
@@ -249,6 +249,7 @@ class HermesRuntime:
         self._started = False
         self._agent_config: AgentConfig | None = None
         self._runtime_id: str | None = None
+        self._settings: dict[str, Any] = {}
         self._model_config: AgentModelConfig | None = None
         self._hermes_home: Path | None = None
         self._hermes_config_path: Path | None = None
@@ -282,7 +283,7 @@ class HermesRuntime:
             runtime_context = RuntimeContext.from_mapping(payload.get("runtime_context"))
             validate_hermes_telemetry_provider(runtime_context)
             self._agent_config = agent_config
-            settings = _settings(agent_config)
+            self._settings = _settings(agent_config)
             model_config = _selected_model(agent_config)
             self._model_config = model_config
             self._runtime_id = runtime_context.runtime_id
@@ -302,7 +303,7 @@ class HermesRuntime:
             os.environ["TERMINAL_ENV"] = "local"
             os.environ.setdefault(
                 "TERMINAL_TIMEOUT",
-                str(settings.get("terminal_timeout", 60)),
+                str(self._settings.get("terminal_timeout", 60)),
             )
 
             relay_enabled = bool(
@@ -373,15 +374,15 @@ class HermesRuntime:
                         skip_context_files=True,
                         skip_memory=True,
                         save_trajectories=bool(
-                            settings.get("save_trajectories", False)
+                            self._settings.get("save_trajectories", False)
                         ),
-                        max_tokens=settings.get("max_tokens", 512),
+                        max_tokens=self._settings.get("max_tokens", 512),
                         request_overrides=(
                             {"temperature": temperature}
                             if temperature is not None
                             else None
                         ),
-                        reasoning_config=settings.get(
+                        reasoning_config=self._settings.get(
                             "reasoning_config", {"effort": "none"}
                         ),
                         platform="fabric",
@@ -534,6 +535,7 @@ class HermesRuntime:
         self._session_db = None
         self._agent_config = None
         self._runtime_id = None
+        self._settings = {}
         self._model_config = None
         self._hermes_home = None
         self._hermes_config_path = None

--- a/adapters/hermes/src/nemo_fabric_adapters/hermes/adapter.py
+++ b/adapters/hermes/src/nemo_fabric_adapters/hermes/adapter.py
@@ -23,6 +23,7 @@ from typing import Any
 from nemo_fabric_adapter_contract.models import AgentConfig
 from nemo_fabric_adapter_contract.models import AgentMcpServerConfig
 from nemo_fabric_adapter_contract.models import AgentModelConfig
+from nemo_fabric_adapter_contract.models import RuntimeContext
 from nemo_fabric_adapters.common import lifecycle
 import nemo_fabric_adapters.common.utils as common_utils
 
@@ -63,12 +64,8 @@ def _max_turns(config: AgentConfig) -> int | None:
     return config.runtime.max_turns if config.runtime is not None else None
 
 
-def _workspace(payload: dict[str, Any]) -> str:
-    environment = common_utils.runtime_context(payload).get("environment") or {}
-    if not isinstance(environment, dict):
-        return "."
-    workspace = environment.get("workspace")
-    return str(workspace) if workspace else "."
+def _workspace(runtime_context: RuntimeContext) -> str:
+    return str(runtime_context.environment.workspace or ".")
 
 
 def _api_key_env(model_config: AgentModelConfig) -> str:
@@ -103,8 +100,9 @@ def _fabric_stream_sink_enabled(config: dict[str, Any] | None) -> bool:
     return False
 
 
-def validate_hermes_telemetry_provider(payload: dict[str, Any]) -> None:
-    providers = common_utils.telemetry_providers(payload)
+def validate_hermes_telemetry_provider(runtime_context: RuntimeContext) -> None:
+    telemetry = runtime_context.telemetry
+    providers = telemetry.metadata.get("telemetry_providers", []) if telemetry else []
     if any(provider != "relay" for provider in providers):
         raise ValueError("only relay telemetry is supported for Hermes")
 
@@ -243,15 +241,14 @@ def resolve_hermes_toolsets(
     return sorted(_get_platform_tools(config, "cli"))
 
 
-def _artifact_root(payload: dict[str, Any]) -> Path:
-    artifacts = common_utils.runtime_context(payload).get("artifacts") or {}
-    root = artifacts.get("root") if isinstance(artifacts, dict) else None
+def _artifact_root(runtime_context: RuntimeContext, base_dir: str) -> Path:
+    root = runtime_context.artifacts.root
     if root:
         artifact_root = Path(str(root))
         if not artifact_root.is_absolute():
-            artifact_root = Path(common_utils.base_dir(payload)) / artifact_root
+            artifact_root = Path(base_dir) / artifact_root
         return artifact_root.resolve()
-    return Path(common_utils.base_dir(payload)).resolve() / "artifacts"
+    return Path(base_dir).resolve() / "artifacts"
 
 
 class HermesRuntime:
@@ -289,19 +286,24 @@ class HermesRuntime:
         try:
             self._relay_session_pending = False
             self._relay_finalize_hook_invoked = False
-            validate_hermes_telemetry_provider(payload)
             agent_config = payload.get("config")
             if not isinstance(agent_config, AgentConfig):
                 raise lifecycle.LifecycleError(
                     "hermes_invalid_config",
                     "Hermes requires a validated AgentConfig",
                 )
+            runtime_context = RuntimeContext.from_mapping(payload.get("runtime_context"))
+            validate_hermes_telemetry_provider(runtime_context)
             self._agent_config = agent_config
             self._settings = _settings(agent_config)
             self._model_config = _selected_model(agent_config)
-            self._runtime_id = common_utils.runtime_id(payload)
-            self._hermes_home = common_utils.runtime_state_directory(
-                _artifact_root(payload) / ".fabric" / "hermes", payload
+            self._runtime_id = runtime_context.runtime_id
+            self._hermes_home = (
+                _artifact_root(runtime_context, common_utils.base_dir(payload))
+                / ".fabric"
+                / "hermes"
+                / "runtimes"
+                / runtime_context.runtime_id
             )
             self._hermes_home.mkdir(parents=True, exist_ok=True)
             os.environ["HOME"] = str(self._hermes_home)
@@ -315,7 +317,9 @@ class HermesRuntime:
                 str(self._settings.get("terminal_timeout", 60)),
             )
 
-            relay_enabled = common_utils.relay_enabled(payload)
+            relay_enabled = bool(
+                runtime_context.telemetry and runtime_context.telemetry.relay_enabled
+            )
             if relay_enabled:
                 relay_payload = {**payload, "config": agent_config.to_mapping()}
                 self._relay_plugin_config = common_utils.load_relay_plugin_config(
@@ -330,7 +334,7 @@ class HermesRuntime:
             self._hermes_config_path, self._hermes_config = write_hermes_config(
                 agent_config,
                 self._hermes_home,
-                workspace=_workspace(payload),
+                workspace=_workspace(runtime_context),
                 relay_enabled=relay_enabled,
             )
             api_key_env = _api_key_env(self._model_config)
@@ -417,7 +421,8 @@ class HermesRuntime:
                 "hermes_runtime_not_started",
                 "Hermes runtime is not started",
             )
-        if common_utils.runtime_id(invocation) != self._runtime_id:
+        runtime_context = RuntimeContext.from_mapping(invocation.get("runtime_context"))
+        if runtime_context.runtime_id != self._runtime_id:
             raise lifecycle.LifecycleError(
                 "hermes_runtime_mismatch",
                 "Hermes invocation does not match the active runtime",
@@ -445,7 +450,7 @@ class HermesRuntime:
                 "nemo-fabric-invocation",
                 ScopeType.Agent,
                 metadata={
-                    "nemo_fabric_request_id": request.get("request_id"),
+                    "nemo_fabric_request_id": runtime_context.request_id,
                 },
             ):
                 try:

--- a/adapters/hermes/uv.lock
+++ b/adapters/hermes/uv.lock
@@ -618,6 +618,15 @@ wheels = [
 ]
 
 [[package]]
+name = "nemo-fabric-adapter-contract"
+version = "0.2.0"
+source = { editable = "../../adapter-contract" }
+
+[package.metadata]
+requires-dist = [{ name = "pydantic", marker = "extra == 'pydantic'", specifier = ">=2.12,<3" }]
+provides-extras = ["pydantic"]
+
+[[package]]
 name = "nemo-fabric-adapters-common"
 version = "0.2.0"
 source = { editable = "../common" }
@@ -627,6 +636,7 @@ name = "nemo-fabric-adapters-hermes"
 version = "0.2.0"
 source = { editable = "." }
 dependencies = [
+    { name = "nemo-fabric-adapter-contract" },
     { name = "nemo-fabric-adapters-common" },
 ]
 
@@ -646,6 +656,7 @@ relay = [
 requires-dist = [
     { name = "hermes-agent", extras = ["mcp"], marker = "python_full_version < '3.14' and extra == 'full'", specifier = ">=0.19.0" },
     { name = "hermes-agent", extras = ["mcp"], marker = "python_full_version < '3.14' and extra == 'harness'", specifier = ">=0.19.0" },
+    { name = "nemo-fabric-adapter-contract", editable = "../../adapter-contract" },
     { name = "nemo-fabric-adapters-common", editable = "../common" },
     { name = "nemo-relay", marker = "extra == 'full'", specifier = ">=0.6.0,<0.7" },
     { name = "nemo-relay", marker = "extra == 'relay'", specifier = ">=0.6.0,<0.7" },

--- a/crates/fabric-cli/assets/adapters/hermes/fabric-adapter.json
+++ b/crates/fabric-cli/assets/adapters/hermes/fabric-adapter.json
@@ -62,6 +62,7 @@
     "additionalProperties": false
   },
   "config": {
+    "input": "agent_config",
     "accepts": [
       "models",
       "models.base_url",

--- a/examples/harbor/swebench/adapters/hermes/fabric-adapter.json
+++ b/examples/harbor/swebench/adapters/hermes/fabric-adapter.json
@@ -62,6 +62,7 @@
     "additionalProperties": false
   },
   "config": {
+    "input": "agent_config",
     "accepts": [
       "models",
       "models.base_url",

--- a/tests/adapters/test_adapaters_common_utils.py
+++ b/tests/adapters/test_adapaters_common_utils.py
@@ -238,22 +238,6 @@ def test_runtime_id_requires_runtime_context():
         common_utils.runtime_id({"runtime_context": {}})
 
 
-def test_runtime_state_directory_is_scoped_to_runtime(
-    tmp_path: Path,
-):
-    first = common_utils.runtime_state_directory(
-        tmp_path / "hermes-home",
-        {"runtime_context": {"runtime_id": "runtime-1"}},
-    )
-    second = common_utils.runtime_state_directory(
-        tmp_path / "hermes-home",
-        {"runtime_context": {"runtime_id": "runtime-2"}},
-    )
-
-    assert first == tmp_path / "hermes-home" / "runtimes" / "runtime-1"
-    assert second == tmp_path / "hermes-home" / "runtimes" / "runtime-2"
-
-
 def test_dump_yaml_falls_back_to_json_when_yaml_is_unavailable(
     monkeypatch: pytest.MonkeyPatch,
 ):

--- a/tests/adapters/test_adapter_package_metadata.py
+++ b/tests/adapters/test_adapter_package_metadata.py
@@ -50,9 +50,7 @@ ADAPTER_EXTRAS = {
             f"nemo-fabric-adapters-hermes[harness] == {PACKAGE_VERSION}; "
             "python_version < '3.14'"
         ),
-        "harness": [
-            "hermes-agent[mcp]>=0.19.0; python_version < '3.14'"
-        ],
+        "harness": ["hermes-agent[mcp]>=0.19.0; python_version < '3.14'"],
         "relay": ["nemo-relay>=0.6.0,<0.7"],
     },
 }
@@ -88,7 +86,10 @@ ADAPTER_EXTRAS = {
         ),
         (
             "adapters/hermes",
-            [f"nemo-fabric-adapters-common == {PACKAGE_VERSION}"],
+            [
+                f"nemo-fabric-adapter-contract == {PACKAGE_VERSION}",
+                f"nemo-fabric-adapters-common == {PACKAGE_VERSION}",
+            ],
         ),
     ],
 )

--- a/tests/adapters/test_hermes_adapter.py
+++ b/tests/adapters/test_hermes_adapter.py
@@ -17,6 +17,7 @@ from unittest.mock import MagicMock
 import pytest
 from nemo_fabric_adapter_contract.models import AgentConfig
 from nemo_fabric_adapter_contract.models import AgentMcpServerConfig
+from nemo_fabric_adapter_contract.models import RuntimeContext
 
 pytestmark = pytest.mark.usefixtures("requires_hermes_agent")
 
@@ -33,35 +34,62 @@ def _agent_config(value: dict[str, object]) -> AgentConfig:
     return AgentConfig.from_mapping(value)
 
 
-@pytest.mark.parametrize("providers", [None, {"relay": {}}])
-def test_validate_hermes_telemetry_provider_accepts_relay(
-    providers: dict[str, object] | None,
-):
-    payload = {}
+def _runtime_context(
+    *,
+    runtime_id: str = "runtime-1",
+    workspace: str | None = None,
+    artifact_root: str | None = None,
+    providers: list[str] | None = None,
+) -> RuntimeContext:
+    environment: dict[str, object] = {
+        "environment_id": "environment-1",
+        "provider": "test",
+        "control_location": "in_env_control",
+        "ownership": "caller_owned",
+    }
+    if workspace is not None:
+        environment["workspace"] = workspace
+    telemetry = None
     if providers is not None:
-        payload["telemetry_plan"] = {"providers": list(providers)}
+        telemetry = {
+            "relay_enabled": providers == ["relay"],
+            "metadata": {"telemetry_providers": providers},
+        }
+    return RuntimeContext.from_mapping(
+        {
+            "runtime_id": runtime_id,
+            "invocation_id": "invocation-1",
+            "request_id": "request-1",
+            "environment": environment,
+            "artifacts": {"root": artifact_root} if artifact_root else {},
+            "telemetry": telemetry,
+        }
+    )
 
-    adapter.validate_hermes_telemetry_provider(payload)
+
+@pytest.mark.parametrize("providers", [None, ["relay"]])
+def test_validate_hermes_telemetry_provider_accepts_relay(
+    providers: list[str] | None,
+):
+    adapter.validate_hermes_telemetry_provider(_runtime_context(providers=providers))
 
 
 def test_validate_hermes_telemetry_provider_rejects_native():
-    payload = {"telemetry_plan": {"providers": ["native"], "relay_enabled": False}}
-
     with pytest.raises(
         ValueError, match="only relay telemetry is supported for Hermes"
     ):
-        adapter.validate_hermes_telemetry_provider(payload)
+        adapter.validate_hermes_telemetry_provider(
+            _runtime_context(providers=["native"])
+        )
 
 
 def test_validate_hermes_telemetry_provider_rejects_mixed_native_and_relay():
-    payload = {
-        "telemetry_plan": {"providers": ["relay", "native"], "relay_enabled": True}
-    }
-
     with pytest.raises(
         ValueError, match="only relay telemetry is supported for Hermes"
     ):
-        adapter.validate_hermes_telemetry_provider(payload)
+        adapter.validate_hermes_telemetry_provider(
+            _runtime_context(providers=["relay", "native"])
+        )
 
 
 def test_descriptor_uses_the_typed_agent_config_contract():
@@ -499,11 +527,11 @@ async def test_runtime_start_discovers_mcp_tools_when_configured(
     payload = {
         "agent_name": "mcp-discover",
         "base_dir": str(tmp_path),
-        "runtime_context": {
-            "runtime_id": "runtime-mcp-discover",
-            "environment": {"workspace": str(tmp_path)},
-            "artifacts": {"root": str(tmp_path / "artifacts")},
-        },
+        "runtime_context": _runtime_context(
+            runtime_id="runtime-mcp-discover",
+            workspace=str(tmp_path),
+            artifact_root=str(tmp_path / "artifacts"),
+        ).to_mapping(),
     }
     payload["config"] = _agent_config(
         {
@@ -616,7 +644,10 @@ def test_summarize_hermes_config():
 
 
 async def test_runtime_start_rejects_native_telemetry():
-    payload = {"telemetry_plan": {"providers": ["native"], "relay_enabled": False}}
+    payload = {
+        "config": _agent_config({}),
+        "runtime_context": _runtime_context(providers=["native"]).to_mapping(),
+    }
 
     with pytest.raises(
         ValueError, match="only relay telemetry is supported for Hermes"
@@ -631,7 +662,9 @@ async def test_runtime_start_requires_typed_agent_config():
                 "config": {
                     "models": {"default": {"provider": "nvidia", "model": "test-model"}}
                 },
-                "runtime_context": {"runtime_id": "runtime-untyped"},
+                "runtime_context": _runtime_context(
+                    runtime_id="runtime-untyped"
+                ).to_mapping(),
             }
         )
 
@@ -651,11 +684,11 @@ async def test_runtime_start_overrides_inherited_terminal_environment(
     monkeypatch.setattr(adapter, "write_hermes_config", stop_after_environment_setup)
     payload = {
         "base_dir": str(tmp_path),
-        "runtime_context": {
-            "runtime_id": "runtime-terminal-env",
-            "environment": {"workspace": str(tmp_path)},
-            "artifacts": {"root": str(tmp_path / "artifacts")},
-        },
+        "runtime_context": _runtime_context(
+            runtime_id="runtime-terminal-env",
+            workspace=str(tmp_path),
+            artifact_root=str(tmp_path / "artifacts"),
+        ).to_mapping(),
     }
     payload["config"] = _agent_config(
         {
@@ -669,12 +702,10 @@ async def test_runtime_start_overrides_inherited_terminal_environment(
 
 
 def test_artifact_root_resolves_relative_to_base_dir(tmp_path: Path):
-    payload = {
-        "base_dir": str(tmp_path),
-        "runtime_context": {"artifacts": {"root": "run-artifacts"}},
-    }
-
-    assert adapter._artifact_root(payload) == (tmp_path / "run-artifacts").resolve()
+    assert adapter._artifact_root(
+        _runtime_context(artifact_root="run-artifacts"),
+        str(tmp_path),
+    ) == (tmp_path / "run-artifacts").resolve()
 
 
 async def test_persistent_runtime_reuses_hermes_agent_session_and_history(
@@ -741,10 +772,10 @@ async def test_persistent_runtime_reuses_hermes_agent_session_and_history(
     payload = {
         "agent_name": "demo",
         "base_dir": str(tmp_path),
-        "runtime_context": {
-            "runtime_id": "runtime-fabric-123",
-            "environment": {"workspace": str(tmp_path)},
-        },
+        "runtime_context": _runtime_context(
+            runtime_id="runtime-fabric-123",
+            workspace=str(tmp_path),
+        ).to_mapping(),
         "request": {
             "input": "hello",
             "context": {"history": [{"role": "user", "content": "stale"}]},

--- a/tests/adapters/test_hermes_adapter.py
+++ b/tests/adapters/test_hermes_adapter.py
@@ -22,9 +22,15 @@ if importlib.util.find_spec("run_agent") is not None:
     from hermes_state import SessionDB
     from run_agent import AIAgent
 
+    from nemo_fabric_adapter_contract.models import AgentConfig
+    from nemo_fabric_adapter_contract.models import AgentMcpServerConfig
     import nemo_fabric_adapters.common.utils as common_utils
 
     from nemo_fabric_adapters.hermes import adapter
+
+
+def _agent_config(value: dict[str, object]) -> AgentConfig:
+    return AgentConfig.from_mapping(value)
 
 
 @pytest.mark.parametrize("providers", [None, {"relay": {}}])
@@ -56,6 +62,27 @@ def test_validate_hermes_telemetry_provider_rejects_mixed_native_and_relay():
         ValueError, match="only relay telemetry is supported for Hermes"
     ):
         adapter.validate_hermes_telemetry_provider(payload)
+
+
+def test_descriptor_uses_the_typed_agent_config_contract():
+    descriptor_path = (
+        Path(__file__).parents[2] / "adapters" / "hermes" / "fabric-adapter.json"
+    )
+    descriptor = json.loads(descriptor_path.read_text(encoding="utf-8"))
+
+    assert descriptor["contract_version"] == "fabric.adapter/v1alpha2"
+    assert descriptor["config"]["input"] == "agent_config"
+    assert descriptor["config"]["accepts"] == [
+        "models",
+        "models.base_url",
+        "models.temperature",
+        "instructions.system",
+        "runtime.max_turns",
+        "tools.enabled",
+        "tools.blocked",
+        "mcp",
+        "skills",
+    ]
 
 
 def test_finalize_relay_session_flushes_before_artifact_collection(monkeypatch):
@@ -163,22 +190,8 @@ async def test_stop_retries_failed_relay_flush_without_refinalizing(monkeypatch)
 
 def test_build_hermes_config_maps_fabric_config_to_hermes_config():
     os.environ["MCP_URL"] = "http://localhost:9000/mcp"
-    payload = {
-        "runtime_context": {"environment": {"workspace": "/workspace/repo"}},
-        "capability_plan": {
-            "native": {
-                "skill_paths": ["skills/review"],
-                "mcp_servers": {
-                    "github": {
-                        "transport": "stdio",
-                        "url": "github-mcp",
-                        "args": ["--stdio"],
-                    },
-                    "memory": {"transport": "sse", "url": "${MCP_URL}"},
-                },
-            }
-        },
-        "config": {
+    agent_config = _agent_config(
+        {
             "harness": {
                 "settings": {
                     "terminal_timeout": 90,
@@ -197,10 +210,24 @@ def test_build_hermes_config_maps_fabric_config_to_hermes_config():
                     "base_url": "https://model.example/v1",
                 }
             },
-        },
-    }
-
-    config = adapter.build_hermes_config(payload, relay_enabled=True)
+            "skills": {"paths": ["skills/review"]},
+            "mcp": {
+                "servers": {
+                    "github": {
+                        "transport": "stdio",
+                        "url": "github-mcp",
+                        "args": ["--stdio"],
+                    },
+                    "memory": {"transport": "sse", "url": "${MCP_URL}"},
+                }
+            },
+        }
+    )
+    config = adapter.build_hermes_config(
+        agent_config,
+        workspace="/workspace/repo",
+        relay_enabled=True,
+    )
 
     assert config == {
         "model": {
@@ -250,14 +277,14 @@ def test_default_max_iterations_matches_hermes_library_default():
 def test_build_hermes_config_omits_max_turns_when_fabric_limit_unset():
     # When max_turns is unset the config layer must leave agent.max_turns
     # absent so Hermes applies its own default rather than a starving override.
-    payload = {
-        "config": {
+    agent_config = _agent_config(
+        {
             "harness": {"settings": {}},
             "models": {"default": {"provider": "nvidia", "model": "nvidia/test-model"}},
         }
-    }
+    )
 
-    config = adapter.build_hermes_config(payload)
+    config = adapter.build_hermes_config(agent_config)
 
     assert "max_turns" not in config["agent"]
 
@@ -265,15 +292,15 @@ def test_build_hermes_config_omits_max_turns_when_fabric_limit_unset():
 def test_build_hermes_config_omits_max_turns_when_fabric_limit_null():
     # An explicit null max_turns is treated like unset: agent.max_turns is
     # omitted so Hermes applies its own default instead of a starving override.
-    payload = {
-        "config": {
+    agent_config = _agent_config(
+        {
             "harness": {"settings": {}},
             "runtime": {"max_turns": None},
             "models": {"default": {"provider": "nvidia", "model": "nvidia/test-model"}},
         }
-    }
+    )
 
-    config = adapter.build_hermes_config(payload)
+    config = adapter.build_hermes_config(agent_config)
 
     assert "max_turns" not in config["agent"]
 
@@ -313,27 +340,11 @@ def test_hermes_config_variation_matrix_surfaces_supported_capabilities(
             },
             "telemetry": {"relay_enabled": True},
         },
-        "capability_plan": {
-            "native": {
-                "skill_paths": [tmp_path / "skills" / "review"],
-                "mcp_servers": {
-                    "github": {
-                        "transport": "stdio",
-                        "url": "github-mcp",
-                        "args": ["--stdio"],
-                        "exposure": "harness_native",
-                    },
-                    "memory": {
-                        "transport": "streamable-http",
-                        "url": "https://mcp.example/memory",
-                        "exposure": "harness_native",
-                    },
-                },
-            }
-        },
         "agent_name": "matrix-agent",
         "base_dir": str(tmp_path),
-        "config": {
+    }
+    agent_config = _agent_config(
+        {
             "harness": {"settings": {}},
             "tools": {"enabled": ["git", "shell"]},
             "models": {
@@ -342,10 +353,29 @@ def test_hermes_config_variation_matrix_surfaces_supported_capabilities(
                     "model": "nvidia/review-model",
                 }
             },
-        },
-    }
+            "skills": {"paths": [tmp_path / "skills" / "review"]},
+            "mcp": {
+                "servers": {
+                    "github": {
+                        "transport": "stdio",
+                        "url": "github-mcp",
+                        "args": ["--stdio"],
+                    },
+                    "memory": {
+                        "transport": "streamable-http",
+                        "url": "https://mcp.example/memory",
+                    },
+                }
+            },
+        }
+    )
+    payload["config"] = agent_config.to_mapping()
 
-    config = adapter.build_hermes_config(payload, relay_enabled=True)
+    config = adapter.build_hermes_config(
+        agent_config,
+        workspace=str(tmp_path / "workspace"),
+        relay_enabled=True,
+    )
     plugin_config = common_utils.load_relay_plugin_config(payload)
     observability = plugin_config["components"][0]["config"]
 
@@ -379,30 +409,11 @@ def test_hermes_config_variation_matrix_surfaces_supported_capabilities(
     assert observability["atif"]["model_name"] == "nvidia/review-model"
 
 
-def test_build_hermes_config_maps_stdio_mcp_args_and_env_from_capability_plan(
+def test_build_hermes_config_maps_stdio_mcp_args_and_env_from_agent_config(
     tmp_path: Path,
 ):
-    payload = {
-        "runtime_context": {
-            "runtime_id": "runtime-mcp-env",
-            "environment": {"workspace": str(tmp_path / "workspace")},
-        },
-        "capability_plan": {
-            "native": {
-                "mcp_servers": {
-                    "analyzer": {
-                        "transport": "stdio",
-                        "url": str(tmp_path / "analyzer-mcp"),
-                        "exposure": "harness_native",
-                        "args": ["--stdio"],
-                        "env": {"NVIDIA_API_KEY": "${NVIDIA_API_KEY}"},
-                    }
-                }
-            }
-        },
-        "agent_name": "mcp-env-agent",
-        "base_dir": str(tmp_path),
-        "config": {
+    agent_config = _agent_config(
+        {
             "harness": {"settings": {}},
             "models": {
                 "default": {
@@ -410,10 +421,23 @@ def test_build_hermes_config_maps_stdio_mcp_args_and_env_from_capability_plan(
                     "model": "nvidia/test-model",
                 }
             },
-        },
-    }
+            "mcp": {
+                "servers": {
+                    "analyzer": {
+                        "transport": "stdio",
+                        "url": str(tmp_path / "analyzer-mcp"),
+                        "args": ["--stdio"],
+                        "env": {"NVIDIA_API_KEY": "${NVIDIA_API_KEY}"},
+                    }
+                }
+            },
+        }
+    )
 
-    config = adapter.build_hermes_config(payload)
+    config = adapter.build_hermes_config(
+        agent_config,
+        workspace=str(tmp_path / "workspace"),
+    )
 
     assert config["mcp_servers"] == {
         "analyzer": {
@@ -475,7 +499,14 @@ async def test_runtime_start_discovers_mcp_tools_when_configured(
     payload = {
         "agent_name": "mcp-discover",
         "base_dir": str(tmp_path),
-        "config": {
+        "runtime_context": {
+            "runtime_id": "runtime-mcp-discover",
+            "environment": {"workspace": str(tmp_path)},
+            "artifacts": {"root": str(tmp_path / "artifacts")},
+        },
+    }
+    payload["config"] = _agent_config(
+        {
             "harness": {"settings": {}},
             "models": {
                 "default": {
@@ -485,25 +516,17 @@ async def test_runtime_start_discovers_mcp_tools_when_configured(
                 }
             },
             "tools": {"enabled": ["mcp-analyzer"]},
-        },
-        "runtime_context": {
-            "runtime_id": "runtime-mcp-discover",
-            "environment": {"workspace": str(tmp_path)},
-            "artifacts": {"root": str(tmp_path / "artifacts")},
-        },
-        "capability_plan": {
-            "native": {
-                "mcp_servers": {
+            "mcp": {
+                "servers": {
                     "analyzer": {
                         "transport": "stdio",
                         "url": str(tmp_path / "analyzer-mcp"),
-                        "exposure": "harness_native",
                         "env": {"NVIDIA_API_KEY": "${NVIDIA_API_KEY}"},
                     }
                 }
-            }
-        },
-    }
+            },
+        }
+    )
 
     runtime = adapter.HermesRuntime()
     await runtime.start(payload)
@@ -519,14 +542,17 @@ async def test_runtime_start_discovers_mcp_tools_when_configured(
 
 
 def test_write_hermes_config_writes_file(tmp_path: Path):
-    payload = {
-        "config": {
+    agent_config = _agent_config(
+        {
             "harness": {"settings": {}},
             "models": {"default": {"provider": "nvidia", "model": "nvidia/test-model"}},
         }
-    }
+    )
 
-    config_path, config = adapter.write_hermes_config(payload, tmp_path / "hermes-home")
+    config_path, config = adapter.write_hermes_config(
+        agent_config,
+        tmp_path / "hermes-home",
+    )
 
     assert config_path == tmp_path / "hermes-home" / "config.yaml"
     assert config_path.exists()
@@ -538,39 +564,34 @@ def test_write_hermes_config_writes_file(tmp_path: Path):
     ("server", "expected"),
     [
         (
-            {"transport": "stdio", "url": "python3", "args": ["server.py"]},
+            AgentMcpServerConfig(
+                transport="stdio",
+                url="python3",
+                args=["server.py"],
+            ),
             {"enabled": True, "command": "python3", "args": ["server.py"]},
         ),
         (
-            {"transport": "sse", "url": "http://localhost:9000/sse"},
+            AgentMcpServerConfig(
+                transport="sse",
+                url="http://localhost:9000/sse",
+            ),
             {"enabled": True, "url": "http://localhost:9000/sse", "transport": "sse"},
         ),
         (
-            {"transport": "websocket", "url": "ws://localhost:9000"},
+            AgentMcpServerConfig(
+                transport="websocket",
+                url="ws://localhost:9000",
+            ),
             {"enabled": True, "url": "ws://localhost:9000", "transport": "websocket"},
         ),
     ],
 )
 def test_hermes_mcp_server_config(
-    server: dict[str, object],
+    server: AgentMcpServerConfig,
     expected: dict[str, object],
 ):
     assert adapter.hermes_mcp_server_config(server) == expected
-
-
-@pytest.mark.parametrize(
-    "server",
-    [
-        {"transport": "stdio"},
-        {"transport": "stdio", "command": "server --stdio"},
-        {"transport": "stdio", "url": "   "},
-    ],
-)
-def test_hermes_mcp_server_config_rejects_unsupported_mappings(
-    server: dict[str, str],
-):
-    with pytest.raises(ValueError, match="requires a URL"):
-        adapter.hermes_mcp_server_config(server)
 
 
 def test_summarize_hermes_config():
@@ -603,6 +624,20 @@ async def test_runtime_start_rejects_native_telemetry():
         await adapter.HermesRuntime().start(payload)
 
 
+async def test_runtime_start_requires_typed_agent_config():
+    with pytest.raises(adapter.lifecycle.LifecycleError) as caught:
+        await adapter.HermesRuntime().start(
+            {
+                "config": {
+                    "models": {"default": {"provider": "nvidia", "model": "test-model"}}
+                },
+                "runtime_context": {"runtime_id": "runtime-untyped"},
+            }
+        )
+
+    assert caught.value.code == "hermes_invalid_config"
+
+
 async def test_runtime_start_overrides_inherited_terminal_environment(
     monkeypatch,
     tmp_path: Path,
@@ -616,16 +651,18 @@ async def test_runtime_start_overrides_inherited_terminal_environment(
     monkeypatch.setattr(adapter, "write_hermes_config", stop_after_environment_setup)
     payload = {
         "base_dir": str(tmp_path),
-        "config": {
-            "harness": {"settings": {}},
-            "models": {"default": {"provider": "nvidia", "model": "test-model"}},
-        },
         "runtime_context": {
             "runtime_id": "runtime-terminal-env",
             "environment": {"workspace": str(tmp_path)},
             "artifacts": {"root": str(tmp_path / "artifacts")},
         },
     }
+    payload["config"] = _agent_config(
+        {
+            "harness": {"settings": {}},
+            "models": {"default": {"provider": "nvidia", "model": "test-model"}},
+        }
+    )
 
     with pytest.raises(RuntimeError, match="stop after environment setup"):
         await adapter.HermesRuntime().start(payload)
@@ -704,11 +741,19 @@ async def test_persistent_runtime_reuses_hermes_agent_session_and_history(
     payload = {
         "agent_name": "demo",
         "base_dir": str(tmp_path),
-        "config": {
+        "runtime_context": {
+            "runtime_id": "runtime-fabric-123",
+            "environment": {"workspace": str(tmp_path)},
+        },
+        "request": {
+            "input": "hello",
+            "context": {"history": [{"role": "user", "content": "stale"}]},
+        },
+    }
+    payload["config"] = _agent_config(
+        {
             "harness": {"settings": {}},
-            "instructions": {
-                "system": {"content": "system", "mode": "replace"}
-            },
+            "instructions": {"system": {"content": "system", "mode": "replace"}},
             "runtime": {"max_turns": None},
             "tools": {"enabled": []},
             "models": {
@@ -719,17 +764,8 @@ async def test_persistent_runtime_reuses_hermes_agent_session_and_history(
                     "temperature": 0.2,
                 }
             },
-        },
-        "runtime_context": {
-            "runtime_id": "runtime-fabric-123",
-            "environment": {"workspace": str(tmp_path)},
-        },
-        "request": {
-            "input": "hello",
-            "context": {"history": [{"role": "user", "content": "stale"}]},
-        },
-        "capability_plan": {"native": {}},
-    }
+        }
+    )
 
     start_payload = {key: value for key, value in payload.items() if key != "request"}
     runtime = adapter.HermesRuntime()
@@ -787,7 +823,7 @@ async def test_persistent_runtime_reuses_hermes_agent_session_and_history(
     mock_session_db.close.assert_called_once_with()
     assert runtime._agent is None
     assert runtime._session_db is None
-    assert runtime._start_payload is None
+    assert runtime._agent_config is None
     assert runtime._conversation_history is None
     assert first["response"] == "first response"
     assert second["response"] == "second response"
@@ -808,4 +844,7 @@ def test_main_serves_persistent_runtime(monkeypatch):
 
     adapter.main()
 
-    serve.assert_called_once_with(adapter.HermesRuntime)
+    serve.assert_called_once_with(
+        adapter.HermesRuntime,
+        config_loader=AgentConfig.from_mapping,
+    )

--- a/tests/adapters/test_hermes_adapter.py
+++ b/tests/adapters/test_hermes_adapter.py
@@ -15,6 +15,8 @@ from types import ModuleType, SimpleNamespace
 from unittest.mock import MagicMock
 
 import pytest
+from nemo_fabric_adapter_contract.models import AgentConfig
+from nemo_fabric_adapter_contract.models import AgentMcpServerConfig
 
 pytestmark = pytest.mark.usefixtures("requires_hermes_agent")
 
@@ -22,8 +24,6 @@ if importlib.util.find_spec("run_agent") is not None:
     from hermes_state import SessionDB
     from run_agent import AIAgent
 
-    from nemo_fabric_adapter_contract.models import AgentConfig
-    from nemo_fabric_adapter_contract.models import AgentMcpServerConfig
     import nemo_fabric_adapters.common.utils as common_utils
 
     from nemo_fabric_adapters.hermes import adapter

--- a/tests/adapters/test_hermes_adapter.py
+++ b/tests/adapters/test_hermes_adapter.py
@@ -312,7 +312,7 @@ def test_build_hermes_config_omits_max_turns_when_fabric_limit_unset():
         }
     )
 
-    config = adapter.build_hermes_config(agent_config)
+    config = adapter.build_hermes_config(agent_config, workspace=".")
 
     assert "max_turns" not in config["agent"]
 
@@ -328,7 +328,7 @@ def test_build_hermes_config_omits_max_turns_when_fabric_limit_null():
         }
     )
 
-    config = adapter.build_hermes_config(agent_config)
+    config = adapter.build_hermes_config(agent_config, workspace=".")
 
     assert "max_turns" not in config["agent"]
 
@@ -580,6 +580,7 @@ def test_write_hermes_config_writes_file(tmp_path: Path):
     config_path, config = adapter.write_hermes_config(
         agent_config,
         tmp_path / "hermes-home",
+        workspace=".",
     )
 
     assert config_path == tmp_path / "hermes-home" / "config.yaml"

--- a/tests/adapters/test_hermes_config_builder.py
+++ b/tests/adapters/test_hermes_config_builder.py
@@ -9,6 +9,7 @@ import sys
 from pathlib import Path
 
 import pytest
+from nemo_fabric_adapter_contract.models import AgentConfig
 
 if sys.version_info >= (3, 14):
     pytest.skip(
@@ -20,8 +21,8 @@ from nemo_fabric_adapters.hermes import adapter
 
 
 def test_build_hermes_config_omits_unset_values_without_hermes_agent():
-    payload = {
-        "config": {
+    config = AgentConfig.from_mapping(
+        {
             "harness": {"settings": {}},
             "models": {
                 "default": {
@@ -30,9 +31,9 @@ def test_build_hermes_config_omits_unset_values_without_hermes_agent():
                 }
             },
         }
-    }
+    )
 
-    config = adapter.build_hermes_config(payload)
+    config = adapter.build_hermes_config(config)
 
     assert config["model"] == {
         "provider": "nvidia",
@@ -53,13 +54,16 @@ def test_write_hermes_config_round_trips_without_pyyaml(
         return real_import(name, *args, **kwargs)
 
     monkeypatch.setattr(builtins, "__import__", import_without_yaml)
-    payload = {
-        "config": {
+    agent_config = AgentConfig.from_mapping(
+        {
             "harness": {"settings": {}},
             "models": {"default": {"provider": "nvidia", "model": "nvidia/test-model"}},
         }
-    }
+    )
 
-    config_path, config = adapter.write_hermes_config(payload, tmp_path / "hermes-home")
+    config_path, config = adapter.write_hermes_config(
+        agent_config,
+        tmp_path / "hermes-home",
+    )
 
     assert json.loads(config_path.read_text(encoding="utf-8")) == config

--- a/tests/adapters/test_hermes_config_builder.py
+++ b/tests/adapters/test_hermes_config_builder.py
@@ -33,7 +33,7 @@ def test_build_hermes_config_omits_unset_values_without_hermes_agent():
         }
     )
 
-    config = adapter.build_hermes_config(config)
+    config = adapter.build_hermes_config(config, workspace=".")
 
     assert config["model"] == {
         "provider": "nvidia",
@@ -64,6 +64,7 @@ def test_write_hermes_config_round_trips_without_pyyaml(
     config_path, config = adapter.write_hermes_config(
         agent_config,
         tmp_path / "hermes-home",
+        workspace=".",
     )
 
     assert json.loads(config_path.read_text(encoding="utf-8")) == config

--- a/tests/adapters/test_hermes_streaming.py
+++ b/tests/adapters/test_hermes_streaming.py
@@ -9,6 +9,7 @@ from pathlib import Path
 from types import SimpleNamespace
 
 import pytest
+from nemo_fabric_adapter_contract.models import AgentConfig
 
 if sys.version_info >= (3, 14):
     pytest.skip(
@@ -57,7 +58,10 @@ async def test_relay_invocation_scope_carries_fabric_request_id(
     events: list[str] = []
     runtime = adapter.HermesRuntime()
     runtime._started = True
-    runtime._start_payload = {}
+    runtime._agent_config = AgentConfig.from_mapping(
+        {"models": {"default": {"provider": "nvidia", "model": "test-model"}}}
+    )
+    runtime._model_config = runtime._agent_config.models["default"]
     runtime._runtime_id = "runtime-1"
     runtime._agent = SimpleNamespace(
         session_id="runtime-1",

--- a/tests/adapters/test_hermes_streaming.py
+++ b/tests/adapters/test_hermes_streaming.py
@@ -10,6 +10,7 @@ from types import SimpleNamespace
 
 import pytest
 from nemo_fabric_adapter_contract.models import AgentConfig
+from nemo_fabric_adapter_contract.models import RuntimeContext
 
 if sys.version_info >= (3, 14):
     pytest.skip(
@@ -111,8 +112,21 @@ async def test_relay_invocation_scope_carries_fabric_request_id(
 
     await runtime.invoke(
         {
-            "runtime_context": {"runtime_id": "runtime-1"},
-            "request": {"input": "hello", "request_id": "request-1"},
+            "runtime_context": RuntimeContext.from_mapping(
+                {
+                    "runtime_id": "runtime-1",
+                    "invocation_id": "invocation-1",
+                    "request_id": "request-1",
+                    "environment": {
+                        "environment_id": "environment-1",
+                        "provider": "test",
+                        "control_location": "in_env_control",
+                        "ownership": "caller_owned",
+                    },
+                    "artifacts": {},
+                }
+            ).to_mapping(),
+            "request": {"input": "hello"},
         }
     )
 

--- a/tests/e2e/test_hermes_config_mapping.py
+++ b/tests/e2e/test_hermes_config_mapping.py
@@ -38,7 +38,7 @@ def test_hermes_config_mapping(tmp_path: Path):
         "base_url": "https://integrate.api.nvidia.com/v1",
     }
     assert config["terminal"]["backend"] == "local"
-    assert config["terminal"]["cwd"].endswith("/workspace")
+    assert Path(config["terminal"]["cwd"]) == tmp_path / "workspace"
     assert config["terminal"]["timeout"] == 30
     assert config["skills"]["external_dirs"] == ["/tmp/fabric-skills/code-review"]
     assert config["mcp_servers"]["github"] == {

--- a/tests/e2e/test_hermes_config_mapping.py
+++ b/tests/e2e/test_hermes_config_mapping.py
@@ -10,6 +10,7 @@ from pathlib import Path
 
 import pytest
 import yaml
+from nemo_fabric_adapter_contract.models import AgentConfig
 
 pytestmark = pytest.mark.usefixtures("requires_hermes_agent")
 
@@ -20,8 +21,9 @@ if importlib.util.find_spec("run_agent") is not None:
 def test_hermes_config_mapping(tmp_path: Path):
     hermes_home = tmp_path / "home"
     config_path, config = hermes_adapter.write_hermes_config(
-        payload(str(tmp_path)),
+        agent_config(),
         hermes_home,
+        workspace=str(tmp_path / "workspace"),
         relay_enabled=True,
     )
 
@@ -48,14 +50,10 @@ def test_hermes_config_mapping(tmp_path: Path):
     assert config["plugins"]["enabled"] == ["observability/nemo_relay"]
 
 
-def payload(tmpdir: str) -> dict:
-    return {
-        "agent_name": "code-review-agent",
-        "base_dir": tmpdir,
-        "config": {
-            "environment": {
-                "workspace": f"{tmpdir}/workspace",
-            },
+def agent_config() -> AgentConfig:
+    return AgentConfig.from_mapping(
+        {
+            "harness": {"settings": {"terminal_timeout": 30}},
             "models": {
                 "default": {
                     "provider": "nvidia",
@@ -65,20 +63,14 @@ def payload(tmpdir: str) -> dict:
                 }
             },
             "tools": {"enabled": []},
-        },
-        "settings": {
-            "terminal_timeout": 30,
-        },
-        "capabilities": {
-            "native": {
-                "skill_paths": ["/tmp/fabric-skills/code-review"],
-                "mcp_servers": {
+            "skills": {"paths": ["/tmp/fabric-skills/code-review"]},
+            "mcp": {
+                "servers": {
                     "github": {
                         "transport": "streamable-http",
                         "url": "https://mcp.github.example/mcp",
-                        "exposure": "harness_native",
                     }
-                },
-            }
-        },
-    }
+                }
+            },
+        }
+    )

--- a/uv.lock
+++ b/uv.lock
@@ -2344,6 +2344,7 @@ name = "nemo-fabric-adapters-hermes"
 version = "0.2.0"
 source = { editable = "adapters/hermes" }
 dependencies = [
+    { name = "nemo-fabric-adapter-contract", marker = "python_full_version < '3.14'" },
     { name = "nemo-fabric-adapters-common", marker = "python_full_version < '3.14'" },
 ]
 
@@ -2356,6 +2357,7 @@ harness = [
 requires-dist = [
     { name = "hermes-agent", extras = ["mcp"], marker = "python_full_version < '3.14' and extra == 'full'", specifier = ">=0.19.0" },
     { name = "hermes-agent", extras = ["mcp"], marker = "python_full_version < '3.14' and extra == 'harness'", specifier = ">=0.19.0" },
+    { name = "nemo-fabric-adapter-contract", editable = "adapter-contract" },
     { name = "nemo-fabric-adapters-common", editable = "adapters/common" },
     { name = "nemo-relay", marker = "extra == 'full'", specifier = ">=0.6.0,<0.7" },
     { name = "nemo-relay", marker = "extra == 'relay'", specifier = ">=0.6.0,<0.7" },


### PR DESCRIPTION
#### Overview

Moves the Hermes Agent adapter onto the typed `fabric.adapter/v1alpha2` `agent_config` input, now available on `main` through #190.

Hermes directly imports the internal `nemo-fabric-adapter-contract` package because it owns the typed lifecycle boundary. This adds no third-party dependency or license change.

#### Details

- Deserializes `AgentConfig` at the lifecycle boundary and maps typed models, instructions, runtime settings, tools, MCP servers, and skills into Hermes configuration.
- Limits raw lifecycle data to runtime context and invocation data; synchronizes the packaged CLI and Harbor descriptors.
- Makes Hermes tests portable across Python versions and Windows path separators.

#### Validation

- `uv run --no-sync pytest tests/adapters/test_hermes_adapter.py tests/adapters/test_hermes_config_builder.py tests/adapters/test_hermes_streaming.py tests/e2e/test_hermes_config_mapping.py tests/adapters/test_adapter_package_metadata.py` (49 passed)
- `just test-python` (722 passed, 16 skipped)
- `just test-rust`
- Ruff, lockfile, wheel-metadata, attribution, and license-diff checks

#### Where should the reviewer start?

Start with `adapters/hermes/src/nemo_fabric_adapters/hermes/adapter.py`, especially `main`, `build_hermes_config`, and `HermesRuntime.start`. `tests/adapters/test_hermes_adapter.py` covers the typed lifecycle boundary; `tests/e2e/test_hermes_config_mapping.py` covers generated configuration portability.

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- Relates to [FABRIC-187](https://linear.app/nvidia/issue/FABRIC-187/move-hermes-agent-adapter-to-v1alpha2-contract-version)

- [x] I confirm this contribution is my own work, or I have the right to submit it under this project's license.
- [x] I searched existing issues and open pull requests, and this does not duplicate existing work.


