### PR TITLE
fix: let the turn that poisoned the runtime publish its own artifacts

### DIFF
--- a/adapters/deepagents/src/nemo_fabric_adapters/deepagents/adapter.py
+++ b/adapters/deepagents/src/nemo_fabric_adapters/deepagents/adapter.py
@@ -595,7 +595,9 @@ class DeepAgentsRuntime:
         if outcome.error is None:
             self._completed_invocations += 1
 
-        telemetry_runtime, relay_artifacts, collect_error = self._telemetry_output()
+        telemetry_runtime, relay_artifacts, collect_error = self._telemetry_output(
+            inherited_quarantine=inherited_quarantine
+        )
         return normalize_output(
             model_name=self._model_name,
             base_url=self._base_url,
@@ -692,11 +694,18 @@ class DeepAgentsRuntime:
 
     def _telemetry_output(
         self,
+        *,
+        inherited_quarantine: bool,
     ) -> tuple[dict[str, Any] | None, list[dict[str, str]] | None, str | None]:
         """Return the telemetry block, artifact references, and any collection fault.
 
         Collecting references walks the filesystem, so it is returned as a fault rather
         than raised: raising here would discard an already-completed turn.
+
+        ``inherited_quarantine`` is the state from *before* this turn: the turn that
+        poisoned the runtime opened a scope and produced its own partial artifacts, so it
+        still publishes them; only turns that inherit the quarantine have none of their
+        own to publish.
         """
 
         if self._observability is None:
@@ -708,7 +717,7 @@ class DeepAgentsRuntime:
         }
         if not self._observability.collect_artifacts:
             return telemetry_runtime, None, None
-        if self._telemetry_quarantine is not None:
+        if inherited_quarantine:
             return telemetry_runtime, None, None
         try:
             relay_artifacts = common_utils.collect_relay_artifacts(

--- a/tests/adapters/test_deepagents.py
+++ b/tests/adapters/test_deepagents.py
@@ -539,6 +539,13 @@ async def test_a_dirty_scope_stack_quarantines_telemetry_for_later_turns(
         )
 
     monkeypatch.setattr(sys.modules["nemo_relay.scope"], "scope", leaking_scope)
+    # A recognisable artifact so the faulting turn's publication can be checked by value
+    # rather than by the key merely existing: real collection over an empty evidence dir
+    # returns [], which would pass a presence-only assertion either way.
+    artifacts = [{"kind": "atif", "path": str(tmp_path / "trajectory.atif.json")}]
+    monkeypatch.setattr(
+        adapter.common_utils, "collect_relay_artifacts", lambda _config: artifacts
+    )
 
     first, second = await invoke_twice(relay_payload(tmp_path))
 
@@ -554,7 +561,9 @@ async def test_a_dirty_scope_stack_quarantines_telemetry_for_later_turns(
     assert "unreliable" in second["telemetry"]["error"]
     # Only turn 1 opened a request scope; turn 2 must not push onto the dirty stack.
     assert entered == ["deepagents-request"]
-    # Artifacts on disk belong to turn 1, so turn 2 must not reference them as its own.
+    # Turn 1 opened a scope and produced its own (partial) artifacts, so it still
+    # publishes them; turn 2 has none of its own and must not claim turn 1's.
+    assert first["relay_artifacts"] == artifacts
     assert "relay_artifacts" not in second
 
     # Turn 1 owns the fault, so it reports it verbatim and needs no separate cause.


### PR DESCRIPTION
#### Overview

Follow-up to #191, addressing the P2 @AjayThorve raised in review after it had merged.

`invoke()` captures the quarantine state from *before* the turn, but `_telemetry_output` consulted `self._telemetry_quarantine` directly. By the time it runs, `_invoke_with_telemetry` has already set that flag on the turn whose fault caused the quarantine — so that turn suppressed its own `relay_artifacts` too, reproducing as `faulting_turn_artifacts=None`.

That contradicts the contract #191 documented: a scope- or flush-degraded turn still references its partial artifacts, and only turns that *inherit* the quarantine omit them.

#### Where should the reviewer start?

`_telemetry_output` in `adapters/deepagents/src/nemo_fabric_adapters/deepagents/adapter.py`, which now takes `inherited_quarantine` as a parameter rather than re-reading the field afterwards. The distinction it encodes: a turn that opened a request scope and faulted during teardown produced its own partial trajectory, so it publishes it flagged as degraded; a turn that inherits the quarantine opened no scope and has nothing of its own, so it must not claim an earlier turn's artifacts.

Then the assertion change in `test_a_dirty_scope_stack_quarantines_telemetry_for_later_turns`. The original test asserted only that later turns withhold artifacts and said nothing about the faulting turn, which is why this went unnoticed. Strengthening it exposed a second weakness worth flagging: that test does not stub `collect_relay_artifacts`, so real collection over an empty evidence directory returns `[]` — a presence-only check like `"relay_artifacts" in first` passes against an implementation that publishes an empty list forever. It now stubs a recognisable artifact and asserts by value.

Both directions are mutation-checked: restoring the original `self._telemetry_quarantine` read fails the test with `KeyError: 'relay_artifacts'`, and removing the suppression entirely fails it because the inherited turn would publish the earlier turn's artifacts as its own.

#### Testing

- `just test-python` (full suite on this base) — 702 passed, 53 skipped.
- `tests/adapters/test_deepagents.py` — 56 passed.
- `ruff check` / `ruff format --check` (v0.15.21, matching `.pre-commit-config.yaml`) and the copyright-header hook pass on both changed files.

No behaviour changes beyond the artifact policy, and no API changes.

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- Relates to #191
- Relates to NVBug 6562846

- [x] I confirm this contribution is my own work, or I have the right to submit it under this project's license.
- [x] I searched existing issues and open pull requests, and this does not duplicate existing work.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Telemetry artifacts are now published for the invocation that triggers quarantine.
  * Subsequent quarantined invocations no longer collect or publish telemetry artifacts.
  * Improved telemetry behavior when handling Relay scope quarantine conditions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->