### PR TITLE
ci: add NVSkills request workflow

### DIFF
--- a/.github/workflows/request-nvskills-ci.yml
+++ b/.github/workflows/request-nvskills-ci.yml
@@ -1,0 +1,29 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+name: Request NVSkills CI
+
+on:
+  issue_comment:
+    types: [created]
+  pull_request:
+    types: [opened, reopened, synchronize, ready_for_review]
+  push:
+
+jobs:
+  request:
+    if: >
+      github.event_name == 'pull_request' ||
+      (github.event_name == 'issue_comment' &&
+        github.event.issue.pull_request &&
+        startsWith(github.event.comment.body, '/nvskills-ci')) ||
+      (github.event_name == 'push' &&
+        github.actor == (vars.NVSKILLS_SIGNATURE_PUSH_ACTOR || 'nv-skills-ci[bot]') &&
+        startsWith(github.event.head_commit.message, vars.NVSKILLS_SIGNATURE_COMMIT_TITLE || 'Attach NVSkills validation signatures'))
+    permissions:
+      contents: read
+      pull-requests: read
+      statuses: read
+    uses: NVIDIA/skills/.github/workflows/team-request.yml@4f1e9e3e0e6913fbd5822acf4757aa6631e87cef # main as of 2026-08-10
+    secrets:
+      NVSKILLS_CI_DISPATCH_TOKEN: ${{ secrets.NVSKILLS_CI_DISPATCH_TOKEN }}


### PR DESCRIPTION
#### Overview

Adds the Fabric-side wrapper for the updated NVIDIA NVSkills CI request workflow. The wrapper follows the current [NVIDIA/skills template](https://github.com/NVIDIA/skills/blob/main/.github/workflows/request-nvskills-ci.yml), matches the Relay integration, and pins the reusable workflow to commit `4f1e9e3e0e6913fbd5822acf4757aa6631e87cef`.

This enables pull-request status gating, maintainer-triggered `/nvskills-ci` requests, and signature-commit follow-up runs. It introduces no product behavior or breaking API changes.

Configuration note: the workflow expects `NVSKILLS_CI_DISPATCH_TOKEN`.

#### Details

- Adds `.github/workflows/request-nvskills-ci.yml`.
- Handles `pull_request`, qualifying `issue_comment`, and NVSkills signature `push` events.
- Grants only `contents: read`, `pull-requests: read`, and `statuses: read`.
- Calls `NVIDIA/skills/.github/workflows/team-request.yml` at an immutable commit.
- Passes only the NVSkills dispatch token to the reusable workflow.

#### Validation

- `uv run --no-sync pre-commit run --files .github/workflows/request-nvskills-ci.yml`
  - copyright header: passed
  - actionlint: passed
- `just --fmt --check`
- `git diff --check`
- Compared the normalized workflow with the current `NVIDIA/skills` template.
- Compared the workflow exactly with the Relay wrapper.
- Inspected the pinned reusable workflow permissions and secret contract.

Product test suites were not run because this change only adds a GitHub Actions workflow.

#### Where should the reviewer start?

`.github/workflows/request-nvskills-ci.yml`, especially the event filter, minimum permissions, immutable reusable-workflow pin, and dispatch secret mapping.

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- Relates to: none

- [x] I confirm this contribution is my own work, or I have the right to submit it under this project's license.
- [x] I searched existing issues and open pull requests, and this does not duplicate existing work.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added automated NVSkills CI requests for pull request activity, supported comments, and validated pushes.
  * Restricted workflow access to authorized events with read-only permissions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->