### PR TITLE
fix(hermes): fail partial agent results

### DIFF
--- a/adapters/hermes/src/nemo_fabric_adapters/hermes/adapter.py
+++ b/adapters/hermes/src/nemo_fabric_adapters/hermes/adapter.py
@@ -282,6 +282,19 @@ class HermesRuntime:
         messages = result.get("messages") or []
         if isinstance(messages, list):
             self._conversation_history = messages
+        reported_error = result.get("error")
+        failed = (
+            bool(result.get("failed"))
+            or bool(result.get("partial"))
+            or bool(reported_error)
+        )
+        if isinstance(reported_error, str) and reported_error:
+            reported_error = {
+                "code": "hermes_reported_failure",
+                "message": reported_error,
+                "retryable": False,
+                "metadata": {},
+            }
 
         output = {
             "harness": "hermes",
@@ -291,11 +304,11 @@ class HermesRuntime:
             "base_url": model_config.base_url,
             "response": result.get("response") or result.get("final_response"),
             "completed": bool(result.get("completed")),
-            "failed": bool(result.get("failed")),
+            "failed": failed,
             "api_calls": result.get("api_calls"),
             "messages": messages,
             "message_count": len(messages),
-            "error": result.get("error"),
+            "error": reported_error,
             "adapter_stdout": adapter_stdout,
             "hermes_home": str(self._hermes_home),
             "hermes_config_path": str(self._hermes_config_path),

--- a/tests/adapters/test_hermes_adapter.py
+++ b/tests/adapters/test_hermes_adapter.py
@@ -1118,6 +1118,94 @@ def test_artifact_root_resolves_relative_to_base_dir(tmp_path: Path):
     )
 
 
+@pytest.fixture(name="started_hermes_runtime")
+def started_hermes_runtime_fixture(
+    monkeypatch,
+) -> tuple[adapter.HermesRuntime, MagicMock]:
+    mock_turn = MagicMock()
+    monkeypatch.setattr(adapter, "_invoke_hermes_turn", mock_turn)
+    agent_config = _agent_config(
+        {"models": {"default": {"provider": "test", "model": "test-model"}}}
+    )
+    runtime = adapter.HermesRuntime()
+    runtime._started = True
+    runtime._agent_config = agent_config
+    runtime._model_config = agent_config.models["default"]
+    runtime._runtime_id = "runtime-incomplete"
+    runtime._agent = MagicMock()
+    return runtime, mock_turn
+
+
+@pytest.mark.parametrize(
+    ("result_update", "expected_failed", "expected_error"),
+    [
+        pytest.param({"failed": True}, True, None, id="failed"),
+        pytest.param({"partial": True}, True, None, id="partial"),
+        pytest.param(
+            {"error": "Response remained truncated after 4 continuation attempts"},
+            True,
+            {
+                "code": "hermes_reported_failure",
+                "message": "Response remained truncated after 4 continuation attempts",
+                "retryable": False,
+                "metadata": {},
+            },
+            id="string-error",
+        ),
+        pytest.param(
+            {
+                "error": {
+                    "code": "hermes_rate_limited",
+                    "message": "provider rate limited the request",
+                    "retryable": True,
+                    "metadata": {"provider": "test"},
+                }
+            },
+            True,
+            {
+                "code": "hermes_rate_limited",
+                "message": "provider rate limited the request",
+                "retryable": True,
+                "metadata": {"provider": "test"},
+            },
+            id="structured-error",
+        ),
+        pytest.param({"error": ""}, False, "", id="empty-error"),
+        pytest.param({}, False, None, id="completed-false-only"),
+    ],
+)
+async def test_hermes_failure_signals_are_normalized(
+    started_hermes_runtime,
+    result_update: dict[str, object],
+    *,
+    expected_failed: bool,
+    expected_error: object | None,
+):
+    runtime, mock_turn = started_hermes_runtime
+    mock_turn.return_value = (
+        {
+            "final_response": "done",
+            "completed": False,
+            "messages": [],
+            **result_update,
+        },
+        "",
+    )
+
+    output = await runtime.invoke(
+        {
+            "runtime_context": _runtime_context(
+                runtime_id="runtime-incomplete"
+            ).to_mapping(),
+            "request": {"input": "complete the task"},
+        }
+    )
+
+    assert output["completed"] is False
+    assert output["failed"] is expected_failed
+    assert output["error"] == expected_error
+
+
 async def test_persistent_runtime_reuses_hermes_agent_session_and_history(
     monkeypatch,
     tmp_path: Path,


### PR DESCRIPTION
#### Overview

Normalize Hermes terminal partial and errored results into Fabric failures. Hermes can return `partial=true` or a non-empty `error` while leaving `failed=false`; Fabric otherwise reports the invocation as successful.

#### Details

- Treat Hermes `failed`, `partial`, and non-empty `error` values as failure signals.
- Convert non-empty Hermes string errors to Fabric's structured error shape while preserving existing structured errors.
- Add a focused result-mapping regression matrix for the current typed runtime.

#### Validation

- `uvx ruff format adapters/hermes/src/nemo_fabric_adapters/hermes/adapter.py tests/adapters/test_hermes_adapter.py`
- `uvx ruff check adapters/hermes/src/nemo_fabric_adapters/hermes/adapter.py tests/adapters/test_hermes_adapter.py`
- `.venv/bin/python -m pytest -q tests/adapters/test_hermes_adapter.py` — 44 passed
- `.venv/bin/python -m pytest -q` — 14 unrelated pre-existing integration/scaffold failures; no Hermes failures.

#### Where should the reviewer start?

Start with the result normalization in `adapters/hermes/src/nemo_fabric_adapters/hermes/adapter.py`, then the regression matrix in `tests/adapters/test_hermes_adapter.py`.

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- Relates to #148 (replacement PR)

- [x] I confirm this contribution is my own work, or I have the right to submit it under this project's license.
- [x] I searched existing issues and open pull requests, and this does not duplicate existing work.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved runtime invocation result handling to consistently identify failed and partial results.
  * Normalized string-reported errors into structured, non-retryable error details.
  * Preserved structured errors and correctly handled empty or missing error information.

* **Tests**
  * Added coverage for failure, partial-result, string-error, structured-error, empty-error, and successful invocation scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->