### PR TITLE
feat: add LangGraph custom agent adapter example

### DIFF
--- a/.github/workflows/ci_python.yml
+++ b/.github/workflows/ci_python.yml
@@ -102,15 +102,6 @@ jobs:
           set -euo pipefail
           just test-python
 
-      - name: Smoke test minimum MCP dependency versions
-        if: matrix.platform == 'linux-amd64' && matrix.python-version == '3.11'
-        run: |
-          uv run --isolated --no-project --python 3.11 \
-            --with mcp==1.10.0 \
-            --with langchain-mcp-adapters==0.1.0 \
-            python -c \
-              "import examples.langgraph_custom_agent.mcp.url_inspector; import langchain_mcp_adapters.client"
-
   build-wheels:
     name: Build wheels (${{ matrix.platform }})
     needs: [test]

--- a/.github/workflows/ci_python.yml
+++ b/.github/workflows/ci_python.yml
@@ -102,6 +102,15 @@ jobs:
           set -euo pipefail
           just test-python
 
+      - name: Smoke test minimum MCP dependency versions
+        if: matrix.platform == 'linux-amd64' && matrix.python-version == '3.11'
+        run: |
+          uv run --isolated --no-project --python 3.11 \
+            --with mcp==1.10.0 \
+            --with langchain-mcp-adapters==0.1.0 \
+            python -c \
+              "import examples.langgraph_custom_agent.mcp.url_inspector; import langchain_mcp_adapters.client"
+
   build-wheels:
     name: Build wheels (${{ matrix.platform }})
     needs: [test]

--- a/examples/README.md
+++ b/examples/README.md
@@ -42,8 +42,8 @@ just build-all
 [`langgraph_custom_agent`](langgraph_custom_agent/README.md) separates a small
 application-defined LangGraph, its dedicated adapter, and consumer-owned
 `FabricConfig`. It builds from the required lifecycle to normalized model and
-instruction variations, then adds optional Relay telemetry without adding an
-adapter streaming API.
+instruction variations, then adds an optional stdio MCP tool and Relay
+telemetry without expanding the required lifecycle.
 
 ## Harbor
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -39,11 +39,17 @@ just build-all
 
 ## LangGraph custom agent
 
-[`langgraph_custom_agent`](langgraph_custom_agent/README.md) separates a small
-application-defined LangGraph, its dedicated adapter, and consumer-owned
-`FabricConfig`. It builds from the required lifecycle to normalized model and
-instruction variations, then adds an optional stdio MCP tool and Relay
-telemetry without expanding the required lifecycle.
+[`langgraph_custom_agent`](langgraph_custom_agent/README.md) shows how to run a
+custom LangGraph application through NeMo Fabric. The email-phishing example
+keeps each responsibility in a separate directory:
+
+- `consumer/` configures and runs the example with `FabricConfig`.
+- `adapter/` receives `AgentConfig` and manages `start`, `invoke`, and `stop`.
+- `agent/` contains the LangGraph application without NeMo Fabric-specific
+  code.
+
+Start with the model-backed example. You can then vary its model settings, add
+a stdio MCP tool, or enable NeMo Relay telemetry.
 
 ## Harbor
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -37,7 +37,7 @@ just build-all
   --input "Reply with exactly: NeMo Fabric works"
 ```
 
-## LangGraph custom agent
+## LangGraph Custom Agent
 
 [`langgraph_custom_agent`](langgraph_custom_agent/README.md) demonstrates how
 to build a dedicated NeMo Fabric adapter for a custom agent. It uses a small

--- a/examples/README.md
+++ b/examples/README.md
@@ -39,9 +39,10 @@ just build-all
 
 ## LangGraph custom agent
 
-[`langgraph_custom_agent`](langgraph_custom_agent/README.md) shows how to run a
-custom LangGraph application through NeMo Fabric. The email-phishing example
-keeps each responsibility in a separate directory:
+[`langgraph_custom_agent`](langgraph_custom_agent/README.md) demonstrates how
+to build a dedicated NeMo Fabric adapter for a custom agent. It uses a small
+email-phishing agent built directly with LangGraph and keeps each responsibility
+in a separate directory:
 
 - `consumer/` configures and runs the example with `FabricConfig`.
 - `adapter/` receives `AgentConfig` and manages `start`, `invoke`, and `stop`.

--- a/examples/README.md
+++ b/examples/README.md
@@ -37,6 +37,14 @@ just build-all
   --input "Reply with exactly: NeMo Fabric works"
 ```
 
+## LangGraph custom agent
+
+[`langgraph_custom_agent`](langgraph_custom_agent/README.md) separates a small
+application-defined LangGraph, its dedicated adapter, and consumer-owned
+`FabricConfig`. It builds from the required lifecycle to normalized model and
+instruction variations, then adds optional Relay telemetry without adding an
+adapter streaming API.
+
 ## Harbor
 
 [`harbor`](harbor/README.md) demonstrates how to evaluate NeMo Fabric agents with

--- a/examples/langgraph_custom_agent/README.md
+++ b/examples/langgraph_custom_agent/README.md
@@ -1,0 +1,172 @@
+<!--
+SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+SPDX-License-Identifier: Apache-2.0
+-->
+
+# NVIDIA NeMo Fabric LangGraph Custom Agent Adapter
+
+This source-only example implements an email-phishing analyzer as a custom
+LangGraph agent with its own NeMo Fabric adapter. It is intentionally small:
+the graph owns application behavior, the adapter owns translation and
+lifecycle, and the consumer owns `FabricConfig`.
+
+The classifier is illustrative, not a production security control.
+
+```mermaid
+flowchart LR
+    Consumer["Consumer<br/>FabricConfig"] --> Fabric[NeMo Fabric]
+    Fabric -->|"AgentConfig + RuntimeContext"| Adapter["Adapter<br/>start / invoke / stop"]
+    Adapter -->|"native model + instruction"| Agent["Custom LangGraph agent"]
+    Agent -->|"classification + explanation"| Adapter
+    Adapter -->|"terminal JSON"| Fabric
+    Adapter -. "optional callback" .-> Relay["NeMo Relay"]
+```
+
+## Read the Boundaries
+
+| Source | Responsibility |
+| --- | --- |
+| [`consumer/config.py`](consumer/config.py) | Builds northbound configs and independent variations. |
+| [`adapter/fabric-adapter.json`](adapter/fabric-adapter.json) | Declares the exact supported contract surface. |
+| [`adapter/configuration.py`](adapter/configuration.py) | Maps typed `AgentConfig` into a native chat model and instruction. |
+| [`adapter/runtime.py`](adapter/runtime.py) | Implements one `start`, zero or more `invoke`, and one `stop`. |
+| [`adapter/telemetry.py`](adapter/telemetry.py) | Lazily activates optional Relay telemetry for an invocation. |
+| [`agent/graph.py`](agent/graph.py) | Defines application behavior without importing Fabric or Relay. |
+
+This is a dedicated custom-agent adapter: selecting its `adapter_id` selects
+this email analyzer. It is not a generic loader for arbitrary LangGraph agents
+and therefore does not accept `workflow`.
+
+## Minimum Contract
+
+The descriptor selects typed southbound configuration and advertises only the
+fields the adapter applies:
+
+```json
+"config": {
+  "input": "agent_config",
+  "accepts": [
+    "models",
+    "models.base_url",
+    "models.temperature",
+    "instructions.system"
+  ]
+}
+```
+
+Fabric projects those values from `FabricConfig` into `AgentConfig`. The
+adapter resolves `models.default` into `ChatOpenAI`, applies the normalized
+system instruction, compiles one graph during `start`, and retains it for
+ordered invocations. The custom graph receives native dependencies; it does
+not parse either Fabric configuration type.
+
+The current local-host binding still carries the invocation request and result
+in JSON envelopes. That unavoidable extraction stays at the edge of
+`adapter/runtime.py`; the preview `AgentRunRequest` and `AgentRunResult` types
+are not emitted as negotiated transport structures.
+
+A successful terminal output is deliberately small:
+
+```json
+{
+  "classification": "phishing",
+  "response": "The email combines several phishing signals.",
+  "signals": ["urgency", "credential_request", "external_link"]
+}
+```
+
+## Configuration Variations
+
+Every variation returns an independent `FabricConfig`:
+
+| Variation | Consumer API or CLI | Southbound effect |
+| --- | --- | --- |
+| Model | `public_config(model=...)` or `--model` | `models.default.model` |
+| Endpoint | `public_config()` / `frontier_config()` | Credential-variable name and `models.default.base_url` |
+| Instruction | `with_system_instruction(...)` or `--system-instruction` | `instructions.system` |
+| Temperature | `with_temperature(...)` or `--temperature` | `models.default.temperature` |
+
+For example:
+
+```python
+config = public_config()
+config = with_system_instruction(config, "Explain only the strongest signal.")
+config = with_temperature(config, 0.2)
+```
+
+The descriptor bounds variation. Unsupported providers, extra model roles,
+model-specific settings, missing endpoints, and missing credential variables
+fail explicitly rather than being ignored.
+
+## Optional Relay Telemetry
+
+`with_relay(config)` enables ATOF and ATIF without changing the adapter
+lifecycle. During `invoke`, Fabric supplies `RuntimeContext.telemetry`; the
+adapter loads that generated configuration, opens one invocation-level Agent
+scope, and passes the public `NemoRelayCallbackHandler` through LangGraph
+runnable config. Relay records the graph and its model-backed node, while the
+terminal result remains separate.
+
+Relay is imported only on the enabled path. This adapter does not implement a
+streaming operation: Fabric's Relay-backed `Runtime.invoke_stream()` still
+runs the ordinary adapter `invoke` operation.
+
+## Run the Source Example
+
+Until this example becomes a package, stage its descriptor under a development
+adapter directory and make the repository importable:
+
+```bash
+uv sync --group adapter-tests
+export FABRIC_LANGGRAPH_EXAMPLE="$PWD/.tmp/langgraph-custom-agent"
+mkdir -p "$FABRIC_LANGGRAPH_EXAMPLE/adapters/langgraph-email-phishing"
+cp examples/langgraph_custom_agent/adapter/fabric-adapter.json \
+  "$FABRIC_LANGGRAPH_EXAMPLE/adapters/langgraph-email-phishing/"
+export PYTHONPATH="$PWD"
+export ADAPTER_PYTHON="$PWD/.venv/bin/python"
+```
+
+Planning is credential-free:
+
+```bash
+.venv/bin/python -m examples.langgraph_custom_agent.consumer \
+  --variant public --base-dir "$FABRIC_LANGGRAPH_EXAMPLE" --plan
+```
+
+Run the requested default model through the public NVIDIA endpoint:
+
+```bash
+export NVIDIA_API_KEY="..."
+.venv/bin/python -m examples.langgraph_custom_agent.consumer \
+  --variant public --base-dir "$FABRIC_LANGGRAPH_EXAMPLE"
+```
+
+Use an internal OpenAI-compatible NVIDIA endpoint with the same config shape:
+
+```bash
+export NVIDIA_FRONTIER_API_KEY="..."
+export NVIDIA_FRONTIER_BASE_URL="https://your-frontier-endpoint/v1"
+.venv/bin/python -m examples.langgraph_custom_agent.consumer \
+  --variant frontier --base-dir "$FABRIC_LANGGRAPH_EXAMPLE"
+```
+
+The endpoint key must grant access to the configured model. Use `--model` when
+the endpoint exposes a different authorized model ID.
+
+Add `--relay` to either live command to produce correlated ATOF and ATIF under
+`$FABRIC_LANGGRAPH_EXAMPLE/artifacts/relay/`.
+
+## Validate
+
+```bash
+.venv/bin/pytest tests/examples/langgraph_custom_agent -q
+```
+
+The focused tests cover descriptor projection, application behavior,
+configuration mapping and rejection, repeated lifecycle invocation, cleanup,
+configuration independence, Relay-off optionality, and correlated Relay
+artifacts.
+
+The example intentionally omits generic workflow loading, tools, MCP, skills,
+checkpointing, cancellation, resume, updates, and native streaming. Adding a
+dormant hook for any of those would make the minimum adapter harder to read.

--- a/examples/langgraph_custom_agent/README.md
+++ b/examples/langgraph_custom_agent/README.md
@@ -13,10 +13,10 @@ lifecycle, and the consumer owns `FabricConfig`.
 The classifier is illustrative, not a production security control.
 
 ```mermaid
-flowchart LR
+flowchart TD
     Consumer["Consumer<br/>FabricConfig"] --> Fabric[NeMo Fabric]
     Fabric -->|"AgentConfig + RuntimeContext"| Adapter["Adapter<br/>start / invoke / stop"]
-    Adapter -->|"native model + instruction"| Agent["Custom LangGraph agent"]
+    Adapter -->|"native dependencies"| Agent["Custom LangGraph agent"]
     Agent -->|"classification + explanation"| Adapter
     Adapter -->|"terminal JSON"| Fabric
     Adapter -. "optional callback" .-> Relay["NeMo Relay"]
@@ -29,9 +29,11 @@ flowchart LR
 | [`consumer/config.py`](consumer/config.py) | Builds northbound configs and independent variations. |
 | [`adapter/fabric-adapter.json`](adapter/fabric-adapter.json) | Declares the exact supported contract surface. |
 | [`adapter/configuration.py`](adapter/configuration.py) | Maps typed `AgentConfig` into a native chat model and instruction. |
+| [`adapter/mcp.py`](adapter/mcp.py) | Optionally maps normalized MCP servers and filters into a native LangChain tool. |
 | [`adapter/runtime.py`](adapter/runtime.py) | Implements one `start`, zero or more `invoke`, and one `stop`. |
 | [`adapter/telemetry.py`](adapter/telemetry.py) | Lazily activates optional Relay telemetry for an invocation. |
 | [`agent/graph.py`](agent/graph.py) | Defines application behavior without importing Fabric or Relay. |
+| [`mcp/url_inspector.py`](mcp/url_inspector.py) | Provides the example's deterministic stdio MCP tool. |
 
 This is a dedicated custom-agent adapter: selecting its `adapter_id` selects
 this email analyzer. It is not a generic loader for arbitrary LangGraph agents
@@ -49,16 +51,20 @@ fields the adapter applies:
     "models",
     "models.base_url",
     "models.temperature",
-    "instructions.system"
+    "instructions.system",
+    "mcp",
+    "mcp.tool_filters"
   ]
 }
 ```
 
-Fabric projects those values from `FabricConfig` into `AgentConfig`. The
-adapter resolves `models.default` into `ChatOpenAI`, applies the normalized
-system instruction, compiles one graph during `start`, and retains it for
-ordered invocations. The custom graph receives native dependencies; it does
-not parse either Fabric configuration type.
+The minimum path configures only a model and instruction; MCP is an optional
+extension described below. Fabric projects configured values from
+`FabricConfig` into `AgentConfig`. The adapter resolves `models.default` into
+`ChatOpenAI`, applies the normalized system instruction, compiles one graph
+during `start`, and retains it for ordered invocations. The custom graph
+receives native dependencies; it does not parse either Fabric configuration
+type.
 
 The current local-host binding still carries the invocation request and result
 in JSON envelopes. That unavoidable extraction stays at the edge of
@@ -85,6 +91,7 @@ Every variation returns an independent `FabricConfig`:
 | Endpoint | `public_config()` / `frontier_config()` | Credential-variable name and `models.default.base_url` |
 | Instruction | `with_system_instruction(...)` or `--system-instruction` | `instructions.system` |
 | Temperature | `with_temperature(...)` or `--temperature` | `models.default.temperature` |
+| stdio MCP | `with_url_inspector_mcp(...)` or `--mcp` | `mcp.servers` and per-server tool policy |
 
 For example:
 
@@ -97,6 +104,31 @@ config = with_temperature(config, 0.2)
 The descriptor bounds variation. Unsupported providers, extra model roles,
 model-specific settings, missing endpoints, and missing credential variables
 fail explicitly rather than being ignored.
+
+## Optional stdio MCP Tool
+
+`with_url_inspector_mcp(config)` adds a deterministic URL-inspection server as
+an optional capability beyond the minimum adapter surface:
+
+```mermaid
+flowchart TD
+    FabricConfig["FabricConfig.mcp"] --> AgentConfig["AgentConfig.mcp"]
+    AgentConfig --> Adapter["adapter/mcp.py"]
+    Adapter --> Client["MultiServerMCPClient"]
+    Client -->|"stdio"| Server["URL inspector MCP server"]
+    Client -->|"native BaseTool"| Graph["Custom LangGraph"]
+```
+
+The adapter validates stdio transport, converts normalized server settings
+through the official LangChain MCP adapter, and applies each server's allow
+and block lists. The graph receives only the resulting native `BaseTool`; it
+does not know about Fabric or MCP configuration. The tool checks URL syntax
+locally and makes no network requests. Startup fails if the configured policy
+does not expose exactly one `inspect_url` tool.
+
+Add `--mcp` to a live command to exercise this path. MCP sessions and stdio
+processes are scoped to discovery or tool calls by `MultiServerMCPClient`; the
+Fabric runtime retains the compiled graph and native tool between invocations.
 
 ## Optional Relay Telemetry
 
@@ -117,7 +149,7 @@ Until this example becomes a package, stage its descriptor under a development
 adapter directory and make the repository importable:
 
 ```bash
-uv sync --group adapter-tests
+uv sync --group langgraph-example
 export FABRIC_LANGGRAPH_EXAMPLE="$PWD/.tmp/langgraph-custom-agent"
 mkdir -p "$FABRIC_LANGGRAPH_EXAMPLE/adapters/langgraph-email-phishing"
 cp examples/langgraph_custom_agent/adapter/fabric-adapter.json \
@@ -156,6 +188,10 @@ the endpoint exposes a different authorized model ID.
 Add `--relay` to either live command to produce correlated ATOF and ATIF under
 `$FABRIC_LANGGRAPH_EXAMPLE/artifacts/relay/`.
 
+Add `--mcp` to include URL inspection before classification. The two optional
+paths compose, so `--mcp --relay` traces the MCP-backed graph node as well as
+the model-backed explanation.
+
 ## Validate
 
 ```bash
@@ -164,9 +200,10 @@ Add `--relay` to either live command to produce correlated ATOF and ATIF under
 
 The focused tests cover descriptor projection, application behavior,
 configuration mapping and rejection, repeated lifecycle invocation, cleanup,
-configuration independence, Relay-off optionality, and correlated Relay
-artifacts.
+configuration independence, normalized MCP projection and filtering,
+Relay-off optionality, and correlated Relay artifacts.
 
-The example intentionally omits generic workflow loading, tools, MCP, skills,
-checkpointing, cancellation, resume, updates, and native streaming. Adding a
-dormant hook for any of those would make the minimum adapter harder to read.
+The example intentionally omits generic workflow loading, named tools, skills,
+checkpointing, cancellation, resume, updates, and native streaming. The stdio
+MCP path is kept optional so the required adapter lifecycle remains easy to
+identify.

--- a/examples/langgraph_custom_agent/README.md
+++ b/examples/langgraph_custom_agent/README.md
@@ -10,7 +10,8 @@ LangGraph agent with its own NeMo Fabric adapter. It is intentionally small:
 the graph owns application behavior, the adapter owns translation and
 lifecycle, and the consumer owns `FabricConfig`.
 
