### PR TITLE
docs: update roadmap integrations

### DIFF
--- a/README.md
+++ b/README.md
@@ -267,11 +267,13 @@ through adapters. Use the following reference to compare the integrations:
 
 ## Roadmap
 
-- **Custom harnesses:** Publish the NeMo Fabric adapter contract as canonical
-  schemas and dependency-free language bindings so third-party developers can
-  build integrations that are compatible with NeMo Fabric. Support integrations
-  maintained by NeMo Fabric and compatible third-party integrations.
-- **Custom agents:** Support custom agents built on maintained or third-party
-  harness integrations without requiring an additional, agent-specific adapter.
-  Preserve the normalized NeMo Fabric lifecycle, results, artifacts, and
-  telemetry.
+- **Custom harness adapter contract:** Publish and evolve canonical schemas and
+  dependency-free language bindings for third-party harness integrations.
+- **Experimental NeMo Agent Toolkit adapter:** Develop an experimental adapter
+  for running NeMo Agent Toolkit workflows through the NeMo Fabric lifecycle.
+- **OOAgents:** Add support for
+  [OOAgents](https://github.com/NVIDIA-NeMo/labs-OO-Agents).
+- **Remote agents:** Add support for invoking remotely hosted agents through the
+  NeMo Fabric lifecycle.
+- **Pi coding harness:** Add support for the
+  [Pi coding harness](https://pi.dev/).

--- a/README.md
+++ b/README.md
@@ -269,7 +269,7 @@ through adapters. Use the following reference to compare the integrations:
 
 - **Custom harness adapter contract:** Publish and evolve canonical schemas and
   dependency-free language bindings for third-party harness integrations.
-- **Experimental NeMo Agent Toolkit adapter:** Develop an experimental adapter
+- **Experimental NVIDIA NeMo Agent Toolkit adapter:** Develop an experimental adapter
   for running NeMo Agent Toolkit workflows through the NeMo Fabric lifecycle.
 - **OOAgents:** Add support for
   [OOAgents](https://github.com/NVIDIA-NeMo/labs-OO-Agents).


### PR DESCRIPTION
#### Overview

Update the existing README roadmap with the next adapter and harness integration areas: the custom harness adapter contract, an experimental NVIDIA NeMo Agent Toolkit adapter, OOAgents, remote agents, and the Pi coding harness.

#### Details

- Keep all five items in the existing `## Roadmap` section.
- Label only the NVIDIA NeMo Agent Toolkit adapter as experimental.
- Link the OOAgents and Pi roadmap items to their project sites.
- Avoid release dates, priorities, or claims that planned integrations are currently supported.

#### Validation

- `python3 scripts/lint/check_copyright.py README.md`
- `git diff --check`
- Verified the OOAgents and Pi links return HTTP 200.
- Product and docs-site suites were not run because only the root README roadmap copy changed.

#### Where should the reviewer start?

Review the five bullets under `README.md` → `Roadmap`.

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- Relates to: none

- [x] I confirm this contribution is my own work, or I have the right to submit it under this project's license.
- [x] I searched existing issues and open pull requests, and this does not duplicate existing work.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated the roadmap to include plans for:
    * A standardized custom harness adapter contract
    * NeMo Agent Toolkit and OOAgents support
    * Remote agent invocation
    * Pi coding harness support
<!-- end of auto-generated comment: release notes by coderabbit.ai -->