### PR TITLE
fix: expose Claude API error status

### DIFF
--- a/adapters/claude/src/nemo_fabric_adapters/claude/adapter.py
+++ b/adapters/claude/src/nemo_fabric_adapters/claude/adapter.py
@@ -720,11 +720,14 @@ def normalize_result(
     failed = _result_failed(result)
     error = None
     if failed:
+        metadata = {"subtype": result.subtype}
+        if result.api_error_status is not None:
+            metadata["api_error_status"] = result.api_error_status
         error = {
             "code": "claude_result_failed",
             "message": "Claude returned an error result",
             "retryable": False,
-            "metadata": {"subtype": result.subtype},
+            "metadata": metadata,
         }
     return {
         "harness": "claude",

--- a/tests/adapters/test_claude_adapter.py
+++ b/tests/adapters/test_claude_adapter.py
@@ -1334,6 +1334,7 @@ def test_error_result_is_normalized_as_failure(claude_payload):
         num_turns=4,
         session_id="claude-session",
         errors=["provider-specific failure"],
+        api_error_status=404,
     )
 
     output = adapter.normalize_result(claude_payload, [], result)
@@ -1343,7 +1344,7 @@ def test_error_result_is_normalized_as_failure(claude_payload):
         "code": "claude_result_failed",
         "message": "Claude returned an error result",
         "retryable": False,
-        "metadata": {"subtype": "error_max_turns"},
+        "metadata": {"subtype": "error_max_turns", "api_error_status": 404},
     }
 
 


### PR DESCRIPTION
#### Overview

The Claude Agent SDK can attach an HTTP status to a terminal error result. Fabric currently drops that status, which makes endpoint failures harder to diagnose.

Retain the non-null status in Fabric's structured failure metadata. This preserves existing failure codes, messages, lifecycle behavior, and raw-error redaction.

#### Details

- Include a non-null Claude SDK `api_error_status` in `claude_result_failed` metadata.
- Cover a 404 terminal SDK result without exposing raw provider error strings.

#### Validation

- `pytest tests/adapters/test_claude_adapter.py` — 47 passed.
- `just test-python` — 740 passed, 55 skipped.
- `ruff==0.15.21 check adapters/claude/src/nemo_fabric_adapters/claude/adapter.py tests/adapters/test_claude_adapter.py` — passed.
- `git diff --check` — passed.

#### Where should the reviewer start?

Start with `normalize_result(...)` in `adapters/claude/src/nemo_fabric_adapters/claude/adapter.py`; the adjacent regression assertion shows the intentionally narrow output change.

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- Relates to [FABRIC-184](https://linear.app/nvidia/issue/FABRIC-184/move-claude-adapter-to-v1alpha2-contract-version).

- [x] I confirm this contribution is my own work, or I have the right to submit it under this project's license.
- [x] I searched existing issues and open pull requests, and this does not duplicate existing work.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Error responses from Claude now include the API error status when available, improving troubleshooting and error visibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->