### PR TITLE
chore: Improve slow Python tests

### DIFF
--- a/crates/fabric-python/Cargo.toml
+++ b/crates/fabric-python/Cargo.toml
@@ -12,7 +12,6 @@ repository.workspace = true
 [lib]
 name = "_native"
 crate-type = ["cdylib", "rlib"]
-test = false
 doctest = false
 
 [dependencies]

--- a/crates/fabric-python/src/lib.rs
+++ b/crates/fabric-python/src/lib.rs
@@ -277,7 +277,7 @@ fn query_python_data_path_with_timeout(
                 return Err(format!(
                     "{origin} interpreter `{}` timed out after {} seconds while reporting its data path",
                     python.display(),
-                    timeout.as_secs()
+                    timeout.as_secs_f64()
                 ));
             }
             Err(error) => {
@@ -355,7 +355,7 @@ mod tests {
         )
         .expect_err("slow data path query should time out");
 
-        assert!(error.contains("timed out"), "{error}");
+        assert!(error.contains("timed out after 0.05 seconds"), "{error}");
         assert!(started.elapsed() < Duration::from_secs(1));
         fs::remove_dir_all(test_dir).expect("temporary test directory should be removed");
     }

--- a/crates/fabric-python/src/lib.rs
+++ b/crates/fabric-python/src/lib.rs
@@ -244,6 +244,14 @@ fn resolve_adapter_python(base_dir: &Path, adapter_python: OsString) -> PathBuf 
 }
 
 fn query_python_data_path(python: &Path, origin: &str) -> Result<String, String> {
+    query_python_data_path_with_timeout(python, origin, PYTHON_DATA_PATH_QUERY_TIMEOUT)
+}
+
+fn query_python_data_path_with_timeout(
+    python: &Path,
+    origin: &str,
+    timeout: Duration,
+) -> Result<String, String> {
     let mut child = Command::new(python)
         .arg("-c")
         .arg(PYTHON_DATA_PATH_SCRIPT)
@@ -256,7 +264,7 @@ fn query_python_data_path(python: &Path, origin: &str) -> Result<String, String>
                 python.display()
             )
         })?;
-    let deadline = Instant::now() + PYTHON_DATA_PATH_QUERY_TIMEOUT;
+    let deadline = Instant::now() + timeout;
     loop {
         match child.try_wait() {
             Ok(Some(_)) => break,
@@ -269,7 +277,7 @@ fn query_python_data_path(python: &Path, origin: &str) -> Result<String, String>
                 return Err(format!(
                     "{origin} interpreter `{}` timed out after {} seconds while reporting its data path",
                     python.display(),
-                    PYTHON_DATA_PATH_QUERY_TIMEOUT.as_secs()
+                    timeout.as_secs()
                 ));
             }
             Err(error) => {
@@ -308,6 +316,49 @@ fn query_python_data_path(python: &Path, origin: &str) -> Result<String, String>
         ));
     }
     Ok(data_path)
