### PR TITLE
docs: document Fabric contribution access

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -2,14 +2,14 @@
 # SPDX-License-Identifier: Apache-2.0
 
 # Default ownership for repository files.
-* @nvidia/nemo-fabric-developers
+* @nvidia/nemo-fabric-reviewers
 
 # Attribution files require dependency approver review due to change in version(s)
 ATTRIBUTIONS-*.md @nvidia/nemo-fabric-dep-approvers
 
 # Documentation changes must go to Fabric documentation approvers.
 /docs/ @nvidia/nemo-fabric-doc-approvers
-/docs/reference/api/ @nvidia/nemo-fabric-developers
+/docs/reference/api/ @nvidia/nemo-fabric-reviewers
 
 # Repository access policy requires Fabric maintainer or admin review.
 /.github/CODEOWNERS @nvidia/nemo-fabric-maintainers @nvidia/nemo-fabric-admins

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -2,11 +2,15 @@
 # SPDX-License-Identifier: Apache-2.0
 
 # Default ownership for repository files.
-* @nvidia/nat-developers
+* @nvidia/nemo-fabric-developers
 
 # Attribution files require dependency approver review due to change in version(s)
-ATTRIBUTIONS-*.md @nvidia/nat-dep-approvers
+ATTRIBUTIONS-*.md @nvidia/nemo-fabric-dep-approvers
 
-# Documentation changes must go to technical writers and NAT developers.
-/docs/ @nvidia/NeMo-Fabric-doc-approvers @nvidia/NAT-developers
-/docs/reference/api/ @nvidia/NAT-developers
+# Documentation changes must go to Fabric documentation approvers.
+/docs/ @nvidia/nemo-fabric-doc-approvers
+/docs/reference/api/ @nvidia/nemo-fabric-developers
+
+# Repository access policy requires Fabric maintainer or admin review.
+/.github/CODEOWNERS @nvidia/nemo-fabric-maintainers @nvidia/nemo-fabric-admins
+/CONTRIBUTING.md @nvidia/nemo-fabric-maintainers @nvidia/nemo-fabric-admins

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -9,7 +9,7 @@ ATTRIBUTIONS-*.md @nvidia/nemo-fabric-dep-approvers
 
 # Documentation changes must go to Fabric documentation approvers.
 /docs/ @nvidia/nemo-fabric-doc-approvers
-/docs/reference/api/ @nvidia/nemo-fabric-doc-approvers @nvidia/nemo-fabric-reviewers
+/docs/reference/api/ @nvidia/nemo-fabric-reviewers
 
 # Repository access policy requires Fabric maintainer or admin review.
 /.github/CODEOWNERS @nvidia/nemo-fabric-maintainers @nvidia/nemo-fabric-admins

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -9,7 +9,7 @@ ATTRIBUTIONS-*.md @nvidia/nemo-fabric-dep-approvers
 
 # Documentation changes must go to Fabric documentation approvers.
 /docs/ @nvidia/nemo-fabric-doc-approvers
-/docs/reference/api/ @nvidia/nemo-fabric-reviewers
+/docs/reference/api/ @nvidia/nemo-fabric-doc-approvers @nvidia/nemo-fabric-reviewers
 
 # Repository access policy requires Fabric maintainer or admin review.
 /.github/CODEOWNERS @nvidia/nemo-fabric-maintainers @nvidia/nemo-fabric-admins

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -16,8 +16,6 @@ repository. Pull request creation is limited to approved users in the
 `NeMo-Fabric-reviewers`, a subset of the developer group. Documentation and
 dependency changes use their specialized approver groups.
 
-Do not request repository access through a public GitHub issue.
-
 For non-security contributions, external contributors should open an issue with
 a reproducer, proposed design, or patch description. A NeMo Fabric maintainer
 can adopt the work into a pull request when appropriate. Do not report security

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -11,9 +11,10 @@ the development workflow, coding standards, and pull request process.
 ## Contribution Access
 
 Anyone with a GitHub account may create or comment on an issue in this public
-repository. Pull request creation and authoritative **Approve** or **Request
-changes** reviews are limited to approved NVIDIA users in the
-`NeMo-Fabric-developers` group.
+repository. Pull request creation is limited to approved NVIDIA users in the
+`NeMo-Fabric-developers` group. General changes require CODEOWNER approval from
+`NeMo-Fabric-reviewers`, a subset of the developer group. Documentation and
+dependency changes use their specialized approver groups.
 
 NVIDIA users who need developer access should follow the internal **Requesting
 NeMo Fabric Developer Access** guide in the NeMo Fabric shared Drive. Do not

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -3,10 +3,26 @@ SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All
 SPDX-License-Identifier: Apache-2.0
 -->
 