-The classifier is illustrative, not a production security control.
+The phishing analyzer is a small application used to demonstrate the adapter
+contract.
 
 ```mermaid
 flowchart TD
@@ -22,18 +23,9 @@ flowchart TD
     Adapter -. "optional callback" .-> Relay["NeMo Relay"]
 ```
 
-## Read the Boundaries
-
-| Source | Responsibility |
-| --- | --- |
-| [`consumer/config.py`](consumer/config.py) | Builds northbound configs and independent variations. |
-| [`adapter/fabric-adapter.json`](adapter/fabric-adapter.json) | Declares the exact supported contract surface. |
-| [`adapter/configuration.py`](adapter/configuration.py) | Maps typed `AgentConfig` into a native chat model and instruction. |
-| [`adapter/mcp.py`](adapter/mcp.py) | Optionally maps normalized MCP servers and filters into a native LangChain tool. |
-| [`adapter/runtime.py`](adapter/runtime.py) | Implements one `start`, zero or more `invoke`, and one `stop`. |
-| [`adapter/telemetry.py`](adapter/telemetry.py) | Lazily activates optional Relay telemetry for an invocation. |
-| [`agent/graph.py`](agent/graph.py) | Defines application behavior without importing Fabric or Relay. |
-| [`mcp/url_inspector.py`](mcp/url_inspector.py) | Provides the example's deterministic stdio MCP tool. |
+The example separates consumer-owned configuration, adapter-owned translation
+and lifecycle, and an application-owned LangGraph agent that has no dependency
+on Fabric or Relay.
 
 This is a dedicated custom-agent adapter: selecting its `adapter_id` selects
 this email analyzer. It is not a generic loader for arbitrary LangGraph agents
@@ -86,19 +78,10 @@ Every variation returns an independent `FabricConfig`:
 
 | Variation | Consumer API or CLI | Southbound effect |
 | --- | --- | --- |
-| Model | `public_config(model=...)` or `--model` | `models.default.model` |
-| Endpoint | `public_config()` / `frontier_config()` | Credential-variable name and `models.default.base_url` |
+| Model | `--model` | `models.default.model` |
 | Instruction | `with_system_instruction(...)` or `--system-instruction` | `instructions.system` |
 | Temperature | `with_temperature(...)` or `--temperature` | `models.default.temperature` |
 | stdio MCP | `with_url_inspector_mcp(...)` or `--mcp` | `mcp.servers` and per-server tool policy |
-
-For example:
-
-```python
-config = public_config()
-config = with_system_instruction(config, "Explain only the strongest signal.")
-config = with_temperature(config, 0.2)
-```
 
 The descriptor bounds variation. Unsupported providers, extra model roles,
 model-specific settings, missing endpoints, and missing credential variables
@@ -134,7 +117,7 @@ Fabric runtime retains the compiled graph and native tool between invocations.
 `with_relay(config)` enables ATOF and ATIF without changing the adapter
 lifecycle. During `invoke`, Fabric supplies `RuntimeContext.telemetry`; the
 adapter loads that generated configuration, opens one invocation-level Agent
-scope, and passes the public `NemoRelayCallbackHandler` through LangGraph
+scope, and passes `NemoRelayCallbackHandler` through LangGraph
 runnable config. Relay records the graph and its model-backed node, while the
 terminal result remains separate.
 
@@ -161,24 +144,15 @@ Planning is credential-free:
 
 ```bash
 .venv/bin/python -m examples.langgraph_custom_agent.consumer \
-  --variant public --base-dir "$FABRIC_LANGGRAPH_EXAMPLE" --plan
+  --base-dir "$FABRIC_LANGGRAPH_EXAMPLE" --plan
 ```
 
-Run the requested default model through the public NVIDIA endpoint:
+Run the default model through `https://integrate.api.nvidia.com/v1`:
 
 ```bash
 export NVIDIA_API_KEY="..."
 .venv/bin/python -m examples.langgraph_custom_agent.consumer \
-  --variant public --base-dir "$FABRIC_LANGGRAPH_EXAMPLE"
-```
-
-Use an internal OpenAI-compatible NVIDIA endpoint with the same config shape:
-
-```bash
-export NVIDIA_FRONTIER_API_KEY="..."
-export NVIDIA_FRONTIER_BASE_URL="https://your-frontier-endpoint/v1"
-.venv/bin/python -m examples.langgraph_custom_agent.consumer \
-  --variant frontier --base-dir "$FABRIC_LANGGRAPH_EXAMPLE"
+  --base-dir "$FABRIC_LANGGRAPH_EXAMPLE"
 ```
 
 The endpoint key must grant access to the configured model. Use `--model` when
@@ -190,17 +164,6 @@ Add `--relay` to either live command to produce correlated ATOF and ATIF under
 Add `--mcp` to include URL inspection before classification. The two optional
 paths compose, so `--mcp --relay` traces the MCP-backed graph node as well as
 the model-backed explanation.
-
-## Validate
-
-```bash
-.venv/bin/pytest tests/examples/langgraph_custom_agent -q
-```
-
-The focused tests cover descriptor projection, application behavior,
-configuration mapping and rejection, repeated lifecycle invocation, cleanup,
-configuration independence, normalized MCP projection and filtering,
-Relay-off optionality, and correlated Relay artifacts.
 
 The example intentionally omits generic workflow loading, named tools, skills,
 checkpointing, cancellation, resume, updates, and native streaming. The stdio

--- a/examples/langgraph_custom_agent/README.md
+++ b/examples/langgraph_custom_agent/README.md
@@ -5,13 +5,12 @@ SPDX-License-Identifier: Apache-2.0
 
 # NVIDIA NeMo Fabric LangGraph Custom Agent Adapter
 
-This source-only example implements an email-phishing analyzer as a custom
-LangGraph agent with its own NeMo Fabric adapter. It is intentionally small:
-the graph owns application behavior, the adapter owns translation and
-lifecycle, and the consumer owns `FabricConfig`.
+This source-only example uses a small email-phishing analyzer to demonstrate
+the NeMo Fabric adapter contract for a custom LangGraph agent. The graph owns
+application behavior, the adapter owns translation and lifecycle, and the
+consumer owns `FabricConfig`.
 
-The phishing analyzer is a small application used to demonstrate the adapter
-contract.
+The following diagram shows those ownership boundaries:
 
 ```mermaid
 flowchart TD
@@ -23,9 +22,8 @@ flowchart TD
     Adapter -. "optional callback" .-> Relay["NeMo Relay"]
 ```
 
-The example separates consumer-owned configuration, adapter-owned translation
-and lifecycle, and an application-owned LangGraph agent that has no dependency
-on Fabric or Relay.
+The application-owned LangGraph agent has no dependency on NeMo Fabric or NeMo
+Relay.
 
 This is a dedicated custom-agent adapter: selecting its `adapter_id` selects
 this email analyzer. It is not a generic loader for arbitrary LangGraph agents
@@ -51,12 +49,12 @@ fields the adapter applies:
 ```
 
 The minimum path configures only a model and instruction; MCP is an optional
-extension described below. Fabric projects configured values from
+extension described below. NeMo Fabric projects configured values from
 `FabricConfig` into `AgentConfig`. The adapter resolves `models.default` into
 `ChatOpenAI`, applies the normalized system instruction, compiles one graph
 during `start`, and retains it for ordered invocations. The custom graph
-receives native dependencies; it does not parse either Fabric configuration
-type.
+receives native dependencies; it does not parse either NeMo Fabric
+configuration type.
 
 The local-host lifecycle transport carries invocation requests and results in
 JSON envelopes. That extraction stays at the edge of `adapter/runtime.py`;
@@ -68,7 +66,12 @@ A successful terminal output is deliberately small:
 {
   "classification": "phishing",
   "response": "The email combines several phishing signals.",
-  "signals": ["urgency", "credential_request", "external_link"]
+  "signals": [
+    "urgency",
+    "credential_request",
+    "external_link",
+    "account_threat"
+  ]
 }
 ```
 
@@ -76,7 +79,7 @@ A successful terminal output is deliberately small:
 
 Every variation returns an independent `FabricConfig`:
 
-| Variation | Consumer API or CLI | Southbound effect |
+| Variation | Consumer API or CLI | Southbound Effect |
 | --- | --- | --- |
 | Model | `--model` | `models.default.model` |
 | Instruction | `with_system_instruction(...)` or `--system-instruction` | `instructions.system` |
@@ -104,25 +107,26 @@ flowchart TD
 The adapter validates stdio transport, converts normalized server settings
 through the official LangChain MCP adapter, and applies each server's allow
 and block lists. The graph receives only the resulting native `BaseTool`; it
-does not know about Fabric or MCP configuration. The tool checks URL syntax
-locally and makes no network requests. Startup fails if the configured policy
-does not expose exactly one `inspect_url` tool.
+does not know about NeMo Fabric or MCP configuration. The tool checks URL
+syntax locally and makes no network requests. Startup fails if the configured
+policy does not expose exactly one `inspect_url` tool.
 
 Add `--mcp` to a live command to exercise this path. MCP sessions and stdio
 processes are scoped to discovery or tool calls by `MultiServerMCPClient`; the
-Fabric runtime retains the compiled graph and native tool between invocations.
+NeMo Fabric runtime retains the compiled graph and native tool between
+invocations.
 
 ## Optional Relay Telemetry
 
 `with_relay(config)` enables ATOF and ATIF without changing the adapter
-lifecycle. During `invoke`, Fabric supplies `RuntimeContext.telemetry`; the
+lifecycle. During `invoke`, NeMo Fabric supplies `RuntimeContext.telemetry`; the
 adapter loads that generated configuration, opens one invocation-level Agent
 scope, and passes `NemoRelayCallbackHandler` through LangGraph
 runnable config. Relay records the graph and its model-backed node, while the
 terminal result remains separate.
 
 Relay is imported only on the enabled path. This adapter does not implement a
-streaming operation: Fabric's Relay-backed `Runtime.invoke_stream()` still
+streaming operation: NeMo Fabric's Relay-backed `Runtime.invoke_stream()` still
 runs the ordinary adapter `invoke` operation.
 
 ## Run the Source Example

--- a/examples/langgraph_custom_agent/README.md
+++ b/examples/langgraph_custom_agent/README.md
@@ -31,6 +31,11 @@ and therefore does not accept `workflow`.
 
 ## Minimum Contract
 
+Custom-agent adapter developers should start with `adapter/fabric-adapter.json`
+and `adapter/runtime.py`. The descriptor declares the adapter contract, while
+the runtime implements its lifecycle and delegates configuration translation
+and optional integrations to the adjacent modules.
+
 The descriptor selects typed southbound configuration and advertises only the
 fields the adapter applies:
 

--- a/examples/langgraph_custom_agent/README.md
+++ b/examples/langgraph_custom_agent/README.md
@@ -66,10 +66,9 @@ during `start`, and retains it for ordered invocations. The custom graph
 receives native dependencies; it does not parse either Fabric configuration
 type.
 
-The current local-host binding still carries the invocation request and result
-in JSON envelopes. That unavoidable extraction stays at the edge of
-`adapter/runtime.py`; the preview `AgentRunRequest` and `AgentRunResult` types
-are not emitted as negotiated transport structures.
+The local-host lifecycle transport carries invocation requests and results in
+JSON envelopes. That extraction stays at the edge of `adapter/runtime.py`;
+`AgentRunRequest` and `AgentRunResult` are not negotiated by this transport.
 
 A successful terminal output is deliberately small:
 
@@ -145,7 +144,7 @@ runs the ordinary adapter `invoke` operation.
 
 ## Run the Source Example
 
-Until this example becomes a package, stage its descriptor under a development
+Because this is a source-only example, stage its descriptor under a development
 adapter directory and make the repository importable:
 
 ```bash

--- a/examples/langgraph_custom_agent/README.md
+++ b/examples/langgraph_custom_agent/README.md
@@ -99,7 +99,7 @@ an optional capability beyond the minimum adapter surface:
 flowchart TD
     FabricConfig["FabricConfig.mcp"] --> AgentConfig["AgentConfig.mcp"]
     AgentConfig --> Adapter["adapter/mcp.py"]
-    Adapter --> Client["MultiServerMCPClient"]
+    Adapter --> Client["MultiServerMCPClient<br/>(langchain_mcp_adapters)"]
     Client -->|"stdio"| Server["URL inspector MCP server"]
     Client -->|"native BaseTool"| Graph["Custom LangGraph"]
 ```

--- a/examples/langgraph_custom_agent/adapter/__init__.py
+++ b/examples/langgraph_custom_agent/adapter/__init__.py
@@ -1,0 +1,2 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0

--- a/examples/langgraph_custom_agent/adapter/configuration.py
+++ b/examples/langgraph_custom_agent/adapter/configuration.py
@@ -80,15 +80,15 @@ def resolve_agent_dependencies(agent_config: AgentConfig) -> AgentDependencies:
             f"Credential environment variable {api_key_env!r} is not set",
         )
 