+}
+
+#[cfg(all(test, unix))]
+mod tests {
+    use std::fs;
+    use std::os::unix::fs::PermissionsExt;
+    use std::time::{Duration, Instant, SystemTime};
+
+    use super::query_python_data_path_with_timeout;
+
+    #[test]
+    fn python_data_path_query_times_out() {
+        let unique = SystemTime::now()
+            .duration_since(SystemTime::UNIX_EPOCH)
+            .expect("system clock should be after the Unix epoch")
+            .as_nanos();
+        let test_dir = std::env::temp_dir().join(format!(
+            "nemo-fabric-python-data-path-timeout-{}-{unique}",
+            std::process::id()
+        ));
+        fs::create_dir(&test_dir).expect("temporary test directory should be created");
+        let slow_python = test_dir.join("slow-python");
+        fs::write(&slow_python, "#!/bin/sh\nwhile :; do :; done\n")
+            .expect("slow test executable should be written");
+        let mut permissions = fs::metadata(&slow_python)
+            .expect("slow test executable metadata should be readable")
+            .permissions();
+        permissions.set_mode(0o700);
+        fs::set_permissions(&slow_python, permissions)
+            .expect("slow test executable should be executable");
+
+        let started = Instant::now();
+        let error = query_python_data_path_with_timeout(
+            &slow_python,
+            "ADAPTER_PYTHON",
+            Duration::from_millis(50),
+        )
+        .expect_err("slow data path query should time out");
+
+        assert!(error.contains("timed out"), "{error}");
+        assert!(started.elapsed() < Duration::from_secs(1));
+        fs::remove_dir_all(test_dir).expect("temporary test directory should be removed");
+    }
 }
 
 fn parse_config(contents: String) -> PyResult<FabricConfig> {

--- a/tests/_utils/mock_api_server.py
+++ b/tests/_utils/mock_api_server.py
@@ -19,6 +19,7 @@ def mock_api_server(port: int) -> Iterator[str]:
 
     Use the /_requests endpoint to inspect captured chat-completion payloads after a test action.
     Use the /_scenario endpoint to configure the server to return a specific status code for subsequent requests.
+    Use the /_reset endpoint to clear all retained request and scenario state.
 
     Args:
         port (int): The port on which the server will listen.
@@ -28,11 +29,15 @@ def mock_api_server(port: int) -> Iterator[str]:
     """
 
     app = FastAPI()
-    app.state.requests = []
-    app.state.status_code = 200
-    app.state.tool_call = None
-    app.state.tool_call_sent = False
-    app.state.mcp_authorization_headers = []
+
+    def reset_state() -> None:
+        app.state.requests = []
+        app.state.status_code = 200
+        app.state.tool_call = None
+        app.state.tool_call_sent = False
+        app.state.mcp_authorization_headers = []
+
+    reset_state()
 
     @app.get("/health")
     def health() -> dict[str, str]:
@@ -70,6 +75,13 @@ def mock_api_server(port: int) -> Iterator[str]:
             "status_code": app.state.status_code,
             "tool_call": app.state.tool_call,
         }
+
+    @app.post("/_reset")
+    def reset() -> dict[str, str]:
+        """Clear captured requests and restore the default response scenario."""
+
+        reset_state()
+        return {"status": "ok"}
 
     @app.get("/_mcp_authorization_headers")
     def mcp_authorization_headers() -> list[str | None]:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -110,13 +110,19 @@ def code_review_agent_dir_fixture(repo_root: Path, tmp_path: Path) -> Path:
         "code-review-agent",
     )
 
-
-@pytest.fixture(name="api_server")
-def api_server_fixture(unused_tcp_port_factory) -> Iterator[str]:
+@pytest.fixture(name="api_server_session", scope="session")
+def api_server_session_fixture(unused_tcp_port_factory) -> Iterator[str]:
     from _utils.mock_api_server import mock_api_server
 
     with mock_api_server(unused_tcp_port_factory()) as base_url:
         yield base_url
+
+
+@pytest.fixture(name="api_server")
+def api_server_fixture(api_server_session: str) -> Iterator[str]:
+    yield api_server_session
+
+    requests.post(f"{api_server_session}/_reset", timeout=5)
 
 
 @pytest.fixture(name="adapter_ids")

--- a/tests/e2e/test_cli_scaffold.py
+++ b/tests/e2e/test_cli_scaffold.py
@@ -37,33 +37,6 @@ def generate_scaffold(destination: Path, language: str) -> None:
     )
 
 
-def test_generated_python_scaffold_installs_editable(tmp_path: Path):
-    destination = tmp_path / "python-agent"
-    generate_scaffold(destination, "python")
-    venv = tmp_path / "venv"
-    subprocess.run(
-        ["uv", "venv", "--seed", "--python", sys.executable, str(venv)],
-        check=True,
-        capture_output=True,
-        text=True,
-        timeout=SUBPROCESS_TIMEOUT_SECONDS,
-    )
-    python = venv / ("Scripts/python.exe" if os.name == "nt" else "bin/python")
-    environment = os.environ.copy()
-    environment["PIP_NO_BUILD_ISOLATION"] = "1"
-    environment["PIP_NO_DEPS"] = "1"
-
-    subprocess.run(
-        [str(python), "-m", "pip", "install", "-e", "."],
-        cwd=destination,
-        env=environment,
-        check=True,
-        capture_output=True,
-        text=True,
-        timeout=SUBPROCESS_TIMEOUT_SECONDS,
-    )
-
-
 def test_generated_rust_scaffold_builds(tmp_path: Path):
     destination = tmp_path / "rust-agent"
     generate_scaffold(destination, "rust")

--- a/tests/python/test_installed_adapter_discovery.py
+++ b/tests/python/test_installed_adapter_discovery.py
@@ -10,7 +10,6 @@ import os
 import shutil
 import subprocess
 import sysconfig
-import time
 import venv
 from collections.abc import Callable
 from functools import partial
@@ -316,20 +315,3 @@ def test_installed_claude_wheel_supplies_metadata_and_settings_schema(
     message = str(caught.value)
     assert str(descriptor.resolve()) in message
     assert "harness.settings.unknown" in message
-
-
-def test_adapter_python_data_path_query_times_out(tmp_path: Path):
-    adapter_env = tmp_path / "slow-adapter-env"
-    _create_venv(adapter_env)
-    adapter_python = adapter_env / (
-        "Scripts/python.exe" if os.name == "nt" else "bin/python"
-    )
-    purelib = _python_sysconfig_path(adapter_python, "purelib")
-    (purelib / "slow_startup.pth").write_text("import time; time.sleep(30)\n")
-    os.environ["ADAPTER_PYTHON"] = str(adapter_python)
-
-    started = time.monotonic()
-    with pytest.raises(FabricConfigError, match="timed out after 5 seconds"):
-        Fabric().plan(_config(), base_dir=tmp_path / "agent")
-
-    assert time.monotonic() - started < 10


### PR DESCRIPTION
#### Overview

* Removed `test_generated_python_scaffold_installs_editable` this test created a new venv and verified that the repo was installable as an editable workspace. Each run took about ~10s.
* Replace `test_adapter_python_data_path_query_times_out` with a Rust test.
  + The issue here is that we don't expose the adapter Python timeout time, which is hard-coded to 5s.
  + Created a impl method that exposes the timeout, and tested it in Rust with a 50ms timeout
* Re-work the api-server fixture to be session scoped cutting down on startup time

#### Where should the reviewer start?

* `crates/fabric-python/src/lib.rs`

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)


- [x] I confirm this contribution is my own work, or I have the right to submit it under this project's license.
- [x] I searched existing issues and open pull requests, and this does not duplicate existing work.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Added configurable timeouts for Python data-path queries, with clearer timeout error messages.
  - Ensured stalled processes terminate within the expected timeframe.

- **Tests**
  - Improved mock API server reset behavior between tests.
  - Reused a shared test server while preserving test isolation.
  - Removed obsolete Python scaffold and timeout regression tests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->