### PR TITLE
fix: allow null errors in successful adapter results

### DIFF
--- a/crates/fabric-core/src/agent_execution.rs
+++ b/crates/fabric-core/src/agent_execution.rs
@@ -239,7 +239,7 @@ fn agent_run_result_schema(schema: &mut Schema) {
                     "properties": {"status": {"const": "succeeded"}},
                     "required": ["status"]
                 },
-                "then": {"not": {"required": ["error"]}}
+                "then": {"properties": {"error": {"type": "null"}}}
             }
         ]),
     );

--- a/crates/fabric-core/src/schema.rs
+++ b/crates/fabric-core/src/schema.rs
@@ -447,6 +447,11 @@ mod tests {
             "output": null,
             "error": {"code": "target_error", "message": "target failed"}
         })));
+        assert!(validator.is_valid(&serde_json::json!({
+            "status": "succeeded",
+            "output": null,
+            "error": null
+        })));
         for path in [
             " \t",
             "nested/../output",

--- a/crates/fabric-core/src/schema.rs
+++ b/crates/fabric-core/src/schema.rs
@@ -449,6 +449,10 @@ mod tests {
         })));
         assert!(validator.is_valid(&serde_json::json!({
             "status": "succeeded",
+            "output": null
+        })));
+        assert!(validator.is_valid(&serde_json::json!({
+            "status": "succeeded",
             "output": null,
             "error": null
         })));

--- a/docs/adapter-contract/results.md
+++ b/docs/adapter-contract/results.md
@@ -31,10 +31,10 @@ Use the generated
 [`AgentRunResult` JSON Schema](https://github.com/NVIDIA/NeMo-Fabric/blob/main/schemas/adapter-contract/agent-run-result.schema.json)
 for exact fields and constraints.
 
-A failed result must contain `error`. A succeeded result must not contain
-`error`. Do not infer status from arbitrary fields in `output`. Exactly one
-terminal result is produced for an invocation, and its status is immutable
-once returned.
+A failed result must contain `error`. A succeeded result can omit `error` or
+set it to `null`; it must not contain a non-null error. Do not infer status
+from arbitrary fields in `output`. Exactly one terminal result is produced for
+an invocation, and its status is immutable once returned.
 
 ## Failure Classes
 

--- a/schemas/adapter-contract/agent-run-result.schema.json
+++ b/schemas/adapter-contract/agent-run-result.schema.json
@@ -199,10 +199,10 @@
         ]
       },
       "then": {
-        "not": {
-          "required": [
-            "error"
-          ]
+        "properties": {
+          "error": {
+            "type": "null"
+          }
         }
       }
     }

--- a/typescript/adapter-contract/schemas/agent-run-result.schema.json
+++ b/typescript/adapter-contract/schemas/agent-run-result.schema.json
@@ -199,10 +199,10 @@
         ]
       },
       "then": {
-        "not": {
-          "required": [
-            "error"
-          ]
+        "properties": {
+          "error": {
+            "type": "null"
+          }
         }
       }
     }

--- a/typescript/adapter-contract/scripts/generate.mjs
+++ b/typescript/adapter-contract/scripts/generate.mjs
@@ -282,10 +282,10 @@ export type AgentRunResult =
   | AgentRunFailed
   | AgentRunCancelled;
 
-/** Successful terminal result. Successful results cannot carry an error. */
+/** Successful terminal result. Successful results can carry only a null error. */
 export interface AgentRunSucceeded extends AgentRunResultCommon {
   status: "succeeded";
-  error?: never;
+  error?: null;
 }
 
 /** Failed terminal result. Failed results must carry a non-null error. */

--- a/typescript/adapter-contract/scripts/projection-guards.mjs
+++ b/typescript/adapter-contract/scripts/projection-guards.mjs
@@ -19,7 +19,7 @@ const supportedRunResultConditionals = [
       properties: { status: { const: "succeeded" } },
       required: ["status"],
     },
-    then: { not: { required: ["error"] } },
+    then: { properties: { error: { type: "null" } } },
   },
 ];
 

--- a/typescript/adapter-contract/src/generated/agent-run-result.ts
+++ b/typescript/adapter-contract/src/generated/agent-run-result.ts
@@ -12,10 +12,10 @@ export type AgentRunResult =
   | AgentRunFailed
   | AgentRunCancelled;
 
-/** Successful terminal result. Successful results cannot carry an error. */
+/** Successful terminal result. Successful results can carry only a null error. */
 export interface AgentRunSucceeded extends AgentRunResultCommon {
   status: "succeeded";
-  error?: never;
+  error?: null;
 }
 
 /** Failed terminal result. Failed results must carry a non-null error. */

--- a/typescript/adapter-contract/test/execution.test.ts
+++ b/typescript/adapter-contract/test/execution.test.ts
@@ -19,6 +19,7 @@ const requests: AgentRunRequest[] = [
 
 const results: AgentRunResult[] = [
   { output: null, status: "succeeded" },
+  { error: null, output: null, status: "succeeded" },
   {
     error: { code: "target_error", message: "target failed" },
     output: { partial: true },


### PR DESCRIPTION
#### Overview

Synchronizes the adapter-result schema with the Rust runtime behavior: a successful result can include `"error": null`, but never a non-null error. This fixes the TypeScript projection failure exposed by PR #188 without bringing in its unrelated changes.

- [x] I confirm this contribution is my own work, or I have the right to submit it under this project license.
- [x] I searched existing issues and open pull requests, and this does not duplicate existing work.

#### Details

- Update the canonical Rust schema and regression coverage.
- Update the guarded TypeScript projection, generated declaration, and packaged schema copy.
- Add type-level coverage for a successful result with `error: null`.

#### Validation

- `cargo fmt --all -- --check`
- `just schemas`
- `just test-rust`
- `just test-typescript`
- `git diff --check`

Not run: `just test-python` (deferred at request).

#### Where should the reviewer start?

Start with `crates/fabric-core/src/agent_execution.rs` and `typescript/adapter-contract/scripts/generate.mjs`; they define the canonical JSON Schema conditional and its TypeScript discriminated-union projection.

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- Relates to: #188

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Successful agent results now consistently support an explicitly null error value.
  * Updated result validation and type definitions to accept successful responses with `error: null`.

* **Documentation**
  * Clarified that successful results may omit `error` or set it to `null`, while non-null errors remain invalid.

* **Tests**
  * Added coverage confirming successful results with null output and null error are valid.
  * Updated execution test fixtures to reflect the clarified result format.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->