-    model_kwargs: dict[str, Any] = {
+    chat_model_options: dict[str, Any] = {
         "model": model_config.model,
         "api_key": api_key,
         "timeout": MODEL_REQUEST_TIMEOUT_SECONDS,
     }
     if model_config.base_url is not None:
-        model_kwargs["base_url"] = model_config.base_url
+        chat_model_options["base_url"] = model_config.base_url
     if model_config.temperature is not None:
-        model_kwargs["temperature"] = model_config.temperature
+        chat_model_options["temperature"] = model_config.temperature
 
     system_instruction = DEFAULT_SYSTEM_INSTRUCTION
     if agent_config.instructions is not None:
@@ -97,6 +97,6 @@ def resolve_agent_dependencies(agent_config: AgentConfig) -> AgentDependencies:
             system_instruction = system.content
 
     return AgentDependencies(
-        model=ChatOpenAI(**model_kwargs),
+        model=ChatOpenAI(**chat_model_options),
         system_instruction=system_instruction,
     )

--- a/examples/langgraph_custom_agent/adapter/configuration.py
+++ b/examples/langgraph_custom_agent/adapter/configuration.py
@@ -1,0 +1,102 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Translate typed AgentConfig into native LangChain dependencies."""
+
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass
+from typing import Any
+
+from langchain_core.language_models import BaseChatModel
+from langchain_openai import ChatOpenAI
+from nemo_fabric_adapter_contract.models import AgentConfig
+from nemo_fabric_adapters.common import lifecycle
+
+DEFAULT_SYSTEM_INSTRUCTION = (
+    "Explain the fixed email-risk classification using only the supplied email "
+    "and extracted signals."
+)
+OPENAI_COMPATIBLE_PROVIDERS = frozenset(
+    {"nvidia", "openai", "openai-compatible"}
+)
+MODEL_REQUEST_TIMEOUT_SECONDS = 60
+
+
+@dataclass(frozen=True, slots=True)
+class AgentDependencies:
+    """Native dependencies passed to the custom agent constructor."""
+
+    model: BaseChatModel
+    system_instruction: str
+
+
+def _config_error(field: str, message: str) -> lifecycle.LifecycleError:
+    return lifecycle.LifecycleError(
+        "email_phishing_invalid_config",
+        message,
+        metadata={"field": field},
+    )
+
+
+def resolve_agent_dependencies(agent_config: AgentConfig) -> AgentDependencies:
+    """Resolve the narrow configuration surface advertised by the descriptor."""
+
+    if set(agent_config.models) != {"default"}:
+        raise _config_error(
+            "models",
+            "The email-phishing adapter requires exactly one model named 'default'",
+        )
+    model_config = agent_config.models["default"]
+    if model_config.settings:
+        raise _config_error(
+            "models.default.settings",
+            "The email-phishing adapter does not accept model-specific settings",
+        )
+    if model_config.provider not in OPENAI_COMPATIBLE_PROVIDERS:
+        raise _config_error(
+            "models.default.provider",
+            f"Unsupported OpenAI-compatible provider {model_config.provider!r}",
+        )
+    if model_config.provider != "openai" and model_config.base_url is None:
+        raise _config_error(
+            "models.default.base_url",
+            f"Provider {model_config.provider!r} requires an explicit base URL",
+        )
+
+    api_key_env = model_config.api_key_env
+    if api_key_env is None and model_config.provider == "openai":
+        api_key_env = "OPENAI_API_KEY"
+    if api_key_env is None:
+        raise _config_error(
+            "models.default.api_key_env",
+            f"Provider {model_config.provider!r} requires a credential environment variable",
+        )
+    api_key = os.environ.get(api_key_env)
+    if not api_key:
+        raise _config_error(
+            "models.default.api_key_env",
+            f"Credential environment variable {api_key_env!r} is not set",
+        )
+
+    model_kwargs: dict[str, Any] = {
+        "model": model_config.model,
+        "api_key": api_key,
+        "timeout": MODEL_REQUEST_TIMEOUT_SECONDS,
+    }
+    if model_config.base_url is not None:
+        model_kwargs["base_url"] = model_config.base_url
+    if model_config.temperature is not None:
+        model_kwargs["temperature"] = model_config.temperature
+
+    system_instruction = DEFAULT_SYSTEM_INSTRUCTION
+    if agent_config.instructions is not None:
+        system = agent_config.instructions.system
+        if system is not None:
+            system_instruction = system.content
+
+    return AgentDependencies(
+        model=ChatOpenAI(**model_kwargs),
+        system_instruction=system_instruction,
+    )

--- a/examples/langgraph_custom_agent/adapter/fabric-adapter.json
+++ b/examples/langgraph_custom_agent/adapter/fabric-adapter.json
@@ -13,7 +13,9 @@
       "models",
       "models.base_url",
       "models.temperature",
-      "instructions.system"
+      "instructions.system",
+      "mcp",
+      "mcp.tool_filters"
     ]
   },
   "telemetry": {

--- a/examples/langgraph_custom_agent/adapter/fabric-adapter.json
+++ b/examples/langgraph_custom_agent/adapter/fabric-adapter.json
@@ -16,6 +16,14 @@
       "instructions.system"
     ]
   },
+  "telemetry": {
+    "providers": {
+      "relay": {
+        "outputs": ["atif"],
+        "integration_modes": ["sdk"]
+      }
+    }
+  },
   "capabilities": {
     "cancellation": false,
     "service": false,

--- a/examples/langgraph_custom_agent/adapter/fabric-adapter.json
+++ b/examples/langgraph_custom_agent/adapter/fabric-adapter.json
@@ -1,0 +1,25 @@
+{
+  "contract_version": "fabric.adapter/v1alpha2",
+  "adapter_id": "nvidia.fabric.example.langgraph.email-phishing",
+  "harness": "langgraph-email-phishing",
+  "adapter_kind": "python",
+  "runner": {
+    "module": "examples.langgraph_custom_agent.adapter.runtime"
+  },
+  "requirements": {},
+  "config": {
+    "input": "agent_config",
+    "accepts": [
+      "models",
+      "models.base_url",
+      "models.temperature",
+      "instructions.system"
+    ]
+  },
+  "capabilities": {
+    "cancellation": false,
+    "service": false,
+    "streaming": false,
+    "updates": false
+  }
+}

--- a/examples/langgraph_custom_agent/adapter/mcp.py
+++ b/examples/langgraph_custom_agent/adapter/mcp.py
@@ -1,0 +1,117 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Translate normalized MCP servers into native LangChain tools."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from langchain_core.tools import BaseTool
+from nemo_fabric_adapter_contract.models import AgentConfig
+from nemo_fabric_adapter_contract.models import AgentMcpServerConfig
+from nemo_fabric_adapters.common import lifecycle
+
+URL_INSPECTOR_TOOL = "inspect_url"
+
+
+def _config_error(field: str, message: str) -> lifecycle.LifecycleError:
+    return lifecycle.LifecycleError(
+        "email_phishing_invalid_mcp",
+        message,
+        metadata={"field": field},
+    )
+
+
+def _stdio_connection(
+    name: str,
+    server: AgentMcpServerConfig,
+) -> dict[str, Any]:
+    field = f"mcp.servers.{name}"
+    if server.transport != "stdio":
+        raise _config_error(
+            f"{field}.transport",
+            "The email-phishing example accepts only stdio MCP servers",
+        )
+    if server.extensions:
+        raise _config_error(
+            f"{field}.extensions",
+            "The email-phishing example does not accept MCP server extensions",
+        )
+
+    connection: dict[str, Any] = {
+        "transport": "stdio",
+        "command": server.url,
+        "args": list(server.args),
+    }
+    if server.env:
+        connection["env"] = dict(server.env)
+    return connection
+
+
+async def _discover_tools(
+    connections: dict[str, dict[str, Any]],
+) -> dict[str, list[BaseTool]]:
+    # The optional dependency is imported only when MCP is configured.
+    from langchain_mcp_adapters.client import MultiServerMCPClient
+
+    client = MultiServerMCPClient(connections)
+    return {
+        name: list(await client.get_tools(server_name=name)) for name in connections
+    }
+
+
+async def resolve_url_inspector(agent_config: AgentConfig) -> BaseTool | None:
+    """Resolve one optional MCP tool used by the custom graph."""
+
+    if agent_config.mcp is None or not agent_config.mcp.servers:
+        return None
+    if agent_config.mcp.extensions:
+        raise _config_error(
+            "mcp.extensions",
+            "The email-phishing example does not accept MCP extensions",
+        )
+
+    connections = {
+        name: _stdio_connection(name, server)
+        for name, server in agent_config.mcp.servers.items()
+    }
+    try:
+        discovered = await _discover_tools(connections)
+    except Exception as error:
+        raise _config_error(
+            "mcp.servers",
+            "The email-phishing adapter could not discover the configured MCP tools",
+        ) from error
+
+    selected: list[BaseTool] = []
+    for name, server in agent_config.mcp.servers.items():
+        tools = discovered[name]
+        discovered_names = {tool.name for tool in tools}
+        if server.allowed_tools is not None:
+            missing = set(server.allowed_tools).difference(discovered_names)
+            if missing:
+                tool_name = sorted(missing)[0]
+                raise _config_error(
+                    f"mcp.servers.{name}.allowed_tools",
+                    f"MCP server {name!r} does not provide tool {tool_name!r}",
+                )
+        selected.extend(
+            tool
+            for tool in tools
+            if (server.allowed_tools is None or tool.name in server.allowed_tools)
+            and tool.name not in server.blocked_tools
+        )
+
+    matches = [tool for tool in selected if tool.name == URL_INSPECTOR_TOOL]
+    if len(matches) > 1:
+        raise _config_error(
+            "mcp.servers",
+            f"More than one MCP server provides {URL_INSPECTOR_TOOL!r}",
+        )
+    if not matches:
+        raise _config_error(
+            "mcp.servers",
+            f"The configured MCP tool policy does not expose {URL_INSPECTOR_TOOL!r}",
+        )
+    return matches[0]

--- a/examples/langgraph_custom_agent/adapter/mcp.py
+++ b/examples/langgraph_custom_agent/adapter/mcp.py
@@ -15,11 +15,18 @@ from nemo_fabric_adapters.common import lifecycle
 URL_INSPECTOR_TOOL = "inspect_url"
 
 
-def _config_error(field: str, message: str) -> lifecycle.LifecycleError:
+def _config_error(
+    field: str,
+    message: str,
+    *,
+    metadata: dict[str, Any] | None = None,
+) -> lifecycle.LifecycleError:
+    details: dict[str, Any] = {"field": field}
+    details.update(metadata or {})
     return lifecycle.LifecycleError(
         "email_phishing_invalid_mcp",
         message,
-        metadata={"field": field},
+        metadata=details,
     )
 
 
@@ -81,7 +88,12 @@ async def resolve_url_inspector(agent_config: AgentConfig) -> BaseTool | None:
     except Exception as error:
         raise _config_error(
             "mcp.servers",
-            "The email-phishing adapter could not discover the configured MCP tools",
+            "The email-phishing adapter could not discover the configured MCP tools; "
+            "verify each stdio command, its arguments, and server startup",
+            metadata={
+                "cause_type": type(error).__name__,
+                "servers": sorted(connections),
+            },
         ) from error
 
     selected: list[BaseTool] = []

--- a/examples/langgraph_custom_agent/adapter/runtime.py
+++ b/examples/langgraph_custom_agent/adapter/runtime.py
@@ -1,7 +1,7 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-"""Minimum Fabric lifecycle for the email-phishing custom agent."""
+"""Minimum NeMo Fabric lifecycle for the email-phishing custom agent."""
 
 from __future__ import annotations
 
@@ -38,7 +38,7 @@ def _runtime_context(payload: dict[str, Any]) -> RuntimeContext:
 
 
 class EmailPhishingRuntime:
-    """One compiled email-phishing graph owned by one Fabric runtime."""
+    """One compiled email-phishing graph owned by one NeMo Fabric runtime."""
 
     def __init__(self) -> None:
         self._runtime_id: str | None = None

--- a/examples/langgraph_custom_agent/adapter/runtime.py
+++ b/examples/langgraph_custom_agent/adapter/runtime.py
@@ -1,0 +1,99 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Minimum Fabric lifecycle for the email-phishing custom agent."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from langgraph.graph.state import CompiledStateGraph
+from nemo_fabric_adapter_contract.models import AgentConfig
+from nemo_fabric_adapter_contract.models import RuntimeContext
+from nemo_fabric_adapters.common import lifecycle
+
+from examples.langgraph_custom_agent.adapter.configuration import (
+    resolve_agent_dependencies,
+)
+from examples.langgraph_custom_agent.agent.graph import build_email_phishing_graph
+
+
+def main() -> None:
+    """Serve one persistent custom-agent runtime."""
+
+    lifecycle.serve(EmailPhishingRuntime, config_loader=AgentConfig.from_mapping)
+
+
+def _runtime_context(payload: dict[str, Any]) -> RuntimeContext:
+    try:
+        return RuntimeContext.from_mapping(payload.get("runtime_context"))
+    except Exception as error:
+        raise lifecycle.LifecycleError(
+            "email_phishing_invalid_runtime_context",
+            "The email-phishing adapter requires a valid RuntimeContext",
+        ) from error
+
+
+class EmailPhishingRuntime:
+    """One compiled email-phishing graph owned by one Fabric runtime."""
+
+    def __init__(self) -> None:
+        self._runtime_id: str | None = None
+        self._graph: CompiledStateGraph | None = None
+
+    async def start(self, payload: dict[str, Any]) -> None:
+        if self._graph is not None:
+            raise lifecycle.LifecycleError(
+                "email_phishing_runtime_already_started",
+                "The email-phishing runtime is already started",
+            )
+        agent_config = payload.get("config")
+        if not isinstance(agent_config, AgentConfig):
+            raise lifecycle.LifecycleError(
+                "email_phishing_invalid_config",
+                "The email-phishing adapter requires a validated AgentConfig",
+            )
+
+        context = _runtime_context(payload)
+        dependencies = resolve_agent_dependencies(agent_config)
+        graph = build_email_phishing_graph(
+            dependencies.model,
+            dependencies.system_instruction,
+        )
+        self._runtime_id = context.runtime_id
+        self._graph = graph
+
+    async def invoke(self, payload: dict[str, Any]) -> dict[str, Any]:
+        if self._graph is None or self._runtime_id is None:
+            raise lifecycle.LifecycleError(
+                "email_phishing_runtime_not_started",
+                "The email-phishing runtime is not started",
+            )
+        context = _runtime_context(payload)
+        if context.runtime_id != self._runtime_id:
+            raise lifecycle.LifecycleError(
+                "email_phishing_runtime_mismatch",
+                "The invocation does not match the active email-phishing runtime",
+            )
+        request = payload.get("request")
+        email = request.get("input") if isinstance(request, dict) else None
+        if not isinstance(email, str) or not email.strip():
+            raise lifecycle.LifecycleError(
+                "email_phishing_invalid_request",
+                "The email-phishing adapter requires a non-empty text input",
+            )
+
+        result = await self._graph.ainvoke({"email": email})
+        return {
+            "response": result["explanation"],
+            "classification": result["classification"],
+            "signals": result["signals"],
+        }
+
+    async def stop(self) -> None:
+        self._runtime_id = None
+        self._graph = None
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/langgraph_custom_agent/adapter/runtime.py
+++ b/examples/langgraph_custom_agent/adapter/runtime.py
@@ -5,6 +5,7 @@
 
 from __future__ import annotations
 
+import logging
 from pathlib import Path
 from typing import Any
 
@@ -19,6 +20,23 @@ from examples.langgraph_custom_agent.adapter.configuration import (
 from examples.langgraph_custom_agent.adapter.mcp import resolve_url_inspector
 from examples.langgraph_custom_agent.adapter.telemetry import observe_invocation
 from examples.langgraph_custom_agent.agent.graph import build_email_phishing_graph
+
+LOGGER = logging.getLogger(__name__)
+
+
+def _invocation_failure() -> dict[str, Any]:
+    """Return a safe terminal failure without invalidating the runtime."""
+
+    return {
+        "response": None,
+        "completed": False,
+        "failed": True,
+        "error": {
+            "code": "email_phishing_invoke_failed",
+            "message": "The email-phishing agent invocation failed",
+            "retryable": False,
+        },
+    }
 
 
 def main() -> None:
@@ -108,16 +126,23 @@ class EmailPhishingRuntime:
                 "The email-phishing adapter requires a non-empty text input",
             )
 
-        async with observe_invocation(
-            context,
-            base_dir=self._base_dir,
-            agent_name=self._agent_name,
-            model_name=self._model_name,
-        ) as telemetry:
-            result = await self._graph.ainvoke(
-                {"email": email},
-                config=telemetry.runnable_config,
+        try:
+            async with observe_invocation(
+                context,
+                base_dir=self._base_dir,
+                agent_name=self._agent_name,
+                model_name=self._model_name,
+            ) as telemetry:
+                result = await self._graph.ainvoke(
+                    {"email": email},
+                    config=telemetry.runnable_config,
+                )
+        except Exception as error:
+            LOGGER.error(
+                "Email-phishing invocation failed (error_type=%s)",
+                type(error).__name__,
             )
+            return _invocation_failure()
         output = {
             "response": result["explanation"],
             "classification": result["classification"],

--- a/examples/langgraph_custom_agent/adapter/runtime.py
+++ b/examples/langgraph_custom_agent/adapter/runtime.py
@@ -5,6 +5,7 @@
 
 from __future__ import annotations
 
+from pathlib import Path
 from typing import Any
 
 from langgraph.graph.state import CompiledStateGraph
@@ -15,6 +16,7 @@ from nemo_fabric_adapters.common import lifecycle
 from examples.langgraph_custom_agent.adapter.configuration import (
     resolve_agent_dependencies,
 )
+from examples.langgraph_custom_agent.adapter.telemetry import observe_invocation
 from examples.langgraph_custom_agent.agent.graph import build_email_phishing_graph
 
 
@@ -39,6 +41,9 @@ class EmailPhishingRuntime:
 
     def __init__(self) -> None:
         self._runtime_id: str | None = None
+        self._base_dir: Path | None = None
+        self._agent_name: str | None = None
+        self._model_name: str | None = None
         self._graph: CompiledStateGraph | None = None
 
     async def start(self, payload: dict[str, Any]) -> None:
@@ -61,10 +66,19 @@ class EmailPhishingRuntime:
             dependencies.system_instruction,
         )
         self._runtime_id = context.runtime_id
+        self._base_dir = Path(payload.get("base_dir") or ".").resolve()
+        self._agent_name = str(payload.get("agent_name") or "email-phishing-agent")
+        self._model_name = agent_config.models["default"].model
         self._graph = graph
 
     async def invoke(self, payload: dict[str, Any]) -> dict[str, Any]:
-        if self._graph is None or self._runtime_id is None:
+        if (
+            self._graph is None
+            or self._runtime_id is None
+            or self._base_dir is None
+            or self._agent_name is None
+            or self._model_name is None
+        ):
             raise lifecycle.LifecycleError(
                 "email_phishing_runtime_not_started",
                 "The email-phishing runtime is not started",
@@ -83,15 +97,31 @@ class EmailPhishingRuntime:
                 "The email-phishing adapter requires a non-empty text input",
             )
 
-        result = await self._graph.ainvoke({"email": email})
-        return {
+        async with observe_invocation(
+            context,
+            base_dir=self._base_dir,
+            agent_name=self._agent_name,
+            model_name=self._model_name,
+        ) as telemetry:
+            result = await self._graph.ainvoke(
+                {"email": email},
+                config=telemetry.runnable_config,
+            )
+        output = {
             "response": result["explanation"],
             "classification": result["classification"],
             "signals": result["signals"],
         }
+        relay_artifacts = telemetry.artifacts()
+        if relay_artifacts:
+            output["relay_artifacts"] = relay_artifacts
+        return output
 
     async def stop(self) -> None:
         self._runtime_id = None
+        self._base_dir = None
+        self._agent_name = None
+        self._model_name = None
         self._graph = None
 
 

--- a/examples/langgraph_custom_agent/adapter/runtime.py
+++ b/examples/langgraph_custom_agent/adapter/runtime.py
@@ -16,6 +16,7 @@ from nemo_fabric_adapters.common import lifecycle
 from examples.langgraph_custom_agent.adapter.configuration import (
     resolve_agent_dependencies,
 )
+from examples.langgraph_custom_agent.adapter.mcp import resolve_url_inspector
 from examples.langgraph_custom_agent.adapter.telemetry import observe_invocation
 from examples.langgraph_custom_agent.agent.graph import build_email_phishing_graph
 
@@ -61,9 +62,11 @@ class EmailPhishingRuntime:
 
         context = _runtime_context(payload)
         dependencies = resolve_agent_dependencies(agent_config)
+        url_inspector = await resolve_url_inspector(agent_config)
         graph = build_email_phishing_graph(
             dependencies.model,
             dependencies.system_instruction,
+            url_inspector,
         )
         self._runtime_id = context.runtime_id
         self._base_dir = Path(payload.get("base_dir") or ".").resolve()
@@ -112,6 +115,8 @@ class EmailPhishingRuntime:
             "classification": result["classification"],
             "signals": result["signals"],
         }
+        if "link_inspections" in result:
+            output["link_inspections"] = result["link_inspections"]
         relay_artifacts = telemetry.artifacts()
         if relay_artifacts:
             output["relay_artifacts"] = relay_artifacts

--- a/examples/langgraph_custom_agent/adapter/runtime.py
+++ b/examples/langgraph_custom_agent/adapter/runtime.py
@@ -28,6 +28,8 @@ def main() -> None:
 
 
 def _runtime_context(payload: dict[str, Any]) -> RuntimeContext:
+    """Decode the runtime context supplied with a lifecycle operation."""
+
     try:
         return RuntimeContext.from_mapping(payload.get("runtime_context"))
     except Exception as error:
@@ -41,6 +43,8 @@ class EmailPhishingRuntime:
     """One compiled email-phishing graph owned by one NeMo Fabric runtime."""
 
     def __init__(self) -> None:
+        """Initialize an unstarted custom-agent runtime."""
+
         self._runtime_id: str | None = None
         self._base_dir: Path | None = None
         self._agent_name: str | None = None
@@ -48,6 +52,8 @@ class EmailPhishingRuntime:
         self._graph: CompiledStateGraph | None = None
 
     async def start(self, payload: dict[str, Any]) -> None:
+        """Resolve native dependencies and retain one compiled graph."""
+
         if self._graph is not None:
             raise lifecycle.LifecycleError(
                 "email_phishing_runtime_already_started",
@@ -75,6 +81,8 @@ class EmailPhishingRuntime:
         self._graph = graph
 
     async def invoke(self, payload: dict[str, Any]) -> dict[str, Any]:
+        """Run one request against the retained graph and return terminal output."""
+
         if (
             self._graph is None
             or self._runtime_id is None
@@ -123,6 +131,8 @@ class EmailPhishingRuntime:
         return output
 
     async def stop(self) -> None:
+        """Release the compiled graph and all runtime-owned references."""
+
         self._runtime_id = None
         self._base_dir = None
         self._agent_name = None

--- a/examples/langgraph_custom_agent/adapter/telemetry.py
+++ b/examples/langgraph_custom_agent/adapter/telemetry.py
@@ -112,7 +112,7 @@ async def observe_invocation(
     agent_name: str,
     model_name: str,
 ) -> AsyncIterator[InvocationTelemetry]:
-    """Activate Relay only when Fabric supplies an enabled telemetry context."""
+    """Activate Relay when NeMo Fabric supplies an enabled telemetry context."""
 
     telemetry = context.telemetry
     if telemetry is None or not telemetry.relay_enabled:

--- a/examples/langgraph_custom_agent/adapter/telemetry.py
+++ b/examples/langgraph_custom_agent/adapter/telemetry.py
@@ -1,0 +1,143 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Optional Relay boundary for one custom-agent invocation."""
+
+from __future__ import annotations
+
+import json
+from contextlib import asynccontextmanager
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+from typing import AsyncIterator
+
+from langchain_core.runnables import RunnableConfig
+from nemo_fabric_adapter_contract.models import RuntimeContext
+from nemo_fabric_adapters.common import lifecycle
+from nemo_fabric_adapters.common import utils as common_utils
+
+
+@dataclass(slots=True)
+class InvocationTelemetry:
+    """Runnable config and artifacts for one Relay-enabled invocation."""
+
+    runnable_config: RunnableConfig | None = None
+    plugin_config: dict[str, Any] | None = None
+
+    def artifacts(self) -> list[dict[str, str]]:
+        if self.plugin_config is None:
+            return []
+        return common_utils.collect_relay_artifacts(self.plugin_config)
+
+
+def _telemetry_error(code: str, message: str) -> lifecycle.LifecycleError:
+    return lifecycle.LifecycleError(code, message)
+
+
+def _load_plugin_config(
+    context: RuntimeContext,
+    *,
+    base_dir: Path,
+    agent_name: str,
+    model_name: str,
+) -> dict[str, Any]:
+    telemetry = context.telemetry
+    if telemetry is None or telemetry.config_path is None:
+        raise _telemetry_error(
+            "email_phishing_relay_config_missing",
+            "Relay is enabled but RuntimeContext has no Relay configuration path",
+        )
+    try:
+        wrapper = json.loads(
+            Path(telemetry.config_path).read_text(encoding="utf-8")
+        )
+        plugin_config = wrapper.get("relay", {}).get("config") or {}
+        if "components" not in plugin_config:
+            plugin_config = {
+                "version": 1,
+                "components": [
+                    {
+                        "kind": "observability",
+                        "enabled": True,
+                        "config": plugin_config or {"version": 2},
+                    }
+                ],
+            }
+        plugin_config.setdefault("version", 1)
+        plugin_config.setdefault("components", [])
+    except (AttributeError, json.JSONDecodeError, OSError, TypeError) as error:
+        raise _telemetry_error(
+            "email_phishing_relay_config_invalid",
+            "Relay configuration could not be loaded",
+        ) from error
+
+    common_utils.normalize_relay_output_dirs(
+        plugin_config,
+        {
+            "agent_name": agent_name,
+            "base_dir": str(base_dir),
+            "config": {"models": {"default": {"model": model_name}}},
+            "runtime_context": context.to_mapping(),
+        },
+    )
+    for component in plugin_config["components"]:
+        if component.get("kind") != "observability":
+            continue
+        atif = component.get("config", {}).get("atif")
+        if isinstance(atif, dict) and atif.get("enabled"):
+            atif["model_name"] = model_name
+    return plugin_config
+
+
+def _relay_api() -> tuple[Any, Any, Any, Any]:
+    try:
+        from nemo_relay import ScopeType
+        from nemo_relay import plugin
+        from nemo_relay import scope
+        from nemo_relay.integrations.langgraph import NemoRelayCallbackHandler
+    except (ImportError, AttributeError) as error:
+        raise _telemetry_error(
+            "email_phishing_relay_unavailable",
+            "Relay telemetry requires a compatible nemo-relay installation",
+        ) from error
+    return plugin, scope, ScopeType, NemoRelayCallbackHandler
+
+
+@asynccontextmanager
+async def observe_invocation(
+    context: RuntimeContext,
+    *,
+    base_dir: Path,
+    agent_name: str,
+    model_name: str,
+) -> AsyncIterator[InvocationTelemetry]:
+    """Activate Relay only when Fabric supplies an enabled telemetry context."""
+
+    telemetry = context.telemetry
+    if telemetry is None or not telemetry.relay_enabled:
+        yield InvocationTelemetry()
+        return
+
+    plugin_config = _load_plugin_config(
+        context,
+        base_dir=base_dir,
+        agent_name=agent_name,
+        model_name=model_name,
+    )
+    plugin, scope, scope_type, callback_handler = _relay_api()
+    observation = InvocationTelemetry(
+        runnable_config={"callbacks": [callback_handler()]},
+        plugin_config=plugin_config,
+    )
+    async with plugin.plugin(plugin_config):
+        with scope.scope(
+            "email-phishing-invocation",
+            scope_type.Agent,
+            metadata={
+                "nemo_fabric_runtime_id": context.runtime_id,
+                "nemo_fabric_invocation_id": context.invocation_id,
+                "nemo_fabric_request_id": context.request_id,
+            },
+        ):
+            yield observation

--- a/examples/langgraph_custom_agent/agent/__init__.py
+++ b/examples/langgraph_custom_agent/agent/__init__.py
@@ -1,0 +1,2 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0

--- a/examples/langgraph_custom_agent/agent/graph.py
+++ b/examples/langgraph_custom_agent/agent/graph.py
@@ -5,18 +5,32 @@
 
 from __future__ import annotations
 
+import json
+import re
+from collections.abc import Mapping
+from typing import Any
 from typing import Literal
 from typing import NotRequired
 from typing import TypedDict
 
 from langchain_core.language_models import BaseChatModel
 from langchain_core.runnables import RunnableConfig
+from langchain_core.tools import BaseTool
 from langgraph.graph import END
 from langgraph.graph import START
 from langgraph.graph import StateGraph
 from langgraph.graph.state import CompiledStateGraph
 
 RiskClassification = Literal["benign", "phishing"]
+URL_PATTERN = re.compile(r"https?://[^\s<>()]+")
+
+
+class LinkInspection(TypedDict):
+    """Validated output from the optional URL inspection tool."""
+
+    url: str
+    hostname: str
+    indicators: list[str]
 
 
 class EmailAnalysisState(TypedDict):
@@ -24,6 +38,7 @@ class EmailAnalysisState(TypedDict):
 
     email: str
     signals: NotRequired[list[str]]
+    link_inspections: NotRequired[list[LinkInspection]]
     classification: NotRequired[RiskClassification]
     explanation: NotRequired[str]
 
@@ -47,6 +62,33 @@ def extract_signals(state: EmailAnalysisState) -> dict[str, list[str]]:
     return {"signals": signals}
 
 
+def _tool_text(value: Any) -> str:
+    if isinstance(value, str):
+        return value
+    if isinstance(value, list):
+        text = [
+            item["text"]
+            for item in value
+            if isinstance(item, Mapping) and isinstance(item.get("text"), str)
+        ]
+        if text:
+            return "\n".join(text)
+    raise TypeError("the URL inspection tool must return text content")
+
+
+def _inspection(url: str, value: Any) -> LinkInspection:
+    result = json.loads(_tool_text(value))
+    if not isinstance(result, dict):
+        raise TypeError("the URL inspection tool result must be an object")
+    hostname = result.get("hostname")
+    indicators = result.get("indicators")
+    if not isinstance(hostname, str) or not isinstance(indicators, list):
+        raise TypeError("the URL inspection tool returned an invalid result")
+    if any(not isinstance(indicator, str) for indicator in indicators):
+        raise TypeError("the URL inspection indicators must be strings")
+    return {"url": url, "hostname": hostname, "indicators": indicators}
+
+
 def classify_risk(
     state: EmailAnalysisState,
 ) -> dict[str, RiskClassification]:
@@ -61,14 +103,38 @@ def classify_risk(
 def build_email_phishing_graph(
     model: BaseChatModel,
     system_instruction: str,
+    url_inspector: BaseTool | None = None,
 ) -> CompiledStateGraph:
     """Build the custom agent from native LangChain dependencies."""
+
+    async def inspect_links(
+        state: EmailAnalysisState,
+        config: RunnableConfig,
+    ) -> dict[str, Any]:
+        if url_inspector is None:  # pragma: no cover - node is conditionally added
+            return {}
+        urls = [
+            match.group().rstrip(".,;:!?)]}")
+            for match in URL_PATTERN.finditer(state["email"])
+        ]
+        inspections = [
+            _inspection(
+                url,
+                await url_inspector.ainvoke({"url": url}, config=config),
+            )
+            for url in urls
+        ]
+        signals = list(state["signals"])
+        if any(inspection["indicators"] for inspection in inspections):
+            signals.append("suspicious_link")
+        return {"link_inspections": inspections, "signals": signals}
 
     async def explain_assessment(
         state: EmailAnalysisState,
         config: RunnableConfig,
     ) -> dict[str, str]:
         signals = ", ".join(state["signals"]) or "none"
+        link_inspections = state.get("link_inspections", [])
         response = await model.ainvoke(
             [
                 ("system", system_instruction),
@@ -77,6 +143,7 @@ def build_email_phishing_graph(
                     "Explain this fixed email-risk assessment concisely.\n"
                     f"Classification: {state['classification']}\n"
                     f"Signals: {signals}\n"
+                    f"Link inspections: {json.dumps(link_inspections)}\n"
                     f"Email:\n{state['email']}",
                 ),
             ],
@@ -91,7 +158,12 @@ def build_email_phishing_graph(
     builder.add_node("classify_risk", classify_risk)
     builder.add_node("explain_assessment", explain_assessment)
     builder.add_edge(START, "extract_signals")
-    builder.add_edge("extract_signals", "classify_risk")
+    if url_inspector is None:
+        builder.add_edge("extract_signals", "classify_risk")
+    else:
+        builder.add_node("inspect_links", inspect_links)
+        builder.add_edge("extract_signals", "inspect_links")
+        builder.add_edge("inspect_links", "classify_risk")
     builder.add_edge("classify_risk", "explain_assessment")
     builder.add_edge("explain_assessment", END)
     return builder.compile()

--- a/examples/langgraph_custom_agent/agent/graph.py
+++ b/examples/langgraph_custom_agent/agent/graph.py
@@ -1,0 +1,97 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Application-defined LangGraph for the email-phishing example."""
+
+from __future__ import annotations
+
+from typing import Literal
+from typing import NotRequired
+from typing import TypedDict
+
+from langchain_core.language_models import BaseChatModel
+from langchain_core.runnables import RunnableConfig
+from langgraph.graph import END
+from langgraph.graph import START
+from langgraph.graph import StateGraph
+from langgraph.graph.state import CompiledStateGraph
+
+RiskClassification = Literal["benign", "phishing"]
+
+
+class EmailAnalysisState(TypedDict):
+    """State accumulated while analyzing one email."""
+
+    email: str
+    signals: NotRequired[list[str]]
+    classification: NotRequired[RiskClassification]
+    explanation: NotRequired[str]
+
+
+def extract_signals(state: EmailAnalysisState) -> dict[str, list[str]]:
+    """Extract a small deterministic set of common phishing signals."""
+
+    email = state["email"].casefold()
+    signals: list[str] = []
+    if any(term in email for term in ("urgent", "immediately", "act now")):
+        signals.append("urgency")
+    if any(
+        term in email
+        for term in ("password", "sign in", "login", "verify your account")
+    ):
+        signals.append("credential_request")
+    if "http://" in email or "https://" in email:
+        signals.append("external_link")
+    if any(term in email for term in ("account locked", "account suspended")):
+        signals.append("account_threat")
+    return {"signals": signals}
+
+
+def classify_risk(
+    state: EmailAnalysisState,
+) -> dict[str, RiskClassification]:
+    """Apply the example's stable, intentionally simple risk policy."""
+
+    classification: RiskClassification = (
+        "phishing" if len(state["signals"]) >= 2 else "benign"
+    )
+    return {"classification": classification}
+
+
+def build_email_phishing_graph(
+    model: BaseChatModel,
+    system_instruction: str,
+) -> CompiledStateGraph:
+    """Build the custom agent from native LangChain dependencies."""
+
+    async def explain_assessment(
+        state: EmailAnalysisState,
+        config: RunnableConfig,
+    ) -> dict[str, str]:
+        signals = ", ".join(state["signals"]) or "none"
+        response = await model.ainvoke(
+            [
+                ("system", system_instruction),
+                (
+                    "user",
+                    "Explain this fixed email-risk assessment concisely.\n"
+                    f"Classification: {state['classification']}\n"
+                    f"Signals: {signals}\n"
+                    f"Email:\n{state['email']}",
+                ),
+            ],
+            config=config,
+        )
+        if not isinstance(response.content, str):
+            raise TypeError("the explanation model must return text content")
+        return {"explanation": response.content}
+
+    builder = StateGraph(EmailAnalysisState)
+    builder.add_node("extract_signals", extract_signals)
+    builder.add_node("classify_risk", classify_risk)
+    builder.add_node("explain_assessment", explain_assessment)
+    builder.add_edge(START, "extract_signals")
+    builder.add_edge("extract_signals", "classify_risk")
+    builder.add_edge("classify_risk", "explain_assessment")
+    builder.add_edge("explain_assessment", END)
+    return builder.compile()

--- a/examples/langgraph_custom_agent/agent/graph.py
+++ b/examples/langgraph_custom_agent/agent/graph.py
@@ -57,7 +57,15 @@ def extract_signals(state: EmailAnalysisState) -> dict[str, list[str]]:
         signals.append("credential_request")
     if "http://" in email or "https://" in email:
         signals.append("external_link")
-    if any(term in email for term in ("account locked", "account suspended")):
+    if any(
+        term in email
+        for term in (
+            "account locked",
+            "account is locked",
+            "account suspended",
+            "account is suspended",
+        )
+    ):
         signals.append("account_threat")
     return {"signals": signals}
 

--- a/examples/langgraph_custom_agent/consumer/__init__.py
+++ b/examples/langgraph_custom_agent/consumer/__init__.py
@@ -1,0 +1,2 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0

--- a/examples/langgraph_custom_agent/consumer/__main__.py
+++ b/examples/langgraph_custom_agent/consumer/__main__.py
@@ -1,0 +1,50 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Plan or run the email-phishing custom-agent example."""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import json
+from pathlib import Path
+
+from nemo_fabric import Fabric
+
+from examples.langgraph_custom_agent.consumer.config import frontier_config
+from examples.langgraph_custom_agent.consumer.config import public_config
+
+
+async def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--variant", choices=("public", "frontier"), default="public")
+    parser.add_argument("--model")
+    parser.add_argument("--base-dir", type=Path, default=Path.cwd())
+    parser.add_argument("--plan", action="store_true")
+    parser.add_argument(
+        "--input",
+        default=(
+            "Urgent: your account is locked. Verify your password immediately at "
+            "https://example.invalid."
+        ),
+    )
+    args = parser.parse_args()
+
+    if args.variant == "frontier":
+        if not args.model:
+            parser.error("--model is required with --variant frontier")
+        config = frontier_config(args.model)
+    else:
+        config = public_config(args.model) if args.model else public_config()
+    fabric = Fabric()
+    output = (
+        fabric.plan(config, base_dir=args.base_dir)
+        if args.plan
+        else await fabric.run(config, base_dir=args.base_dir, input=args.input)
+    )
+    print(json.dumps(output.to_mapping(), indent=2))
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/examples/langgraph_custom_agent/consumer/__main__.py
+++ b/examples/langgraph_custom_agent/consumer/__main__.py
@@ -31,12 +31,8 @@ async def main() -> None:
     )
     args = parser.parse_args()
 
-    if args.variant == "frontier":
-        if not args.model:
-            parser.error("--model is required with --variant frontier")
-        config = frontier_config(args.model)
-    else:
-        config = public_config(args.model) if args.model else public_config()
+    config_factory = frontier_config if args.variant == "frontier" else public_config
+    config = config_factory(args.model) if args.model else config_factory()
     fabric = Fabric()
     output = (
         fabric.plan(config, base_dir=args.base_dir)

--- a/examples/langgraph_custom_agent/consumer/__main__.py
+++ b/examples/langgraph_custom_agent/consumer/__main__.py
@@ -17,6 +17,7 @@ from examples.langgraph_custom_agent.consumer.config import public_config
 from examples.langgraph_custom_agent.consumer.config import with_relay
 from examples.langgraph_custom_agent.consumer.config import with_system_instruction
 from examples.langgraph_custom_agent.consumer.config import with_temperature
+from examples.langgraph_custom_agent.consumer.config import with_url_inspector_mcp
 
 
 async def main() -> None:
@@ -25,6 +26,7 @@ async def main() -> None:
     parser.add_argument("--model")
     parser.add_argument("--system-instruction")
     parser.add_argument("--temperature", type=float)
+    parser.add_argument("--mcp", action="store_true")
     parser.add_argument("--relay", action="store_true")
     parser.add_argument("--base-dir", type=Path, default=Path.cwd())
     parser.add_argument("--plan", action="store_true")
@@ -43,6 +45,8 @@ async def main() -> None:
         config = with_system_instruction(config, args.system_instruction)
     if args.temperature is not None:
         config = with_temperature(config, args.temperature)
+    if args.mcp:
+        config = with_url_inspector_mcp(config)
     if args.relay:
         config = with_relay(config)
     fabric = Fabric()

--- a/examples/langgraph_custom_agent/consumer/__main__.py
+++ b/examples/langgraph_custom_agent/consumer/__main__.py
@@ -14,12 +14,18 @@ from nemo_fabric import Fabric
 
 from examples.langgraph_custom_agent.consumer.config import frontier_config
 from examples.langgraph_custom_agent.consumer.config import public_config
+from examples.langgraph_custom_agent.consumer.config import with_relay
+from examples.langgraph_custom_agent.consumer.config import with_system_instruction
+from examples.langgraph_custom_agent.consumer.config import with_temperature
 
 
 async def main() -> None:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("--variant", choices=("public", "frontier"), default="public")
     parser.add_argument("--model")
+    parser.add_argument("--system-instruction")
+    parser.add_argument("--temperature", type=float)
+    parser.add_argument("--relay", action="store_true")
     parser.add_argument("--base-dir", type=Path, default=Path.cwd())
     parser.add_argument("--plan", action="store_true")
     parser.add_argument(
@@ -33,6 +39,12 @@ async def main() -> None:
 
     config_factory = frontier_config if args.variant == "frontier" else public_config
     config = config_factory(args.model) if args.model else config_factory()
+    if args.system_instruction:
+        config = with_system_instruction(config, args.system_instruction)
+    if args.temperature is not None:
+        config = with_temperature(config, args.temperature)
+    if args.relay:
+        config = with_relay(config)
     fabric = Fabric()
     output = (
         fabric.plan(config, base_dir=args.base_dir)

--- a/examples/langgraph_custom_agent/consumer/config.py
+++ b/examples/langgraph_custom_agent/consumer/config.py
@@ -1,0 +1,74 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Consumer-owned FabricConfig variants for the custom agent."""
+
+from __future__ import annotations
+
+import os
+
+from nemo_fabric import FabricConfig
+from nemo_fabric import HarnessConfig
+from nemo_fabric import InstructionConfig
+from nemo_fabric import InstructionsConfig
+from nemo_fabric import MetadataConfig
+from nemo_fabric import ModelConfig
+from nemo_fabric import RuntimeConfig
+
+ADAPTER_ID = "nvidia.fabric.example.langgraph.email-phishing"
+PUBLIC_DEFAULT_MODEL = "nvidia/nemotron-3-nano-30b-a3b"
+PUBLIC_BASE_URL = "https://integrate.api.nvidia.com/v1"
+
+
+def _config(*, model: str, api_key_env: str, base_url: str) -> FabricConfig:
+    return FabricConfig(
+        metadata=MetadataConfig(
+            name="langgraph-email-phishing",
+            description="Classifies email risk with a dedicated LangGraph agent.",
+        ),
+        harness=HarnessConfig(
+            adapter_id=ADAPTER_ID,
+            resolution="preinstalled",
+        ),
+        models={
+            "default": ModelConfig(
+                provider="nvidia",
+                model=model,
+                api_key_env=api_key_env,
+                base_url=base_url,
+                temperature=0.0,
+            )
+        },
+        instructions=InstructionsConfig(
+            system=InstructionConfig(
+                content=(
+                    "Explain why the fixed classification follows from the detected "
+                    "signals. Do not change the classification."
+                )
+            )
+        ),
+        runtime=RuntimeConfig(input_schema="text", output_schema="message"),
+    )
+
+
+def public_config(model: str = PUBLIC_DEFAULT_MODEL) -> FabricConfig:
+    """Use the public NVIDIA API Catalog endpoint."""
+
+    return _config(
+        model=model,
+        api_key_env="NVIDIA_API_KEY",
+        base_url=PUBLIC_BASE_URL,
+    )
+
+
+def frontier_config(model: str) -> FabricConfig:
+    """Use an internal NVIDIA Frontier OpenAI-compatible endpoint."""
+
+    base_url = os.environ.get("NVIDIA_FRONTIER_BASE_URL")
+    if not base_url:
+        raise RuntimeError("NVIDIA_FRONTIER_BASE_URL is required for frontier testing")
+    return _config(
+        model=model,
+        api_key_env="NVIDIA_FRONTIER_API_KEY",
+        base_url=base_url,
+    )

--- a/examples/langgraph_custom_agent/consumer/config.py
+++ b/examples/langgraph_custom_agent/consumer/config.py
@@ -16,7 +16,7 @@ from nemo_fabric import ModelConfig
 from nemo_fabric import RuntimeConfig
 
 ADAPTER_ID = "nvidia.fabric.example.langgraph.email-phishing"
-PUBLIC_DEFAULT_MODEL = "nvidia/nemotron-3-nano-30b-a3b"
+DEFAULT_MODEL = "nvidia/nemotron-3-nano-omni-30b-a3b-reasoning"
 PUBLIC_BASE_URL = "https://integrate.api.nvidia.com/v1"
 
 
@@ -51,7 +51,7 @@ def _config(*, model: str, api_key_env: str, base_url: str) -> FabricConfig:
     )
 
 
-def public_config(model: str = PUBLIC_DEFAULT_MODEL) -> FabricConfig:
+def public_config(model: str = DEFAULT_MODEL) -> FabricConfig:
     """Use the public NVIDIA API Catalog endpoint."""
 
     return _config(
@@ -61,7 +61,7 @@ def public_config(model: str = PUBLIC_DEFAULT_MODEL) -> FabricConfig:
     )
 
 
-def frontier_config(model: str) -> FabricConfig:
+def frontier_config(model: str = DEFAULT_MODEL) -> FabricConfig:
     """Use an internal NVIDIA Frontier OpenAI-compatible endpoint."""
 
     base_url = os.environ.get("NVIDIA_FRONTIER_BASE_URL")

--- a/examples/langgraph_custom_agent/consumer/config.py
+++ b/examples/langgraph_custom_agent/consumer/config.py
@@ -22,7 +22,8 @@ from nemo_fabric import RelayObservabilityConfig
 from nemo_fabric import RuntimeConfig
 
 ADAPTER_ID = "nvidia.fabric.example.langgraph.email-phishing"
-DEFAULT_MODEL = "nvidia/nemotron-3-nano-omni-30b-a3b-reasoning"
+PUBLIC_DEFAULT_MODEL = "nvidia/nemotron-3-nano-omni-30b-a3b-reasoning"
+FRONTIER_DEFAULT_MODEL = "nvidia/nvidia/nemotron-3-nano-omni-30b-a3b-reasoning"
 PUBLIC_BASE_URL = "https://integrate.api.nvidia.com/v1"
 URL_INSPECTOR_SERVER = (
     Path(__file__).parents[1] / "mcp" / "url_inspector.py"
@@ -60,7 +61,7 @@ def _config(*, model: str, api_key_env: str, base_url: str) -> FabricConfig:
     )
 
 
-def public_config(model: str = DEFAULT_MODEL) -> FabricConfig:
+def public_config(model: str = PUBLIC_DEFAULT_MODEL) -> FabricConfig:
     """Use the public NVIDIA API Catalog endpoint."""
 
     return _config(
@@ -70,7 +71,7 @@ def public_config(model: str = DEFAULT_MODEL) -> FabricConfig:
     )
 
 
-def frontier_config(model: str = DEFAULT_MODEL) -> FabricConfig:
+def frontier_config(model: str = FRONTIER_DEFAULT_MODEL) -> FabricConfig:
     """Use an internal NVIDIA Frontier OpenAI-compatible endpoint."""
 
     base_url = os.environ.get("NVIDIA_FRONTIER_BASE_URL")

--- a/examples/langgraph_custom_agent/consumer/config.py
+++ b/examples/langgraph_custom_agent/consumer/config.py
@@ -130,7 +130,7 @@ def with_relay(base: FabricConfig) -> FabricConfig:
                     RelayAtofFileSinkConfig(
                         output_directory="./artifacts/relay",
                         filename="events.atof.jsonl",
-                        mode="overwrite",
+                        mode="append",
                     )
                 ],
             ),

--- a/examples/langgraph_custom_agent/consumer/config.py
+++ b/examples/langgraph_custom_agent/consumer/config.py
@@ -13,6 +13,10 @@ from nemo_fabric import InstructionConfig
 from nemo_fabric import InstructionsConfig
 from nemo_fabric import MetadataConfig
 from nemo_fabric import ModelConfig
+from nemo_fabric import RelayAtifConfig
+from nemo_fabric import RelayAtofConfig
+from nemo_fabric import RelayAtofFileSinkConfig
+from nemo_fabric import RelayObservabilityConfig
 from nemo_fabric import RuntimeConfig
 
 ADAPTER_ID = "nvidia.fabric.example.langgraph.email-phishing"
@@ -72,3 +76,51 @@ def frontier_config(model: str = DEFAULT_MODEL) -> FabricConfig:
         api_key_env="NVIDIA_FRONTIER_API_KEY",
         base_url=base_url,
     )
