### PR TITLE
fix: preserve completed results after cleanup failures

### DIFF
--- a/crates/fabric-core/src/runtime.rs
+++ b/crates/fabric-core/src/runtime.rs
@@ -712,7 +712,20 @@ pub fn run_plan(plan: &RunPlan, request: RunRequest) -> Result<RunResult> {
             return Err(error);
         }
     };
-    result.events.extend(stop_runtime(plan, &runtime)?);
+    match stop_runtime(plan, &runtime) {
+        Ok(events) => result.events.extend(events),
+        Err(error) if result.status == RunStatus::Succeeded => {
+            result.status = RunStatus::Failed;
+            result.error = Some(ErrorInfo {
+                stage: ErrorStage::Stop,
+                code: "runtime_stop_failed".to_string(),
+                message: error.to_string(),
+                retryable: false,
+                metadata: BTreeMap::new(),
+            });
+        }
+        Err(_) => {}
+    }
     Ok(result)
 }
 
@@ -3936,6 +3949,23 @@ for line in sys.stdin:
         assert!(error.to_string().contains("fake_stop"), "{error}");
         let retry = stop_runtime(&plan, &runtime).expect("cleanup retry is idempotent");
         assert_eq!(retry[0].metadata["already_stopped"], true);
+
+        let _ = fs::remove_dir_all(root);
+    }
+
+    #[test]
+    fn run_plan_preserves_completed_result_when_stop_fails() {
+        let (root, plan) = local_host_plan("stop_failure");
+
+        let result = run_plan(&plan, RunRequest::text("completed"))
+            .expect("completed result with stop failure");
+
+        assert_eq!(result.status, RunStatus::Failed);
+        assert_eq!(result.output["input"], "completed");
+        let error = result.error.expect("stop error");
+        assert_eq!(error.stage, ErrorStage::Stop);
+        assert_eq!(error.code, "runtime_stop_failed");
+        assert!(error.message.contains("fake_stop"), "{}", error.message);
 
         let _ = fs::remove_dir_all(root);
     }

--- a/python/src/nemo_fabric/runtime.py
+++ b/python/src/nemo_fabric/runtime.py
@@ -541,9 +541,18 @@ async def _run_native_lifecycle(
         finally:
             try:
                 stop_events = json.loads(native.stop_runtime(plan_json, runtime_json))
-            except Exception:
+            except Exception as error:
                 if invoke_error is None:
-                    raise
+                    if result is None:
+                        raise
+                    if result.get("status") == "succeeded":
+                        result["status"] = "failed"
+                        result["error"] = {
+                            "stage": "stop",
+                            "code": "runtime_stop_failed",
+                            "message": str(error),
+                            "retryable": False,
+                        }
                 stop_events = []
             if result is not None and isinstance(stop_events, list):
                 result.setdefault("events", []).extend(stop_events)

--- a/tests/python/test_runtime.py
+++ b/tests/python/test_runtime.py
@@ -529,10 +529,14 @@ async def test_run_surfaces_cleanup_failure_after_success(
 ):
     mock_native.stop_runtime.side_effect = RuntimeError("stop failed")
 
-    with pytest.raises(FabricRuntimeError, match="stop failed") as caught:
-        await native_client.run(_config(), input="hello")
+    result = await native_client.run(_config(), input="hello")
 
-    assert caught.value.stage == "run"
+    assert result.status == "failed"
+    assert result.output["messages"][-1]["content"] == "reply-1"
+    assert result.error is not None
+    assert result.error.stage == "stop"
+    assert result.error.code == "runtime_stop_failed"
+    assert result.error.message == "stop failed"
     assert mock_native.stop_runtime.call_count == 1
 
 


### PR DESCRIPTION
#### Overview

Preserve a completed invocation result when runtime cleanup fails. The result is returned with a failed status and stop-stage error instead of being discarded.

#### Details

- Preserve successful `run_plan` output when `stop_runtime` fails.
- Apply the same behavior to Python's `Fabric.run` lifecycle.
- Add Rust and Python regressions.

#### Validation

- `cargo test -p nemo-fabric-core --lib` (102 passed)
- `cargo check -p fabric-python --locked`
- `uv run --no-sync pytest -q tests/python/test_runtime.py` (23 passed)
- `cargo fmt --all -- --check`; Ruff check; `git diff --check`
- The full `just test-rust` and `just test-python` commands could not complete within this terminal's foreground execution limit.

#### Where should the reviewer start?

`crates/fabric-core/src/runtime.rs`: the cleanup-error branch in `run_plan` retains the completed result.

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- Relates to #140 (replacement)

- [x] I confirm this contribution is my own work, or I have the right to submit it under this project's license.
- [x] I searched existing issues and open pull requests, and this does not duplicate existing work.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Preserved successful invocation output when runtime shutdown encounters an error.
  * Reported shutdown failures as structured, non-retryable errors instead of discarding completed results.
  * Prevented cleanup errors from replacing an invocation that had already failed.
  * Continued raising shutdown errors when no invocation result is available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->