-# Contributing to NeMo Fabric
+# Contributing to NVIDIA NeMo Fabric
 
 Thank you for your interest in contributing to NeMo Fabric. This guide covers
 the development workflow, coding standards, and pull request process.
+
+## Contribution Access
+
+Anyone with a GitHub account may create or comment on an issue in this public
+repository. Pull request creation and authoritative **Approve** or **Request
+changes** reviews are limited to approved NVIDIA users in the
+`NeMo-Fabric-developers` group.
+
+NVIDIA users who need developer access should follow the internal **Requesting
+NeMo Fabric Developer Access** guide in the NeMo Fabric shared Drive. Do not
+request repository access through a public GitHub issue.
+
+External contributors should open an issue with a reproducer, proposed design,
+or patch description. A NeMo Fabric maintainer can adopt the work into a pull
+request when appropriate. Public issue and pull request comments remain
+welcome and do not require developer access.
 
 ## Development Setup
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -11,19 +11,19 @@ the development workflow, coding standards, and pull request process.
 ## Contribution Access
 
 Anyone with a GitHub account may create or comment on an issue in this public
-repository. Pull request creation is limited to approved NVIDIA users in the
+repository. Pull request creation is limited to approved users in the
 `NeMo-Fabric-developers` group. General changes require CODEOWNER approval from
 `NeMo-Fabric-reviewers`, a subset of the developer group. Documentation and
 dependency changes use their specialized approver groups.
 
-NVIDIA users who need developer access should follow the internal **Requesting
-NeMo Fabric Developer Access** guide in the NeMo Fabric shared Drive. Do not
-request repository access through a public GitHub issue.
+Do not request repository access through a public GitHub issue.
 
-External contributors should open an issue with a reproducer, proposed design,
-or patch description. A NeMo Fabric maintainer can adopt the work into a pull
-request when appropriate. Public issue and pull request comments remain
-welcome and do not require developer access.
+For non-security contributions, external contributors should open an issue with
+a reproducer, proposed design, or patch description. A NeMo Fabric maintainer
+can adopt the work into a pull request when appropriate. Do not report security
+vulnerabilities through a public issue or pull request; follow the [security
+policy](SECURITY.md). Public issue and pull request comments remain welcome and
+do not require developer access.
 
 ## Development Setup
 


### PR DESCRIPTION
#### Overview

Replace NeMo Agent Toolkit team references with the new NeMo Fabric role teams
and document the public contribution-access model. Public GitHub Issues and
comments remain available, while pull request creation and authoritative reviews
are reserved for approved NeMo Fabric developers.

#### Details

- Assign default ownership to the approved 10-person
  `@nvidia/nemo-fabric-reviewers` subset of Developers.
- Assign attribution files to `@nvidia/nemo-fabric-dep-approvers`.
- Assign documentation ownership to the approved NeMo Fabric documentation
  approvers, with generated API docs owned by the reviewer team.
- Require NeMo Fabric maintainer or admin ownership for `CODEOWNERS` and
  `CONTRIBUTING.md` changes.
- Explain the issue-first path for non-security external contributions and
  direct vulnerability reporters to `SECURITY.md`.

#### Validation

- `git diff --check`
- Verified every referenced team exists in the NVIDIA organization.
- Verified `NeMo-Fabric-reviewers` contains exactly the approved 10 Developers
  and has Write access.
- Verified the live repository roles: Developers, Dependency Approvers, and
  Documentation Approvers have Write; Maintainers have Maintain; Admins have
  Admin.
- Docs-site build not run because no `docs/` or generated reference content
  changed.

#### Where should the reviewer start?

Start with `.github/CODEOWNERS`, especially the ownership of `/docs/` and the
access-policy files. Then review the new **Contribution Access** section in
`CONTRIBUTING.md`.

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- Relates to: [FABRIC-182](https://linear.app/nvidia/issue/FABRIC-182/create-fabric-specific-dl-groups)

- [x] I confirm this contribution is my own work, or I have the right to submit it under this project's license.
- [x] I searched existing issues and open pull requests, and this does not duplicate existing work.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified contribution access guidelines, including issue permissions, pull requests, reviews, external contributions, and security reporting.
  * Updated the contributing guide with clearer repository access and contribution procedures.

* **Chores**
  * Updated repository ownership and review assignments to reflect current Fabric teams.
  * Added explicit ownership coverage for repository access files and API documentation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->