+
+
+def with_system_instruction(base: FabricConfig, content: str) -> FabricConfig:
+    """Return an independent config with a different normalized instruction."""
+
+    config = base.model_copy(deep=True)
+    config.instructions = InstructionsConfig(
+        system=InstructionConfig(content=content)
+    )
+    return config
+
+
+def with_temperature(base: FabricConfig, temperature: float) -> FabricConfig:
+    """Return an independent config with a different model temperature."""
+
+    config = base.model_copy(deep=True)
+    config.models["default"].temperature = temperature
+    return config
+
+
+def with_relay(base: FabricConfig) -> FabricConfig:
+    """Return an independent config with Relay ATOF and ATIF enabled."""
+
+    config = base.model_copy(deep=True)
+    config.runtime.artifacts = "./artifacts"
+    config.enable_relay(
+        output_dir="./artifacts/relay",
+        observability=RelayObservabilityConfig(
+            atof=RelayAtofConfig(
+                enabled=True,
+                sinks=[
+                    RelayAtofFileSinkConfig(
+                        output_directory="./artifacts/relay",
+                        filename="events.atof.jsonl",
+                        mode="overwrite",
+                    )
+                ],
+            ),
+            atif=RelayAtifConfig(
+                enabled=True,
+                output_directory="./artifacts/relay",
+                filename_template="trajectory-{session_id}.atif.json",
+                agent_name="langgraph-email-phishing",
+                agent_version="fabric-sdk-example",
+            ),
+        ),
+    )
+    return config

