### PR TITLE
fix: preserve Codex JSON-RPC code

### DIFF
--- a/adapters/codex/src/nemo_fabric_adapters/codex/adapter.py
+++ b/adapters/codex/src/nemo_fabric_adapters/codex/adapter.py
@@ -22,6 +22,7 @@ from openai_codex import (
     AsyncCodex,
     CodexConfig,
     CodexError,
+    JsonRpcError,
     Sandbox,
     TransportClosedError,
     is_retryable_error,
@@ -793,11 +794,14 @@ def sdk_failure(error: BaseException) -> dict[str, Any]:
             "codex_connection_failed", "Codex SDK runtime connection closed"
         )
     if isinstance(error, CodexError):
+        metadata = {"sdk_error": type(error).__name__}
+        if isinstance(error, JsonRpcError):
+            metadata["jsonrpc_code"] = error.code
         return _failure(
             "codex_sdk_failed",
             "Codex SDK request failed",
             retryable=is_retryable_error(error),
-            sdk_error=type(error).__name__,
+            **metadata,
         )
     if isinstance(error, OSError):
         return _failure(

--- a/tests/adapters/test_codex_adapter.py
+++ b/tests/adapters/test_codex_adapter.py
@@ -13,7 +13,7 @@ from unittest.mock import MagicMock
 import pytest
 from nemo_fabric import Fabric
 from nemo_fabric_adapters.codex import adapter
-from openai_codex import AsyncCodex, AsyncThread, AsyncTurnHandle
+from openai_codex import AsyncCodex, AsyncThread, AsyncTurnHandle, JsonRpcError
 from openai_codex.types import TurnStatus
 
 
@@ -709,6 +709,15 @@ def test_failed_sdk_turn_is_normalized_and_transport_is_closed(
         "retryable": False,
     }
     assert mock_codex.instances[0].closed is True
+
+
+def test_sdk_failure_preserves_jsonrpc_code():
+    output = adapter.sdk_failure(JsonRpcError(-32000, "provider failure"))
+
+    assert output["error"]["metadata"] == {
+        "sdk_error": "JsonRpcError",
+        "jsonrpc_code": -32000,
+    }
 
 
 def test_incomplete_sdk_turn_is_failed(codex_payload, mock_codex):


### PR DESCRIPTION
#### Overview

Codex SDK JSON-RPC failures expose a numeric RPC code. Fabric retained the exception type and retryability but dropped that safe diagnostic.

Retain the numeric code in the existing structured error metadata. Raw SDK messages and data remain excluded because they can contain provider payloads. No request, lifecycle, retry, or provider behavior changes.

#### Details

- Include `jsonrpc_code` for `JsonRpcError` failures.
- Cover a JSON-RPC failure without exposing raw provider data.

#### Validation

- `pytest -q tests/adapters/test_codex_adapter.py` — 47 passed.
- `just test-python` — 741 passed, 55 skipped.
- `ruff==0.15.21 check adapters/codex/src/nemo_fabric_adapters/codex/adapter.py tests/adapters/test_codex_adapter.py` — passed.
- `git diff --check` — passed.

#### Where should the reviewer start?

Start with `sdk_failure(...)` in `adapters/codex/src/nemo_fabric_adapters/codex/adapter.py`; the adjacent regression test shows the only new public field.

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- Relates to [FABRIC-185](https://linear.app/nvidia/issue/FABRIC-185/move-codex-adapter-to-v1alpha2-contract-version).

- [x] I confirm this contribution is my own work, or I have the right to submit it under this project's license.
- [x] I searched existing issues and open pull requests, and this does not duplicate existing work.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error details returned for Codex SDK failures by including the applicable JSON-RPC error code.
  * Preserved existing SDK error type and retryability information for clearer troubleshooting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->