### PR TITLE
fix: remove unreachable run_id emptiness check after polling loop

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -113,10 +113,6 @@ collect:github-artifacts:
         fi
         sleep "$NEMO_FABRIC_CI_GITHUB_RUN_POLL_SECONDS"
       done
-      if [ -z "$run_id" ]; then
-        echo "Error: no GitHub Actions run found for tag ${tag}." >&2
-        exit 1
-      fi
 
       run_html_url="$(
         gh run view "$run_id" \


### PR DESCRIPTION
This PR addresses the following issue in `.gitlab-ci.yml`: remove unreachable run_id emptiness check after polling loop.

## Changes
- `.gitlab-ci.yml`: remove unreachable run_id emptiness check after polling loop.

## Details
```diff
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,13 +1,9 @@
-        if [ -n "$run_id" ]; then
-          break
-        fi
-        if [ "$(date -u +%s)" -ge "$deadline" ]; then
-          echo "Error: no ${trigger_type} GitHub Actions run found for tag ${tag} within ${NEMO_FABRIC_CI_GITHUB_RUN_WAIT_SECONDS} seconds." >&2
-          exit 1
-        fi
-        sleep "$NEMO_FABRIC_CI_GITHUB_RUN_POLL_SECONDS"
-      done
-      if [ -z "$run_id" ]; then
-        echo "Error: no GitHub Actions run found for tag ${tag}." >&2
-        exit 1
-      fi
+        if [ -n "$run_id" ]; then
+          break
+        fi
+        if [ "$(date -u +%s)" -ge "$deadline" ]; then
+          echo "Error: no ${trigger_type} GitHub Actions run found for tag ${tag} within ${NEMO_FABRIC_CI_GITHUB_RUN_WAIT_SECONDS} seconds." >&2
+          exit 1
+        fi
+        sleep "$NEMO_FABRIC_CI_GITHUB_RUN_POLL_SECONDS"
+      done
```

## Tests

> Let me know if you want tests added for this fix or not.

## Contributor guidelines

Per this repo's [CONTRIBUTING.md](CONTRIBUTING.md):
- All commits are signed off (`Signed-off-by` trailer, DCO).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved workflow monitoring by handling timeouts and missing runs directly during status checks.
  * Removed redundant validation to streamline run selection and monitoring.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->