--- a/examples/langgraph_custom_agent/consumer/config.py
+++ b/examples/langgraph_custom_agent/consumer/config.py
@@ -6,6 +6,8 @@
 from __future__ import annotations
 
 import os
+import sys
+from pathlib import Path
 
 from nemo_fabric import FabricConfig
 from nemo_fabric import HarnessConfig
@@ -22,6 +24,9 @@ from nemo_fabric import RuntimeConfig
 ADAPTER_ID = "nvidia.fabric.example.langgraph.email-phishing"
 DEFAULT_MODEL = "nvidia/nemotron-3-nano-omni-30b-a3b-reasoning"
 PUBLIC_BASE_URL = "https://integrate.api.nvidia.com/v1"
+URL_INSPECTOR_SERVER = (
+    Path(__file__).parents[1] / "mcp" / "url_inspector.py"
+).resolve()
 
 
 def _config(*, model: str, api_key_env: str, base_url: str) -> FabricConfig:
@@ -93,6 +98,21 @@ def with_temperature(base: FabricConfig, temperature: float) -> FabricConfig:
 
     config = base.model_copy(deep=True)
     config.models["default"].temperature = temperature
+    return config
+
+
+def with_url_inspector_mcp(base: FabricConfig) -> FabricConfig:
+    """Return an independent config with the example's stdio MCP server."""
+
+    config = base.model_copy(deep=True)
+    config.add_mcp_server(
+        "url-inspector",
+        transport="stdio",
+        url=os.environ.get("ADAPTER_PYTHON", sys.executable),
+        args=[str(URL_INSPECTOR_SERVER)],
+        exposure="harness_native",
+        allowed_tools=["inspect_url"],
+    )
     return config
 
 

--- a/examples/langgraph_custom_agent/mcp/__init__.py
+++ b/examples/langgraph_custom_agent/mcp/__init__.py
@@ -1,0 +1,2 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0

--- a/examples/langgraph_custom_agent/mcp/url_inspector.py
+++ b/examples/langgraph_custom_agent/mcp/url_inspector.py
@@ -1,0 +1,50 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Small deterministic stdio MCP server for the phishing example."""
+
+from __future__ import annotations
+
+import ipaddress
+from typing import TypedDict
+from urllib.parse import urlparse
+
+from mcp.server.fastmcp import FastMCP
+
+
+class UrlInspection(TypedDict):
+    """Non-authoritative URL metadata returned to the example graph."""
+
+    hostname: str
+    indicators: list[str]
+
+
+server = FastMCP("email-link-inspector", log_level="ERROR")
+
+
+@server.tool(structured_output=True)
+def inspect_url(url: str) -> UrlInspection:
+    """Inspect URL syntax for a few deterministic phishing indicators."""
+
+    parsed = urlparse(url)
+    hostname = parsed.hostname or ""
+    indicators: list[str] = []
+    if parsed.scheme != "https":
+        indicators.append("unencrypted_link")
+    if "@" in parsed.netloc:
+        indicators.append("embedded_credentials")
+    try:
+        ipaddress.ip_address(hostname)
+    except ValueError:
+        pass
+    else:
+        indicators.append("ip_literal_host")
+    if hostname.startswith("xn--") or ".xn--" in hostname:
+        indicators.append("punycode_host")
+    if hostname.endswith(".invalid"):
+        indicators.append("reserved_test_domain")
+    return {"hostname": hostname, "indicators": indicators}
+
+
+if __name__ == "__main__":
+    server.run(transport="stdio")

--- a/examples/langgraph_custom_agent/mcp/url_inspector.py
+++ b/examples/langgraph_custom_agent/mcp/url_inspector.py
@@ -3,8 +3,6 @@
 
 """Small deterministic stdio MCP server for the phishing example."""
 
-from __future__ import annotations
-
 import ipaddress
 from typing import TypedDict
 from urllib.parse import urlparse
@@ -22,7 +20,7 @@ class UrlInspection(TypedDict):
 server = FastMCP("email-link-inspector", log_level="ERROR")
 
 
-@server.tool(structured_output=True)
+@server.tool()
 def inspect_url(url: str) -> UrlInspection:
     """Inspect URL syntax for a few deterministic phishing indicators."""
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -88,7 +88,7 @@ langgraph-example = [
   "langchain-mcp-adapters>=0.1,<0.3.0",
   "langchain-openai>=0.3,<2.0",
   "langgraph>=1.2,<2.0",
-  "mcp>=1.2",
+  "mcp>=1.10",
 ]
 
 dev = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -83,6 +83,13 @@ adapter-tests = [
   "nemo-fabric-adapters-hermes[harness]; python_version < '3.14'",
 ]
 
+langgraph-example = [
+  "langchain>=1.3,<2.0",
+  "langchain-mcp-adapters>=0.1,<0.3.0",
+  "langchain-openai>=0.3",
+  "langgraph>=1.2,<2.0",
+]
+
 dev = [
     "ipython~=8.20",
     "pip-licenses>=5,<6",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -86,8 +86,9 @@ adapter-tests = [
 langgraph-example = [
   "langchain>=1.3,<2.0",
   "langchain-mcp-adapters>=0.1,<0.3.0",
-  "langchain-openai>=0.3",
+  "langchain-openai>=0.3,<2.0",
   "langgraph>=1.2,<2.0",
+  "mcp>=1.2",
 ]
 
 dev = [

--- a/tests/examples/langgraph_custom_agent/conftest.py
+++ b/tests/examples/langgraph_custom_agent/conftest.py
@@ -1,0 +1,54 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Shared fixtures for the LangGraph custom-agent example tests."""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from typing import Any
+
+import pytest
+
+
+@pytest.fixture(name="runtime_context_factory")
+def runtime_context_factory_fixture() -> Callable[[str, str], dict[str, Any]]:
+    def build(runtime_id: str, invocation_id: str) -> dict[str, Any]:
+        return {
+            "runtime_id": runtime_id,
+            "invocation_id": invocation_id,
+            "request_id": f"request-{invocation_id}",
+            "environment": {
+                "environment_id": "environment-1",
+                "provider": "local",
+                "control_location": "in_env_control",
+                "ownership": "caller_owned",
+            },
+            "artifacts": {},
+        }
+
+    return build
+
+
+@pytest.fixture(name="agent_config_mapping")
+def agent_config_mapping_fixture() -> dict[str, Any]:
+    return {
+        "models": {
+            "default": {
+                "provider": "nvidia",
+                "model": "nvidia/test-model",
+                "api_key_env": "TEST_API_KEY",
+                "base_url": "https://example.test/v1",
+            }
+        }
+    }
+
+
+@pytest.fixture(name="lifecycle_request_factory")
+def lifecycle_request_factory_fixture() -> Callable[
+    [str, dict[str, Any]], dict[str, Any]
+]:
+    def build(operation: str, payload: dict[str, Any]) -> dict[str, Any]:
+        return {"operation": operation, "payload": payload}
+
+    return build

--- a/tests/examples/langgraph_custom_agent/test_adapter.py
+++ b/tests/examples/langgraph_custom_agent/test_adapter.py
@@ -8,7 +8,6 @@ from __future__ import annotations
 import asyncio
 import io
 import json
-from typing import Any
 
 import pytest
 from langchain_core.language_models.fake_chat_models import FakeListChatModel
@@ -20,39 +19,12 @@ from examples.langgraph_custom_agent.adapter.configuration import AgentDependenc
 from examples.langgraph_custom_agent.adapter import runtime as runtime_module
 
 
-def _context(runtime_id: str, invocation_id: str) -> dict[str, Any]:
-    return {
-        "runtime_id": runtime_id,
-        "invocation_id": invocation_id,
-        "request_id": f"request-{invocation_id}",
-        "environment": {
-            "environment_id": "environment-1",
-            "provider": "local",
-            "control_location": "in_env_control",
-            "ownership": "caller_owned",
-        },
-        "artifacts": {},
-    }
-
-
-def _config() -> dict[str, Any]:
-    return {
-        "models": {
-            "default": {
-                "provider": "nvidia",
-                "model": "nvidia/test-model",
-                "api_key_env": "TEST_API_KEY",
-                "base_url": "https://example.test/v1",
-            }
-        }
-    }
-
-
-def _request(operation: str, payload: dict[str, Any]) -> dict[str, Any]:
-    return {"operation": operation, "payload": payload}
-
-
-def test_lifecycle_host_starts_once_invokes_repeatedly_and_stops(monkeypatch):
+def test_lifecycle_host_starts_once_invokes_repeatedly_and_stops(
+    monkeypatch,
+    runtime_context_factory,
+    agent_config_mapping,
+    lifecycle_request_factory,
+):
     model = FakeListChatModel(responses=["first explanation", "second explanation"])
     monkeypatch.setattr(
         runtime_module,
@@ -61,30 +33,36 @@ def test_lifecycle_host_starts_once_invokes_repeatedly_and_stops(monkeypatch):
     )
     runtime_id = "runtime-1"
     requests = [
-        _request(
+        lifecycle_request_factory(
             "start",
             {
-                "config": _config(),
-                "runtime_context": _context(runtime_id, "runtime-start"),
+                "config": agent_config_mapping,
+                "runtime_context": runtime_context_factory(
+                    runtime_id, "runtime-start"
+                ),
             },
         ),
-        _request(
+        lifecycle_request_factory(
             "invoke",
             {
-                "runtime_context": _context(runtime_id, "invocation-1"),
+                "runtime_context": runtime_context_factory(
+                    runtime_id, "invocation-1"
+                ),
                 "request": {
                     "input": "Urgent: verify your password at https://one.invalid."
                 },
             },
         ),
-        _request(
+        lifecycle_request_factory(
             "invoke",
             {
-                "runtime_context": _context(runtime_id, "invocation-2"),
+                "runtime_context": runtime_context_factory(
+                    runtime_id, "invocation-2"
+                ),
                 "request": {"input": "Team lunch is at noon."},
             },
         ),
-        _request("stop", {"runtime_id": runtime_id}),
+        lifecycle_request_factory("stop", {"runtime_id": runtime_id}),
     ]
     input_stream = io.StringIO(
         "".join(f"{json.dumps(request)}\n" for request in requests)
@@ -117,14 +95,16 @@ def test_lifecycle_host_starts_once_invokes_repeatedly_and_stops(monkeypatch):
     }
 
 
-def test_runtime_rejects_invoke_before_start():
+def test_runtime_rejects_invoke_before_start(runtime_context_factory):
     runtime = runtime_module.EmailPhishingRuntime()
 
     with pytest.raises(lifecycle.LifecycleError) as error:
         asyncio.run(
             runtime.invoke(
                 {
-                    "runtime_context": _context("runtime-1", "invocation-1"),
+                    "runtime_context": runtime_context_factory(
+                        "runtime-1", "invocation-1"
+                    ),
                     "request": {"input": "hello"},
                 }
             )
@@ -133,7 +113,11 @@ def test_runtime_rejects_invoke_before_start():
     assert error.value.code == "email_phishing_runtime_not_started"
 
 
-def test_runtime_rejects_runtime_mismatch(monkeypatch):
+def test_runtime_rejects_runtime_mismatch(
+    monkeypatch,
+    runtime_context_factory,
+    agent_config_mapping,
+):
     monkeypatch.setattr(
         runtime_module,
         "resolve_agent_dependencies",
@@ -146,8 +130,10 @@ def test_runtime_rejects_runtime_mismatch(monkeypatch):
     asyncio.run(
         runtime.start(
             {
-                "config": AgentConfig.from_mapping(_config()),
-                "runtime_context": _context("runtime-1", "runtime-start"),
+                "config": AgentConfig.from_mapping(agent_config_mapping),
+                "runtime_context": runtime_context_factory(
+                    "runtime-1", "runtime-start"
+                ),
             }
         )
     )
@@ -156,7 +142,9 @@ def test_runtime_rejects_runtime_mismatch(monkeypatch):
         asyncio.run(
             runtime.invoke(
                 {
-                    "runtime_context": _context("runtime-2", "invocation-1"),
+                    "runtime_context": runtime_context_factory(
+                        "runtime-2", "invocation-1"
+                    ),
                     "request": {"input": "hello"},
                 }
             )
@@ -166,7 +154,11 @@ def test_runtime_rejects_runtime_mismatch(monkeypatch):
     asyncio.run(runtime.stop())
 
 
-def test_stop_is_safe_after_partial_start(monkeypatch):
+def test_stop_is_safe_after_partial_start(
+    monkeypatch,
+    runtime_context_factory,
+    agent_config_mapping,
+):
     def fail_resolution(_config):
         raise lifecycle.LifecycleError("test_start_failure", "start failed")
 
@@ -177,19 +169,34 @@ def test_stop_is_safe_after_partial_start(monkeypatch):
     )
     runtime = runtime_module.EmailPhishingRuntime()
     start_payload = {
-        "config": AgentConfig.from_mapping(_config()),
-        "runtime_context": _context("runtime-1", "runtime-start"),
+        "config": AgentConfig.from_mapping(agent_config_mapping),
+        "runtime_context": runtime_context_factory("runtime-1", "runtime-start"),
     }
 
     with pytest.raises(lifecycle.LifecycleError, match="start failed"):
         asyncio.run(runtime.start(start_payload))
 
     asyncio.run(runtime.stop())
-    assert runtime._graph is None
-    assert runtime._runtime_id is None
+    with pytest.raises(lifecycle.LifecycleError) as error:
+        asyncio.run(
+            runtime.invoke(
+                {
+                    "runtime_context": runtime_context_factory(
+                        "runtime-1", "invocation-after-stop"
+                    ),
+                    "request": {"input": "hello"},
+                }
+            )
+        )
+
+    assert error.value.code == "email_phishing_runtime_not_started"
 
 
-def test_runtime_returns_optional_mcp_link_inspections(monkeypatch):
+def test_runtime_returns_optional_mcp_link_inspections(
+    monkeypatch,
+    runtime_context_factory,
+    agent_config_mapping,
+):
     @tool
     async def inspect_url(url: str) -> str:
         """Inspect one URL."""
@@ -217,8 +224,10 @@ def test_runtime_returns_optional_mcp_link_inspections(monkeypatch):
     asyncio.run(
         runtime.start(
             {
-                "config": AgentConfig.from_mapping(_config()),
-                "runtime_context": _context("runtime-1", "runtime-start"),
+                "config": AgentConfig.from_mapping(agent_config_mapping),
+                "runtime_context": runtime_context_factory(
+                    "runtime-1", "runtime-start"
+                ),
             }
         )
     )
@@ -226,7 +235,9 @@ def test_runtime_returns_optional_mcp_link_inspections(monkeypatch):
     output = asyncio.run(
         runtime.invoke(
             {
-                "runtime_context": _context("runtime-1", "invocation-1"),
+                "runtime_context": runtime_context_factory(
+                    "runtime-1", "invocation-1"
+                ),
                 "request": {"input": "Review https://example.invalid/login."},
             }
         )

--- a/tests/examples/langgraph_custom_agent/test_adapter.py
+++ b/tests/examples/langgraph_custom_agent/test_adapter.py
@@ -1,0 +1,188 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for the minimum custom-agent lifecycle."""
+
+from __future__ import annotations
+
+import asyncio
+import io
+import json
+from typing import Any
+
+import pytest
+from langchain_core.language_models.fake_chat_models import FakeListChatModel
+from nemo_fabric_adapters.common import lifecycle
+from nemo_fabric_adapter_contract.models import AgentConfig
+
+from examples.langgraph_custom_agent.adapter.configuration import AgentDependencies
+from examples.langgraph_custom_agent.adapter import runtime as runtime_module
+
+
+def _context(runtime_id: str, invocation_id: str) -> dict[str, Any]:
+    return {
+        "runtime_id": runtime_id,
+        "invocation_id": invocation_id,
+        "request_id": f"request-{invocation_id}",
+        "environment": {
+            "environment_id": "environment-1",
+            "provider": "local",
+            "control_location": "in_env_control",
+            "ownership": "caller_owned",
+        },
+        "artifacts": {},
+    }
+
+
+def _config() -> dict[str, Any]:
+    return {
+        "models": {
+            "default": {
+                "provider": "nvidia",
+                "model": "nvidia/test-model",
+                "api_key_env": "TEST_API_KEY",
+                "base_url": "https://example.test/v1",
+            }
+        }
+    }
+
+
+def _request(operation: str, payload: dict[str, Any]) -> dict[str, Any]:
+    return {"operation": operation, "payload": payload}
+
+
+def test_lifecycle_host_starts_once_invokes_repeatedly_and_stops(monkeypatch):
+    model = FakeListChatModel(responses=["first explanation", "second explanation"])
+    monkeypatch.setattr(
+        runtime_module,
+        "resolve_agent_dependencies",
+        lambda _config: AgentDependencies(model, "Explain the assessment."),
+    )
+    runtime_id = "runtime-1"
+    requests = [
+        _request(
+            "start",
+            {
+                "config": _config(),
+                "runtime_context": _context(runtime_id, "runtime-start"),
+            },
+        ),
+        _request(
+            "invoke",
+            {
+                "runtime_context": _context(runtime_id, "invocation-1"),
+                "request": {
+                    "input": "Urgent: verify your password at https://one.invalid."
+                },
+            },
+        ),
+        _request(
+            "invoke",
+            {
+                "runtime_context": _context(runtime_id, "invocation-2"),
+                "request": {"input": "Team lunch is at noon."},
+            },
+        ),
+        _request("stop", {"runtime_id": runtime_id}),
+    ]
+    input_stream = io.StringIO(
+        "".join(f"{json.dumps(request)}\n" for request in requests)
+    )
+    output_stream = io.StringIO()
+
+    lifecycle.serve(
+        runtime_module.EmailPhishingRuntime,
+        config_loader=AgentConfig.from_mapping,
+        input_stream=input_stream,
+        output_stream=output_stream,
+    )
+
+    responses = [json.loads(line) for line in output_stream.getvalue().splitlines()]
+    assert [response["outcome"]["status"] for response in responses] == [
+        "succeeded",
+        "succeeded",
+        "succeeded",
+        "succeeded",
+    ]
+    assert responses[1]["outcome"]["output"] == {
+        "response": "first explanation",
+        "classification": "phishing",
+        "signals": ["urgency", "credential_request", "external_link"],
+    }
+    assert responses[2]["outcome"]["output"] == {
+        "response": "second explanation",
+        "classification": "benign",
+        "signals": [],
+    }
+
+
+def test_runtime_rejects_invoke_before_start():
+    runtime = runtime_module.EmailPhishingRuntime()
+
+    with pytest.raises(lifecycle.LifecycleError) as error:
+        asyncio.run(
+            runtime.invoke(
+                {
+                    "runtime_context": _context("runtime-1", "invocation-1"),
+                    "request": {"input": "hello"},
+                }
+            )
+        )
+
+    assert error.value.code == "email_phishing_runtime_not_started"
+
+
+def test_runtime_rejects_runtime_mismatch(monkeypatch):
+    monkeypatch.setattr(
+        runtime_module,
+        "resolve_agent_dependencies",
+        lambda _config: AgentDependencies(
+            FakeListChatModel(responses=["unused"]),
+            "Explain the assessment.",
+        ),
+    )
+    runtime = runtime_module.EmailPhishingRuntime()
+    asyncio.run(
+        runtime.start(
+            {
+                "config": AgentConfig.from_mapping(_config()),
+                "runtime_context": _context("runtime-1", "runtime-start"),
+            }
+        )
+    )
+
+    with pytest.raises(lifecycle.LifecycleError) as error:
+        asyncio.run(
+            runtime.invoke(
+                {
+                    "runtime_context": _context("runtime-2", "invocation-1"),
+                    "request": {"input": "hello"},
+                }
+            )
+        )
+
+    assert error.value.code == "email_phishing_runtime_mismatch"
+    asyncio.run(runtime.stop())
+
+
+def test_stop_is_safe_after_partial_start(monkeypatch):
+    def fail_resolution(_config):
+        raise lifecycle.LifecycleError("test_start_failure", "start failed")
+
+    monkeypatch.setattr(
+        runtime_module,
+        "resolve_agent_dependencies",
+        fail_resolution,
+    )
+    runtime = runtime_module.EmailPhishingRuntime()
+    start_payload = {
+        "config": AgentConfig.from_mapping(_config()),
+        "runtime_context": _context("runtime-1", "runtime-start"),
+    }
+
+    with pytest.raises(lifecycle.LifecycleError, match="start failed"):
+        asyncio.run(runtime.start(start_payload))
+
+    asyncio.run(runtime.stop())
+    assert runtime._graph is None
+    assert runtime._runtime_id is None

--- a/tests/examples/langgraph_custom_agent/test_adapter.py
+++ b/tests/examples/langgraph_custom_agent/test_adapter.py
@@ -95,6 +95,105 @@ def test_lifecycle_host_starts_once_invokes_repeatedly_and_stops(
     }
 
 
+def test_invocation_failure_does_not_invalidate_runtime(
+    monkeypatch,
+    runtime_context_factory,
+    agent_config_mapping,
+    lifecycle_request_factory,
+):
+    class FailThenSucceedGraph:
+        def __init__(self):
+            self.calls = 0
+
+        async def ainvoke(self, _input, *, config):
+            self.calls += 1
+            if self.calls == 1:
+                raise TimeoutError("provider details must not escape")
+            return {
+                "explanation": "second invocation succeeded",
+                "classification": "benign",
+                "signals": [],
+            }
+
+    graph = FailThenSucceedGraph()
+    monkeypatch.setattr(
+        runtime_module,
+        "resolve_agent_dependencies",
+        lambda _config: AgentDependencies(
+            FakeListChatModel(responses=["unused"]),
+            "Explain the assessment.",
+        ),
+    )
+    monkeypatch.setattr(
+        runtime_module,
+        "build_email_phishing_graph",
+        lambda *_args: graph,
+    )
+    runtime_id = "runtime-1"
+    requests = [
+        lifecycle_request_factory(
+            "start",
+            {
+                "config": agent_config_mapping,
+                "runtime_context": runtime_context_factory(
+                    runtime_id, "runtime-start"
+                ),
+            },
+        ),
+        lifecycle_request_factory(
+            "invoke",
+            {
+                "runtime_context": runtime_context_factory(
+                    runtime_id, "invocation-1"
+                ),
+                "request": {"input": "first"},
+            },
+        ),
+        lifecycle_request_factory(
+            "invoke",
+            {
+                "runtime_context": runtime_context_factory(
+                    runtime_id, "invocation-2"
+                ),
+                "request": {"input": "second"},
+            },
+        ),
+        lifecycle_request_factory("stop", {"runtime_id": runtime_id}),
+    ]
+    input_stream = io.StringIO(
+        "".join(f"{json.dumps(request)}\n" for request in requests)
+    )
+    output_stream = io.StringIO()
+
+    lifecycle.serve(
+        runtime_module.EmailPhishingRuntime,
+        config_loader=AgentConfig.from_mapping,
+        input_stream=input_stream,
+        output_stream=output_stream,
+    )
+
+    responses = [json.loads(line) for line in output_stream.getvalue().splitlines()]
+    assert responses[1]["outcome"] == {
+        "status": "succeeded",
+        "output": {
+            "response": None,
+            "completed": False,
+            "failed": True,
+            "error": {
+                "code": "email_phishing_invoke_failed",
+                "message": "The email-phishing agent invocation failed",
+                "retryable": False,
+            },
+        },
+    }
+    assert responses[2]["outcome"]["output"] == {
+        "response": "second invocation succeeded",
+        "classification": "benign",
+        "signals": [],
+    }
+    assert graph.calls == 2
+
+
 def test_runtime_rejects_invoke_before_start(runtime_context_factory):
     runtime = runtime_module.EmailPhishingRuntime()
 

--- a/tests/examples/langgraph_custom_agent/test_adapter.py
+++ b/tests/examples/langgraph_custom_agent/test_adapter.py
@@ -12,6 +12,7 @@ from typing import Any
 
 import pytest
 from langchain_core.language_models.fake_chat_models import FakeListChatModel
+from langchain_core.tools import tool
 from nemo_fabric_adapters.common import lifecycle
 from nemo_fabric_adapter_contract.models import AgentConfig
 
@@ -186,3 +187,61 @@ def test_stop_is_safe_after_partial_start(monkeypatch):
     asyncio.run(runtime.stop())
     assert runtime._graph is None
     assert runtime._runtime_id is None
+
+
+def test_runtime_returns_optional_mcp_link_inspections(monkeypatch):
+    @tool
+    async def inspect_url(url: str) -> str:
+        """Inspect one URL."""
+
+        return json.dumps(
+            {
+                "hostname": "example.invalid",
+                "indicators": ["reserved_test_domain"],
+            }
+        )
+
+    async def resolve(_config):
+        return inspect_url
+
+    monkeypatch.setattr(
+        runtime_module,
+        "resolve_agent_dependencies",
+        lambda _config: AgentDependencies(
+            FakeListChatModel(responses=["The link is suspicious."]),
+            "Explain the assessment.",
+        ),
+    )
+    monkeypatch.setattr(runtime_module, "resolve_url_inspector", resolve)
+    runtime = runtime_module.EmailPhishingRuntime()
+    asyncio.run(
+        runtime.start(
+            {
+                "config": AgentConfig.from_mapping(_config()),
+                "runtime_context": _context("runtime-1", "runtime-start"),
+            }
+        )
+    )
+
+    output = asyncio.run(
+        runtime.invoke(
+            {
+                "runtime_context": _context("runtime-1", "invocation-1"),
+                "request": {"input": "Review https://example.invalid/login."},
+            }
+        )
+    )
+
+    assert output["signals"] == [
+        "credential_request",
+        "external_link",
+        "suspicious_link",
+    ]
+    assert output["link_inspections"] == [
+        {
+            "url": "https://example.invalid/login",
+            "hostname": "example.invalid",
+            "indicators": ["reserved_test_domain"],
+        }
+    ]
+    asyncio.run(runtime.stop())

--- a/tests/examples/langgraph_custom_agent/test_agent.py
+++ b/tests/examples/langgraph_custom_agent/test_agent.py
@@ -6,9 +6,11 @@
 from __future__ import annotations
 
 import asyncio
+import json
 from pathlib import Path
 
 from langchain_core.language_models.fake_chat_models import FakeListChatModel
+from langchain_core.tools import tool
 
 from examples.langgraph_custom_agent.agent.graph import build_email_phishing_graph
 
@@ -48,3 +50,45 @@ def test_graph_keeps_classification_deterministic_and_uses_model_for_explanation
     assert result["explanation"] == (
         "The email combines several phishing signals."
     )
+
+
+def test_graph_uses_an_optional_native_url_inspection_tool():
+    @tool
+    async def inspect_url(url: str) -> list[dict[str, str]]:
+        """Inspect one URL."""
+
+        return [
+            {
+                "type": "text",
+                "text": json.dumps(
+                    {
+                        "hostname": "example.invalid",
+                        "indicators": ["reserved_test_domain"],
+                    }
+                ),
+            }
+        ]
+
+    graph = build_email_phishing_graph(
+        FakeListChatModel(responses=["The link adds another risk signal."]),
+        "Explain the fixed assessment.",
+        inspect_url,
+    )
+
+    result = asyncio.run(
+        graph.ainvoke({"email": "Review https://example.invalid/login."})
+    )
+
+    assert result["classification"] == "phishing"
+    assert result["signals"] == [
+        "credential_request",
+        "external_link",
+        "suspicious_link",
+    ]
+    assert result["link_inspections"] == [
+        {
+            "url": "https://example.invalid/login",
+            "hostname": "example.invalid",
+            "indicators": ["reserved_test_domain"],
+        }
+    ]

--- a/tests/examples/langgraph_custom_agent/test_agent.py
+++ b/tests/examples/langgraph_custom_agent/test_agent.py
@@ -1,0 +1,40 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for the Fabric-independent email-phishing graph."""
+
+from __future__ import annotations
+
+import asyncio
+
+from langchain_core.language_models.fake_chat_models import FakeListChatModel
+
+from examples.langgraph_custom_agent.agent.graph import build_email_phishing_graph
+
+
+def test_graph_keeps_classification_deterministic_and_uses_model_for_explanation():
+    graph = build_email_phishing_graph(
+        FakeListChatModel(responses=["The email combines several phishing signals."]),
+        "Explain the fixed assessment.",
+    )
+
+    result = asyncio.run(
+        graph.ainvoke(
+            {
+                "email": (
+                    "Urgent: your account is locked. Verify your password at "
+                    "https://example.invalid."
+                )
+            }
+        )
+    )
+
+    assert result["classification"] == "phishing"
+    assert result["signals"] == [
+        "urgency",
+        "credential_request",
+        "external_link",
+    ]
+    assert result["explanation"] == (
+        "The email combines several phishing signals."
+    )

--- a/tests/examples/langgraph_custom_agent/test_agent.py
+++ b/tests/examples/langgraph_custom_agent/test_agent.py
@@ -6,10 +6,20 @@
 from __future__ import annotations
 
 import asyncio
+from pathlib import Path
 
 from langchain_core.language_models.fake_chat_models import FakeListChatModel
 
 from examples.langgraph_custom_agent.agent.graph import build_email_phishing_graph
+
+GRAPH_SOURCE = Path(__file__).parents[3] / "examples/langgraph_custom_agent/agent/graph.py"
+
+
+def test_application_graph_does_not_depend_on_fabric_or_relay():
+    source = GRAPH_SOURCE.read_text(encoding="utf-8")
+
+    assert "nemo_fabric" not in source
+    assert "nemo_relay" not in source
 
 
 def test_graph_keeps_classification_deterministic_and_uses_model_for_explanation():

--- a/tests/examples/langgraph_custom_agent/test_agent.py
+++ b/tests/examples/langgraph_custom_agent/test_agent.py
@@ -6,22 +6,42 @@
 from __future__ import annotations
 
 import asyncio
+import ast
 import json
 from pathlib import Path
 
+import pytest
 from langchain_core.language_models.fake_chat_models import FakeListChatModel
 from langchain_core.tools import tool
 
+from examples.langgraph_custom_agent.agent import graph as graph_module
+from examples.langgraph_custom_agent.agent.graph import _inspection
 from examples.langgraph_custom_agent.agent.graph import build_email_phishing_graph
-
-GRAPH_SOURCE = Path(__file__).parents[3] / "examples/langgraph_custom_agent/agent/graph.py"
 
 
 def test_application_graph_does_not_depend_on_fabric_or_relay():
-    source = GRAPH_SOURCE.read_text(encoding="utf-8")
+    source_path = Path(graph_module.__file__)
+    tree = ast.parse(source_path.read_text(encoding="utf-8"))
+    imported_modules = {
+        alias.name
+        for node in ast.walk(tree)
+        if isinstance(node, ast.Import)
+        for alias in node.names
+    }
+    imported_modules.update(
+        node.module
+        for node in ast.walk(tree)
+        if isinstance(node, ast.ImportFrom) and node.module is not None
+    )
 
-    assert "nemo_fabric" not in source
-    assert "nemo_relay" not in source
+    assert not any(
+        module == "nemo_fabric" or module.startswith("nemo_fabric.")
+        for module in imported_modules
+    )
+    assert not any(
+        module == "nemo_relay" or module.startswith("nemo_relay.")
+        for module in imported_modules
+    )
 
 
 def test_graph_keeps_classification_deterministic_and_uses_model_for_explanation():
@@ -46,6 +66,7 @@ def test_graph_keeps_classification_deterministic_and_uses_model_for_explanation
         "urgency",
         "credential_request",
         "external_link",
+        "account_threat",
     ]
     assert result["explanation"] == (
         "The email combines several phishing signals."
@@ -92,3 +113,30 @@ def test_graph_uses_an_optional_native_url_inspection_tool():
             "indicators": ["reserved_test_domain"],
         }
     ]
+
+
+@pytest.mark.parametrize(
+    ("tool_result", "error_type", "message"),
+    [
+        ("not JSON", json.JSONDecodeError, None),
+        (json.dumps([]), TypeError, "must be an object"),
+        (
+            json.dumps({"hostname": 7, "indicators": []}),
+            TypeError,
+            "returned an invalid result",
+        ),
+        (
+            json.dumps({"hostname": "example.invalid", "indicators": [7]}),
+            TypeError,
+            "indicators must be strings",
+        ),
+        ([], TypeError, "must return text content"),
+    ],
+)
+def test_url_inspection_rejects_malformed_tool_results(
+    tool_result,
+    error_type,
+    message,
+):
+    with pytest.raises(error_type, match=message):
+        _inspection("https://example.invalid", tool_result)

--- a/tests/examples/langgraph_custom_agent/test_configuration.py
+++ b/tests/examples/langgraph_custom_agent/test_configuration.py
@@ -1,0 +1,108 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for the narrow AgentConfig-to-LangChain mapping."""
+
+from __future__ import annotations
+
+from copy import deepcopy
+
+import pytest
+from langchain_openai import ChatOpenAI
+from nemo_fabric_adapter_contract.models import AgentConfig
+from nemo_fabric_adapters.common import lifecycle
+
+from examples.langgraph_custom_agent.adapter.configuration import (
+    MODEL_REQUEST_TIMEOUT_SECONDS,
+)
+from examples.langgraph_custom_agent.adapter.configuration import (
+    resolve_agent_dependencies,
+)
+
+
+def _config_mapping() -> dict:
+    return {
+        "models": {
+            "default": {
+                "provider": "nvidia",
+                "model": "nvidia/test-model",
+                "api_key_env": "TEST_NVIDIA_API_KEY",
+                "base_url": "https://example.test/v1",
+                "temperature": 0.2,
+            }
+        },
+        "instructions": {
+            "system": {
+                "content": "Use the extracted signals.",
+                "mode": "replace",
+            }
+        },
+    }
+
+
+def test_resolver_applies_every_advertised_model_and_instruction_field(monkeypatch):
+    monkeypatch.setenv("TEST_NVIDIA_API_KEY", "test-key")
+
+    dependencies = resolve_agent_dependencies(
+        AgentConfig.from_mapping(_config_mapping())
+    )
+
+    assert isinstance(dependencies.model, ChatOpenAI)
+    assert dependencies.model.model_name == "nvidia/test-model"
+    assert dependencies.model.openai_api_base == "https://example.test/v1"
+    assert dependencies.model.temperature == 0.2
+    assert dependencies.model.request_timeout == MODEL_REQUEST_TIMEOUT_SECONDS
+    assert dependencies.system_instruction == "Use the extracted signals."
+
+
+@pytest.mark.parametrize(
+    ("mutate", "field"),
+    [
+        (
+            lambda value: value["models"].update(
+                {"other": deepcopy(value["models"]["default"])}
+            ),
+            "models",
+        ),
+        (
+            lambda value: value["models"]["default"].update(
+                {"settings": {"unsupported": True}}
+            ),
+            "models.default.settings",
+        ),
+        (
+            lambda value: value["models"]["default"].update(
+                {"provider": "anthropic"}
+            ),
+            "models.default.provider",
+        ),
+        (
+            lambda value: value["models"]["default"].pop("base_url"),
+            "models.default.base_url",
+        ),
+    ],
+)
+def test_resolver_rejects_accepted_but_unusable_model_configuration(
+    monkeypatch,
+    mutate,
+    field,
+):
+    monkeypatch.setenv("TEST_NVIDIA_API_KEY", "test-key")
+    mapping = _config_mapping()
+    mutate(mapping)
+
+    with pytest.raises(lifecycle.LifecycleError) as error:
+        resolve_agent_dependencies(AgentConfig.from_mapping(mapping))
+
+    assert error.value.code == "email_phishing_invalid_config"
+    assert error.value.metadata == {"field": field}
+
+
+def test_resolver_reports_the_missing_credential_name(monkeypatch):
+    monkeypatch.delenv("TEST_NVIDIA_API_KEY", raising=False)
+
+    with pytest.raises(lifecycle.LifecycleError) as error:
+        resolve_agent_dependencies(AgentConfig.from_mapping(_config_mapping()))
+
+    assert error.value.metadata == {"field": "models.default.api_key_env"}
+    assert "TEST_NVIDIA_API_KEY" in error.value.message

--- a/tests/examples/langgraph_custom_agent/test_consumer.py
+++ b/tests/examples/langgraph_custom_agent/test_consumer.py
@@ -5,8 +5,6 @@
 
 from __future__ import annotations
 
-import os
-
 from examples.langgraph_custom_agent.consumer.config import DEFAULT_MODEL
 from examples.langgraph_custom_agent.consumer.config import frontier_config
 from examples.langgraph_custom_agent.consumer.config import public_config
@@ -16,8 +14,11 @@ from examples.langgraph_custom_agent.consumer.config import with_temperature
 from examples.langgraph_custom_agent.consumer.config import with_url_inspector_mcp
 
 
-def test_public_and_frontier_configs_vary_only_endpoint_and_credential():
-    os.environ["NVIDIA_FRONTIER_BASE_URL"] = "https://frontier.example/v1"
+def test_public_and_frontier_configs_vary_only_endpoint_and_credential(monkeypatch):
+    monkeypatch.setenv(
+        "NVIDIA_FRONTIER_BASE_URL",
+        "https://frontier.example/v1",
+    )
 
     public = public_config()
     frontier = frontier_config()

--- a/tests/examples/langgraph_custom_agent/test_consumer.py
+++ b/tests/examples/langgraph_custom_agent/test_consumer.py
@@ -13,6 +13,7 @@ from examples.langgraph_custom_agent.consumer.config import public_config
 from examples.langgraph_custom_agent.consumer.config import with_relay
 from examples.langgraph_custom_agent.consumer.config import with_system_instruction
 from examples.langgraph_custom_agent.consumer.config import with_temperature
+from examples.langgraph_custom_agent.consumer.config import with_url_inspector_mcp
 
 
 def test_public_and_frontier_configs_vary_only_endpoint_and_credential():
@@ -57,3 +58,16 @@ def test_relay_variant_is_additive_and_independent():
     assert relay.relay.observability.atof.enabled is True
     assert relay.relay.observability.atif.enabled is True
     assert relay.runtime.artifacts == "./artifacts"
+
+
+def test_stdio_mcp_variant_is_additive_and_bounded():
+    base = public_config()
+
+    mcp = with_url_inspector_mcp(base)
+
+    assert base.mcp is None
+    server = mcp.mcp.servers["url-inspector"]
+    assert server.transport == "stdio"
+    assert server.exposure == "harness_native"
+    assert server.allowed_tools == ["inspect_url"]
+    assert server.blocked_tools == []

--- a/tests/examples/langgraph_custom_agent/test_consumer.py
+++ b/tests/examples/langgraph_custom_agent/test_consumer.py
@@ -1,0 +1,59 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for independent northbound configuration variants."""
+
+from __future__ import annotations
+
+import os
+
+from examples.langgraph_custom_agent.consumer.config import DEFAULT_MODEL
+from examples.langgraph_custom_agent.consumer.config import frontier_config
+from examples.langgraph_custom_agent.consumer.config import public_config
+from examples.langgraph_custom_agent.consumer.config import with_relay
+from examples.langgraph_custom_agent.consumer.config import with_system_instruction
+from examples.langgraph_custom_agent.consumer.config import with_temperature
+
+
+def test_public_and_frontier_configs_vary_only_endpoint_and_credential():
+    os.environ["NVIDIA_FRONTIER_BASE_URL"] = "https://frontier.example/v1"
+
+    public = public_config()
+    frontier = frontier_config()
+
+    assert public.models["default"].model == frontier.models["default"].model
+    assert public.models["default"].model == DEFAULT_MODEL
+    assert public.models["default"].api_key_env == "NVIDIA_API_KEY"
+    assert frontier.models["default"].api_key_env == "NVIDIA_FRONTIER_API_KEY"
+    assert public.models["default"].base_url == (
+        "https://integrate.api.nvidia.com/v1"
+    )
+    assert frontier.models["default"].base_url == "https://frontier.example/v1"
+
+
+def test_instruction_and_temperature_variants_do_not_mutate_their_input():
+    base = public_config()
+
+    instruction = with_system_instruction(base, "Explain only the strongest signal.")
+    temperature = with_temperature(base, 0.4)
+
+    assert base.instructions.system.content != instruction.instructions.system.content
+    assert instruction.instructions.system.content == (
+        "Explain only the strongest signal."
+    )
+    assert base.models["default"].temperature == 0.0
+    assert temperature.models["default"].temperature == 0.4
+
+
+def test_relay_variant_is_additive_and_independent():
+    base = public_config()
+
+    relay = with_relay(base)
+
+    assert base.telemetry is None
+    assert base.relay is None
+    assert base.runtime.artifacts is None
+    assert "relay" in relay.telemetry.providers
+    assert relay.relay.observability.atof.enabled is True
+    assert relay.relay.observability.atif.enabled is True
+    assert relay.runtime.artifacts == "./artifacts"

--- a/tests/examples/langgraph_custom_agent/test_consumer.py
+++ b/tests/examples/langgraph_custom_agent/test_consumer.py
@@ -5,7 +5,8 @@
 
 from __future__ import annotations
 
-from examples.langgraph_custom_agent.consumer.config import DEFAULT_MODEL
+from examples.langgraph_custom_agent.consumer.config import FRONTIER_DEFAULT_MODEL
+from examples.langgraph_custom_agent.consumer.config import PUBLIC_DEFAULT_MODEL
 from examples.langgraph_custom_agent.consumer.config import frontier_config
 from examples.langgraph_custom_agent.consumer.config import public_config
 from examples.langgraph_custom_agent.consumer.config import with_relay
@@ -14,7 +15,7 @@ from examples.langgraph_custom_agent.consumer.config import with_temperature
 from examples.langgraph_custom_agent.consumer.config import with_url_inspector_mcp
 
 
-def test_public_and_frontier_configs_vary_only_endpoint_and_credential(monkeypatch):
+def test_public_and_frontier_configs_use_endpoint_specific_defaults(monkeypatch):
     monkeypatch.setenv(
         "NVIDIA_FRONTIER_BASE_URL",
         "https://frontier.example/v1",
@@ -23,8 +24,8 @@ def test_public_and_frontier_configs_vary_only_endpoint_and_credential(monkeypat
     public = public_config()
     frontier = frontier_config()
 
-    assert public.models["default"].model == frontier.models["default"].model
-    assert public.models["default"].model == DEFAULT_MODEL
+    assert public.models["default"].model == PUBLIC_DEFAULT_MODEL
+    assert frontier.models["default"].model == FRONTIER_DEFAULT_MODEL
     assert public.models["default"].api_key_env == "NVIDIA_API_KEY"
     assert frontier.models["default"].api_key_env == "NVIDIA_FRONTIER_API_KEY"
     assert public.models["default"].base_url == (

--- a/tests/examples/langgraph_custom_agent/test_contract.py
+++ b/tests/examples/langgraph_custom_agent/test_contract.py
@@ -1,7 +1,7 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-"""Phase 0 contract for the dedicated LangGraph custom-agent example."""
+"""Descriptor and planning contract for the LangGraph custom-agent example."""
 
 from __future__ import annotations
 

--- a/tests/examples/langgraph_custom_agent/test_mcp.py
+++ b/tests/examples/langgraph_custom_agent/test_mcp.py
@@ -116,6 +116,26 @@ def test_resolver_rejects_non_stdio_transport():
     assert error.value.metadata == {"field": "mcp.servers.links.transport"}
 
 
+def test_resolver_reports_discovery_context_without_exposing_raw_error_details(
+    monkeypatch,
+):
+    async def fail_discovery(_connections):
+        raise FileNotFoundError("secret command argument")
+
+    monkeypatch.setattr(mcp_module, "_discover_tools", fail_discovery)
+
+    with pytest.raises(lifecycle.LifecycleError) as error:
+        asyncio.run(mcp_module.resolve_url_inspector(_config()))
+
+    assert error.value.metadata == {
+        "field": "mcp.servers",
+        "cause_type": "FileNotFoundError",
+        "servers": ["links"],
+    }
+    assert "secret command argument" not in error.value.message
+    assert "verify each stdio command" in error.value.message
+
+
 def test_example_url_inspector_is_deterministic():
     assert inspect_url("https://example.invalid/login") == {
         "hostname": "example.invalid",

--- a/tests/examples/langgraph_custom_agent/test_mcp.py
+++ b/tests/examples/langgraph_custom_agent/test_mcp.py
@@ -1,0 +1,123 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for normalized MCP-to-LangChain translation."""
+
+from __future__ import annotations
+
+import asyncio
+import json
+
+import pytest
+from langchain_core.tools import tool
+from nemo_fabric_adapter_contract.models import AgentConfig
+from nemo_fabric_adapters.common import lifecycle
+
+from examples.langgraph_custom_agent.adapter import mcp as mcp_module
+from examples.langgraph_custom_agent.mcp.url_inspector import inspect_url
+
+
+def _config(
+    *,
+    transport: str = "stdio",
+    allowed_tools: list[str] | None = None,
+    blocked_tools: list[str] | None = None,
+) -> AgentConfig:
+    server = {
+        "transport": transport,
+        "url": "python",
+        "args": ["url_inspector.py"],
+    }
+    if allowed_tools is not None:
+        server["allowed_tools"] = allowed_tools
+    if blocked_tools:
+        server["blocked_tools"] = blocked_tools
+    return AgentConfig.from_mapping({"mcp": {"servers": {"links": server}}})
+
+
+def test_stdio_connection_maps_the_normalized_command_and_arguments():
+    server = _config().mcp.servers["links"]
+
+    assert mcp_module._stdio_connection("links", server) == {
+        "transport": "stdio",
+        "command": "python",
+        "args": ["url_inspector.py"],
+    }
+
+
+def test_resolver_applies_per_server_tool_filters(monkeypatch):
+    @tool
+    def inspect_url(url: str) -> str:
+        """Inspect one URL."""
+
+        return json.dumps({"hostname": "example.invalid", "indicators": []})
+
+    @tool
+    def unused_tool(value: str) -> str:
+        """An unrelated server tool."""
+
+        return value
+
+    async def discover(_connections):
+        return {"links": [inspect_url, unused_tool]}
+
+    monkeypatch.setattr(mcp_module, "_discover_tools", discover)
+
+    selected = asyncio.run(
+        mcp_module.resolve_url_inspector(
+            _config(allowed_tools=["inspect_url"], blocked_tools=[])
+        )
+    )
+
+    assert selected is inspect_url
+
+
+def test_resolver_rejects_an_unknown_allowed_tool(monkeypatch):
+    async def discover(_connections):
+        return {"links": []}
+
+    monkeypatch.setattr(mcp_module, "_discover_tools", discover)
+
+    with pytest.raises(lifecycle.LifecycleError) as error:
+        asyncio.run(
+            mcp_module.resolve_url_inspector(_config(allowed_tools=["missing"]))
+        )
+
+    assert error.value.code == "email_phishing_invalid_mcp"
+    assert error.value.metadata == {"field": "mcp.servers.links.allowed_tools"}
+
+
+def test_resolver_rejects_a_policy_that_blocks_the_required_tool(monkeypatch):
+    @tool
+    def inspect_url(url: str) -> str:
+        """Inspect one URL."""
+
+        return url
+
+    async def discover(_connections):
+        return {"links": [inspect_url]}
+
+    monkeypatch.setattr(mcp_module, "_discover_tools", discover)
+
+    with pytest.raises(lifecycle.LifecycleError) as error:
+        asyncio.run(
+            mcp_module.resolve_url_inspector(
+                _config(blocked_tools=["inspect_url"])
+            )
+        )
+
+    assert error.value.metadata == {"field": "mcp.servers"}
+
+
+def test_resolver_rejects_non_stdio_transport():
+    with pytest.raises(lifecycle.LifecycleError) as error:
+        asyncio.run(mcp_module.resolve_url_inspector(_config(transport="http")))
+
+    assert error.value.metadata == {"field": "mcp.servers.links.transport"}
+
+
+def test_example_url_inspector_is_deterministic():
+    assert inspect_url("https://example.invalid/login") == {
+        "hostname": "example.invalid",
+        "indicators": ["reserved_test_domain"],
+    }

--- a/tests/examples/langgraph_custom_agent/test_phase0.py
+++ b/tests/examples/langgraph_custom_agent/test_phase0.py
@@ -6,6 +6,8 @@
 from __future__ import annotations
 
 import json
+import os
+import sys
 from pathlib import Path
 
 from nemo_fabric import Fabric
@@ -16,8 +18,10 @@ from nemo_fabric import InstructionsConfig
 from nemo_fabric import MetadataConfig
 from nemo_fabric import ModelConfig
 
+from examples.langgraph_custom_agent.consumer.config import URL_INSPECTOR_SERVER
 from examples.langgraph_custom_agent.consumer.config import public_config
 from examples.langgraph_custom_agent.consumer.config import with_relay
+from examples.langgraph_custom_agent.consumer.config import with_url_inspector_mcp
 
 ROOT = Path(__file__).parents[3]
 ADAPTER_ID = "nvidia.fabric.example.langgraph.email-phishing"
@@ -39,7 +43,7 @@ def _stage_descriptor(tmp_path: Path) -> None:
     )
 
 
-def test_descriptor_freezes_the_minimum_custom_agent_contract():
+def test_descriptor_freezes_the_custom_agent_contract_surface():
     descriptor = json.loads(DESCRIPTOR.read_text(encoding="utf-8"))
 
     assert descriptor == {
@@ -56,6 +60,8 @@ def test_descriptor_freezes_the_minimum_custom_agent_contract():
                 "models.base_url",
                 "models.temperature",
                 "instructions.system",
+                "mcp",
+                "mcp.tool_filters",
             ],
         },
         "telemetry": {
@@ -127,3 +133,27 @@ def test_plan_accepts_only_the_verified_relay_output(tmp_path: Path):
     assert plan["telemetry_plan"]["relay_enabled"] is True
     assert plan["telemetry_plan"]["providers"] == ["relay"]
     assert plan["telemetry_plan"]["adapter_outputs"] == ["atif"]
+
+
+def test_plan_projects_optional_stdio_mcp_to_agent_config(tmp_path: Path):
+    _stage_descriptor(tmp_path)
+
+    plan = (
+        Fabric()
+        .plan(
+            with_url_inspector_mcp(public_config()),
+            base_dir=tmp_path,
+        )
+        .to_mapping()
+    )
+
+    assert plan["agent_config"]["mcp"] == {
+        "servers": {
+            "url-inspector": {
+                "transport": "stdio",
+                "url": os.environ.get("ADAPTER_PYTHON", sys.executable),
+                "args": [str(URL_INSPECTOR_SERVER)],
+                "allowed_tools": ["inspect_url"],
+            }
+        }
+    }

--- a/tests/examples/langgraph_custom_agent/test_phase0.py
+++ b/tests/examples/langgraph_custom_agent/test_phase0.py
@@ -16,6 +16,9 @@ from nemo_fabric import InstructionsConfig
 from nemo_fabric import MetadataConfig
 from nemo_fabric import ModelConfig
 
+from examples.langgraph_custom_agent.consumer.config import public_config
+from examples.langgraph_custom_agent.consumer.config import with_relay
+
 ROOT = Path(__file__).parents[3]
 ADAPTER_ID = "nvidia.fabric.example.langgraph.email-phishing"
 DESCRIPTOR = (
@@ -25,6 +28,15 @@ DESCRIPTOR = (
     / "adapter"
     / "fabric-adapter.json"
 )
+
+
+def _stage_descriptor(tmp_path: Path) -> None:
+    staged = tmp_path / "adapters" / "langgraph-email-phishing"
+    staged.mkdir(parents=True)
+    (staged / "fabric-adapter.json").write_text(
+        DESCRIPTOR.read_text(encoding="utf-8"),
+        encoding="utf-8",
+    )
 
 
 def test_descriptor_freezes_the_minimum_custom_agent_contract():
@@ -46,6 +58,14 @@ def test_descriptor_freezes_the_minimum_custom_agent_contract():
                 "instructions.system",
             ],
         },
+        "telemetry": {
+            "providers": {
+                "relay": {
+                    "outputs": ["atif"],
+                    "integration_modes": ["sdk"],
+                }
+            }
+        },
         "capabilities": {
             "cancellation": False,
             "service": False,
@@ -56,12 +76,7 @@ def test_descriptor_freezes_the_minimum_custom_agent_contract():
 
 
 def test_plan_projects_only_the_advertised_agent_config(tmp_path: Path):
-    staged = tmp_path / "adapters" / "langgraph-email-phishing"
-    staged.mkdir(parents=True)
-    (staged / "fabric-adapter.json").write_text(
-        DESCRIPTOR.read_text(encoding="utf-8"),
-        encoding="utf-8",
-    )
+    _stage_descriptor(tmp_path)
     config = FabricConfig(
         metadata=MetadataConfig(name="langgraph-email-phishing"),
         harness=HarnessConfig(
@@ -102,3 +117,13 @@ def test_plan_projects_only_the_advertised_agent_config(tmp_path: Path):
             }
         },
     }
+
+
+def test_plan_accepts_only_the_verified_relay_output(tmp_path: Path):
+    _stage_descriptor(tmp_path)
+
+    plan = Fabric().plan(with_relay(public_config()), base_dir=tmp_path).to_mapping()
+
+    assert plan["telemetry_plan"]["relay_enabled"] is True
+    assert plan["telemetry_plan"]["providers"] == ["relay"]
+    assert plan["telemetry_plan"]["adapter_outputs"] == ["atif"]

--- a/tests/examples/langgraph_custom_agent/test_phase0.py
+++ b/tests/examples/langgraph_custom_agent/test_phase0.py
@@ -1,0 +1,104 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Phase 0 contract for the dedicated LangGraph custom-agent example."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from nemo_fabric import Fabric
+from nemo_fabric import FabricConfig
+from nemo_fabric import HarnessConfig
+from nemo_fabric import InstructionConfig
+from nemo_fabric import InstructionsConfig
+from nemo_fabric import MetadataConfig
+from nemo_fabric import ModelConfig
+
+ROOT = Path(__file__).parents[3]
+ADAPTER_ID = "nvidia.fabric.example.langgraph.email-phishing"
+DESCRIPTOR = (
+    ROOT
+    / "examples"
+    / "langgraph_custom_agent"
+    / "adapter"
+    / "fabric-adapter.json"
+)
+
+
+def test_descriptor_freezes_the_minimum_custom_agent_contract():
+    descriptor = json.loads(DESCRIPTOR.read_text(encoding="utf-8"))
+
+    assert descriptor == {
+        "contract_version": "fabric.adapter/v1alpha2",
+        "adapter_id": ADAPTER_ID,
+        "harness": "langgraph-email-phishing",
+        "adapter_kind": "python",
+        "runner": {"module": "examples.langgraph_custom_agent.adapter.runtime"},
+        "requirements": {},
+        "config": {
+            "input": "agent_config",
+            "accepts": [
+                "models",
+                "models.base_url",
+                "models.temperature",
+                "instructions.system",
+            ],
+        },
+        "capabilities": {
+            "cancellation": False,
+            "service": False,
+            "streaming": False,
+            "updates": False,
+        },
+    }
+
+
+def test_plan_projects_only_the_advertised_agent_config(tmp_path: Path):
+    staged = tmp_path / "adapters" / "langgraph-email-phishing"
+    staged.mkdir(parents=True)
+    (staged / "fabric-adapter.json").write_text(
+        DESCRIPTOR.read_text(encoding="utf-8"),
+        encoding="utf-8",
+    )
+    config = FabricConfig(
+        metadata=MetadataConfig(name="langgraph-email-phishing"),
+        harness=HarnessConfig(
+            adapter_id=ADAPTER_ID,
+            resolution="preinstalled",
+        ),
+        models={
+            "default": ModelConfig(
+                provider="nvidia",
+                model="nvidia/test-model",
+                api_key_env="NVIDIA_API_KEY",
+                base_url="https://integrate.api.nvidia.com/v1",
+                temperature=0.2,
+            )
+        },
+        instructions=InstructionsConfig(
+            system=InstructionConfig(content="Explain the email risk assessment.")
+        ),
+    )
+
+    plan = Fabric().plan(config, base_dir=tmp_path)
+
+    assert plan.adapter.adapter_id == ADAPTER_ID
+    assert plan.to_mapping()["agent_config"] == {
+        "models": {
+            "default": {
+                "provider": "nvidia",
+                "model": "nvidia/test-model",
+                "api_key_env": "NVIDIA_API_KEY",
+                "temperature": 0.2,
+                "base_url": "https://integrate.api.nvidia.com/v1",
+            }
+        },
+        "instructions": {
+            "system": {
+                "content": "Explain the email risk assessment.",
+                "mode": "replace",
+            }
+        },
+    }

--- a/tests/examples/langgraph_custom_agent/test_telemetry.py
+++ b/tests/examples/langgraph_custom_agent/test_telemetry.py
@@ -17,7 +17,11 @@ from examples.langgraph_custom_agent.adapter.telemetry import observe_invocation
 from examples.langgraph_custom_agent.agent.graph import build_email_phishing_graph
 
 
-def _context(config_path: Path | None = None) -> RuntimeContext:
+def _context(
+    config_path: Path | None = None,
+    *,
+    invocation_id: str = "invocation-1",
+) -> RuntimeContext:
     telemetry = None
     if config_path is not None:
         telemetry = {
@@ -28,8 +32,8 @@ def _context(config_path: Path | None = None) -> RuntimeContext:
     return RuntimeContext.from_mapping(
         {
             "runtime_id": "runtime-1",
-            "invocation_id": "invocation-1",
-            "request_id": "request-1",
+            "invocation_id": invocation_id,
+            "request_id": f"request-{invocation_id}",
             "environment": {
                 "environment_id": "environment-1",
                 "provider": "local",
@@ -89,7 +93,7 @@ def test_relay_observes_graph_and_model_backed_node(tmp_path):
                                                 "type": "file",
                                                 "output_directory": "relay",
                                                 "filename": "events.atof.jsonl",
-                                                "mode": "overwrite",
+                                                "mode": "append",
                                             }
                                         ],
                                     },
@@ -110,13 +114,18 @@ def test_relay_observes_graph_and_model_backed_node(tmp_path):
         encoding="utf-8",
     )
     graph = build_email_phishing_graph(
-        FakeListChatModel(responses=["The fixed assessment is phishing."]),
+        FakeListChatModel(
+            responses=[
+                "The first fixed assessment is phishing.",
+                "The second fixed assessment is phishing.",
+            ]
+        ),
         "Explain the fixed assessment.",
     )
 
-    async def run() -> list[dict[str, str]]:
+    async def run(invocation_id: str) -> list[dict[str, str]]:
         async with observe_invocation(
-            _context(config_path),
+            _context(config_path, invocation_id=invocation_id),
             base_dir=tmp_path,
             agent_name="email-phishing",
             model_name="test-model",
@@ -135,7 +144,8 @@ def test_relay_observes_graph_and_model_backed_node(tmp_path):
         ] == "test-model"
         return telemetry.artifacts()
 
-    artifacts = asyncio.run(run())
+    artifacts = asyncio.run(run("invocation-1"))
+    asyncio.run(run("invocation-2"))
 
     assert {artifact["kind"] for artifact in artifacts} == {"atof", "atif"}
     atof_path = Path(
@@ -147,8 +157,8 @@ def test_relay_observes_graph_and_model_backed_node(tmp_path):
         event.get("metadata", {}).get("langgraph_node") == "explain_assessment"
         for event in events
     )
-    assert any(
+    invocation_ids = {
         event.get("metadata", {}).get("nemo_fabric_invocation_id")
-        == "invocation-1"
         for event in events
-    )
+    }
+    assert {"invocation-1", "invocation-2"}.issubset(invocation_ids)

--- a/tests/examples/langgraph_custom_agent/test_telemetry.py
+++ b/tests/examples/langgraph_custom_agent/test_telemetry.py
@@ -1,0 +1,154 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for the example's optional Relay boundary."""
+
+from __future__ import annotations
+
+import asyncio
+import builtins
+import json
+from pathlib import Path
+
+from langchain_core.language_models.fake_chat_models import FakeListChatModel
+from nemo_fabric_adapter_contract.models import RuntimeContext
+
+from examples.langgraph_custom_agent.adapter.telemetry import observe_invocation
+from examples.langgraph_custom_agent.agent.graph import build_email_phishing_graph
+
+
+def _context(config_path: Path | None = None) -> RuntimeContext:
+    telemetry = None
+    if config_path is not None:
+        telemetry = {
+            "relay_enabled": True,
+            "config_path": str(config_path),
+            "metadata": {"telemetry_providers": ["relay"]},
+        }
+    return RuntimeContext.from_mapping(
+        {
+            "runtime_id": "runtime-1",
+            "invocation_id": "invocation-1",
+            "request_id": "request-1",
+            "environment": {
+                "environment_id": "environment-1",
+                "provider": "local",
+                "control_location": "in_env_control",
+                "ownership": "caller_owned",
+            },
+            "artifacts": {},
+            "telemetry": telemetry,
+        }
+    )
+
+
+def test_relay_disabled_path_does_not_import_relay(tmp_path, monkeypatch):
+    imported = []
+    original_import = builtins.__import__
+
+    def guarded_import(name, *args, **kwargs):
+        if name == "nemo_relay" or name.startswith("nemo_relay."):
+            imported.append(name)
+            raise AssertionError("Relay must remain optional")
+        return original_import(name, *args, **kwargs)
+
+    monkeypatch.setattr(builtins, "__import__", guarded_import)
+
+    async def run() -> None:
+        async with observe_invocation(
+            _context(),
+            base_dir=tmp_path,
+            agent_name="email-phishing",
+            model_name="test-model",
+        ) as telemetry:
+            assert telemetry.runnable_config is None
+            assert telemetry.artifacts() == []
+
+    asyncio.run(run())
+    assert imported == []
+
+
+def test_relay_observes_graph_and_model_backed_node(tmp_path):
+    config_path = tmp_path / "relay-config.json"
+    config_path.write_text(
+        json.dumps(
+            {
+                "relay": {
+                    "config": {
+                        "version": 1,
+                        "components": [
+                            {
+                                "kind": "observability",
+                                "enabled": True,
+                                "config": {
+                                    "version": 2,
+                                    "atof": {
+                                        "enabled": True,
+                                        "sinks": [
+                                            {
+                                                "type": "file",
+                                                "output_directory": "relay",
+                                                "filename": "events.atof.jsonl",
+                                                "mode": "overwrite",
+                                            }
+                                        ],
+                                    },
+                                    "atif": {
+                                        "enabled": True,
+                                        "output_directory": "relay",
+                                        "filename_template": (
+                                            "trajectory-{session_id}.atif.json"
+                                        ),
+                                    },
+                                },
+                            }
+                        ],
+                    }
+                }
+            }
+        ),
+        encoding="utf-8",
+    )
+    graph = build_email_phishing_graph(
+        FakeListChatModel(responses=["The fixed assessment is phishing."]),
+        "Explain the fixed assessment.",
+    )
+
+    async def run() -> list[dict[str, str]]:
+        async with observe_invocation(
+            _context(config_path),
+            base_dir=tmp_path,
+            agent_name="email-phishing",
+            model_name="test-model",
+        ) as telemetry:
+            result = await graph.ainvoke(
+                {
+                    "email": (
+                        "Urgent: verify your password at https://example.invalid."
+                    )
+                },
+                config=telemetry.runnable_config,
+            )
+        assert result["classification"] == "phishing"
+        assert telemetry.plugin_config["components"][0]["config"]["atif"][
+            "model_name"
+        ] == "test-model"
+        return telemetry.artifacts()
+
+    artifacts = asyncio.run(run())
+
+    assert {artifact["kind"] for artifact in artifacts} == {"atof", "atif"}
+    atof_path = Path(
+        next(artifact["path"] for artifact in artifacts if artifact["kind"] == "atof")
+    )
+    events = [json.loads(line) for line in atof_path.read_text().splitlines()]
+    assert any(event.get("name") == "email-phishing-invocation" for event in events)
+    assert any(
+        event.get("metadata", {}).get("langgraph_node") == "explain_assessment"
+        for event in events
+    )
+    assert any(
+        event.get("metadata", {}).get("nemo_fabric_invocation_id")
+        == "invocation-1"
+        for event in events
+    )

--- a/uv.lock
+++ b/uv.lock
@@ -2169,6 +2169,12 @@ docs = [
     { name = "lazydocs" },
     { name = "pyyaml" },
 ]
+langgraph-example = [
+    { name = "langchain" },
+    { name = "langchain-mcp-adapters" },
+    { name = "langchain-openai" },
+    { name = "langgraph" },
+]
 package = [
     { name = "maturin" },
     { name = "maturin", extra = ["zig"], marker = "sys_platform == 'linux'" },
@@ -2224,6 +2230,12 @@ docs = [
     { name = "beautifulsoup4", specifier = ">=4.12" },
     { name = "lazydocs", specifier = ">=0.4" },
     { name = "pyyaml", specifier = ">=6.0" },
+]
+langgraph-example = [
+    { name = "langchain", specifier = ">=1.3,<2.0" },
+    { name = "langchain-mcp-adapters", specifier = ">=0.1,<0.3.0" },
+    { name = "langchain-openai", specifier = ">=0.3" },
+    { name = "langgraph", specifier = ">=1.2,<2.0" },
 ]
 package = [
     { name = "maturin", marker = "sys_platform != 'linux'", specifier = ">=1.9.3,<2.0" },

--- a/uv.lock
+++ b/uv.lock
@@ -2238,7 +2238,7 @@ langgraph-example = [
     { name = "langchain-mcp-adapters", specifier = ">=0.1,<0.3.0" },
     { name = "langchain-openai", specifier = ">=0.3,<2.0" },
     { name = "langgraph", specifier = ">=1.2,<2.0" },
-    { name = "mcp", specifier = ">=1.2" },
+    { name = "mcp", specifier = ">=1.10" },
 ]
 package = [
     { name = "maturin", marker = "sys_platform != 'linux'", specifier = ">=1.9.3,<2.0" },

--- a/uv.lock
+++ b/uv.lock
@@ -2174,6 +2174,8 @@ langgraph-example = [
     { name = "langchain-mcp-adapters" },
     { name = "langchain-openai" },
     { name = "langgraph" },
+    { name = "mcp", version = "1.26.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.14'" },
+    { name = "mcp", version = "1.28.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.14'" },
 ]
 package = [
     { name = "maturin" },
@@ -2234,8 +2236,9 @@ docs = [
 langgraph-example = [
     { name = "langchain", specifier = ">=1.3,<2.0" },
     { name = "langchain-mcp-adapters", specifier = ">=0.1,<0.3.0" },
-    { name = "langchain-openai", specifier = ">=0.3" },
+    { name = "langchain-openai", specifier = ">=0.3,<2.0" },
     { name = "langgraph", specifier = ">=1.2,<2.0" },
+    { name = "mcp", specifier = ">=1.2" },
 ]
 package = [
     { name = "maturin", marker = "sys_platform != 'linux'", specifier = ">=1.9.3,<2.0" },


### PR DESCRIPTION
#### Overview

This change adds a source-level email-phishing custom agent built directly with
LangGraph and a dedicated NVIDIA NeMo Fabric adapter. It keeps the consumer,
adapter, and application graph separate so the northbound `FabricConfig`,
southbound `AgentConfig`, lifecycle translation, and NeMo Fabric-independent
agent behavior are easy to follow.

The example begins with the required `start`, `invoke`, and `stop` surface. It
then demonstrates normalized model and instruction variation, an optional stdio
MCP tool, and optional NeMo Relay telemetry without expanding the required
lifecycle. It is intentionally a dedicated custom-agent adapter rather than a
generic LangGraph workflow loader or published package.

#### Details

- Add a deterministic email-signal and risk-classification graph with a
  model-backed explanation node.
- Add a dedicated adapter descriptor and typed `AgentConfig` mapping for the
  model, instruction, temperature, endpoint, and optional MCP configuration.
- Retain one compiled LangGraph runtime across ordered `start`, repeated
  `invoke`, and `stop` operations.
- Add an optional deterministic stdio MCP URL-inspection tool through the native
  LangChain MCP integration.
- Add optional invocation-scoped NeMo Relay telemetry with append-safe ATOF and
  per-invocation ATIF output.
- Add focused tests for projection, graph behavior, configuration validation,
  lifecycle ordering and cleanup, MCP filtering, and Relay boundaries.
- Document the minimum contract, configuration variation, optional
  capabilities, ownership boundaries, and source-run commands.

This PR has no breaking changes.

#### Known telemetry limitation

The current NeMo Relay LangGraph callback emits graph and chain scopes but does
not emit the underlying chat-model or tool lifecycle events. ATOF and ATIF
artifacts are produced and correlated, but ATIF consequently represents
LangGraph nodes as nested agent trajectories and does not include normalized
model/tool calls or token usage. This is a Relay integration limitation rather
than an adapter or `RelayAtifConfig` issue and should be addressed separately.

#### Validation

- `just --set no_uv true test-python` — 760 passed, 15 skipped.
- `uv run pytest -q tests/examples/langgraph_custom_agent` — 36 passed.
- Frontier live run with `--relay --mcp` — succeeded with correlated ATOF and
  ATIF artifacts.
- `uv lock --check` — passed.
- `scripts/licensing/license_diff.py --base-ref upstream/main` — no Rust or
  Python dependency changes.
- `pre-commit run --all-files attributions-python` — passed.
- Focused Ruff, copyright-header, and `git diff --check` validation — passed.

#### Where should the reviewer start?

Start with `examples/langgraph_custom_agent/README.md` for the purpose and three
ownership boundaries. Then review `adapter/runtime.py` beside `agent/graph.py`
to compare the minimum adapter lifecycle with the NeMo Fabric-independent custom
agent.

Review `consumer/config.py` with `adapter/configuration.py` for
northbound-to-southbound variation. Treat `adapter/mcp.py` and
`adapter/telemetry.py` as optional paths beyond the minimum surface.

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- Relates to #190

- [x] I confirm this contribution is my own work, or I have the right to submit it under this project's license.
- [x] I searched existing issues and open pull requests, and this does not duplicate existing work.
