### PR TITLE
docs: use NeMo Agent Toolkit name consistently

### DIFF
--- a/docs/adapter-contract/custom-agents.md
+++ b/docs/adapter-contract/custom-agents.md
@@ -63,8 +63,8 @@ workflow:
 ```
 
 NeMo Fabric owns the intent name and its portable semantics. Each adapter maps a
-supported intent to its target-native implementation. The NAT reference
-adapter currently demonstrates this mode for `fabric.agent.react`.
+supported intent to its target-native implementation. The NeMo Agent Toolkit
+reference adapter currently demonstrates this mode for `fabric.agent.react`.
 
 ### Installed Python Entry Point
 

--- a/docs/adapter-contract/custom-agents.md
+++ b/docs/adapter-contract/custom-agents.md
@@ -63,8 +63,9 @@ workflow:
 ```
 
 NeMo Fabric owns the intent name and its portable semantics. Each adapter maps a
-supported intent to its target-native implementation. The NeMo Agent Toolkit
-reference adapter currently demonstrates this mode for `fabric.agent.react`.
+supported intent to its target-native implementation. The NVIDIA NeMo Agent
+Toolkit reference adapter currently demonstrates this mode for
+`fabric.agent.react`.
 
 ### Installed Python Entry Point
 

--- a/external/README.md
+++ b/external/README.md
@@ -18,4 +18,4 @@ The following source-only reference adapter is available:
 
 | Harness | Adapter ID | Reference |
 | --- | --- | --- |
-| NeMo Agent Toolkit | `nvidia.fabric.nat` | [NeMo Agent Toolkit adapter](nat/README.md) |
+| NVIDIA NeMo Agent Toolkit | `nvidia.fabric.nat` | [NeMo Agent Toolkit adapter](nat/README.md) |

--- a/external/README.md
+++ b/external/README.md
@@ -18,4 +18,4 @@ The following source-only reference adapter is available:
 
 | Harness | Adapter ID | Reference |
 | --- | --- | --- |
-| NVIDIA NeMo Agent Toolkit | `nvidia.fabric.nat` | [NAT adapter](nat/README.md) |
+| NeMo Agent Toolkit | `nvidia.fabric.nat` | [NeMo Agent Toolkit adapter](nat/README.md) |

--- a/external/nat/README.md
+++ b/external/nat/README.md
@@ -3,62 +3,65 @@ SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All
 SPDX-License-Identifier: Apache-2.0
 -->
 
-# NVIDIA NeMo Fabric NAT Reference Adapter
+# NeMo Agent Toolkit Reference Adapter for NVIDIA NeMo Fabric
 
-This source-only adapter runs an NVIDIA NeMo Agent Toolkit (NAT) workflow behind
+This source-only adapter runs a NeMo Agent Toolkit workflow behind
 the NeMo Fabric lifecycle contract. It is a third-party adapter reference, not a
 bundled NeMo Fabric adapter or a published package.
 
-The implementation constructs NAT configuration in memory from the typed
-southbound `AgentConfig` dataclass; it does not read a NAT YAML file, parse the
-northbound `FabricConfig`, or depend on Pydantic for its contract boundary.
+The implementation constructs NeMo Agent Toolkit configuration in memory from
+the typed southbound `AgentConfig` dataclass; it does not read a NeMo Agent
+Toolkit YAML file, parse the northbound `FabricConfig`, or depend on Pydantic for
+its contract boundary.
 
 ## Configuration Boundary
 
 NeMo Fabric owns portable configuration. `workflow` selects a Fabric-enumerated
 agent factory and `tools.definitions` supplies named functions and function
-groups that the adapter resolves as installed NAT components.
+groups that the adapter resolves as installed NeMo Agent Toolkit components.
 
-| NeMo Fabric input | NAT configuration |
+| NeMo Fabric input | NeMo Agent Toolkit configuration |
 | --- | --- |
 | `models.<role>` | `llms.<role>`; every NeMo Fabric model-role name is preserved |
 | `instructions.system` | Built-in `react_agent` workflow `additional_instructions`; other workflow types reject this field in the initial adapter |
 | `workflow.entrypoint.kind=factory` | Resolve a Fabric-enumerated agent intent |
-| `workflow.entrypoint.ref=fabric.agent.react` | NAT `react_agent` workflow factory |
+| `workflow.entrypoint.ref=fabric.agent.react` | NeMo Agent Toolkit `react_agent` workflow factory |
 | `workflow.settings` | Remaining `workflow` component fields |
-| `tools.definitions.<name>` with `kind=function` | NAT `functions.<name>`; `ref` becomes `_type` |
-| `tools.definitions.<name>` with `kind=function_group` | NAT `function_groups.<name>`; `ref` becomes `_type` |
+| `tools.definitions.<name>` with `kind=function` | NeMo Agent Toolkit `functions.<name>`; `ref` becomes `_type` |
+| `tools.definitions.<name>` with `kind=function_group` | NeMo Agent Toolkit `function_groups.<name>`; `ref` becomes `_type` |
 | `mcp.servers.<name>` | Generated `mcp_client` function group named `<name>` |
-| `tools.enabled`, `tools.blocked` | Effective NAT-native workflow tool selection |
+| `tools.enabled`, `tools.blocked` | Effective native NeMo Agent Toolkit workflow tool selection |
 
-The adapter loads installed `nat.components` entry points before NAT validates
-the generated configuration. A custom function or function group is supplied
-as an installed NAT component package and selected by `tools.definitions.ref`.
-No Python callable crosses the configuration contract. A custom adapter may
-publish a broader workflow schema without changing this shared NAT adapter.
+The adapter loads installed `nat.components` entry points before validating the
+generated configuration with NeMo Agent Toolkit. A custom function or function
+group is supplied as an installed NeMo Agent Toolkit component package and
+selected by `tools.definitions.ref`. No Python callable crosses the configuration
+contract. A custom adapter may publish a broader workflow schema without
+changing this shared NeMo Agent Toolkit adapter.
 
 At runtime, `start` loads components, enters one `WorkflowBuilder`, creates a
 `SessionManager` with that shared builder, and retains both resources. Each
 `invoke` opens a session from the retained manager, enters `session.run(...)`,
-and awaits `runner.result()`. That runner path already invokes NAT functions
-asynchronously while preserving NAT's concurrency, context, tracing, and
-lifecycle behavior; the adapter does not call a workflow function's lower-level
-`ainvoke()` method directly.
+and awaits `runner.result()`. That runner path already invokes NeMo Agent Toolkit
+functions asynchronously while preserving the toolkit's concurrency, context,
+tracing, and lifecycle behavior; the adapter does not call a workflow function's
+lower-level `ainvoke()` method directly.
 
 Native OpenAI streaming is available when the retained `SessionManager` reports
 `ChatResponseChunk` as the workflow's streaming output schema. The adapter is
-tested against NAT 1.7.0 and 1.8.0; both versions' shared ReAct registrations
-declare that schema. The adapter checks the schema rather than branching on a
-workflow name, opens one NAT session and run, and consumes
-`runner.result_stream(to_type=ChatResponseChunk)` exactly once. It serializes and
-forwards the OpenAI Chat Completions chunks in order. `invoke` serializes NAT's
-terminal `runner.result()` object into `result.output["response"]`. By contrast,
-the terminal NeMo Fabric `invoke_openai_stream` result contains the concatenated
-string `delta.content` values for choice index `0` in
+tested against NeMo Agent Toolkit 1.7.0 and 1.8.0; both versions' shared ReAct
+registrations declare that schema. The adapter checks the schema rather than
+branching on a workflow name, opens one NeMo Agent Toolkit session and one run,
+and consumes `runner.result_stream(to_type=ChatResponseChunk)` exactly once. It
+serializes and forwards the OpenAI Chat Completions chunks in order. `invoke`
+serializes the terminal NeMo Agent Toolkit `runner.result()` object into
+`result.output["response"]`. By contrast, the terminal NeMo Fabric
+`invoke_openai_stream` result contains the concatenated string `delta.content`
+values for choice index `0` in
 `result.output["response"]`; empty and usage-only streams complete with an empty
 response. The adapter does not add SSE framing, a `[DONE]` marker, or a synthetic
 finish chunk. A workflow without the required schema returns
-`nat_openai_stream_unsupported_schema` before NAT opens a session.
+`nat_openai_stream_unsupported_schema` before NeMo Agent Toolkit opens a session.
 
 `stop` shuts down the session manager and exits the builder context. This first
 reference does not claim cancellation, service, or live-update support.
@@ -67,14 +70,15 @@ reference does not claim cancellation, service, or live-update support.
 
 The adapter consumes the `AgentConfig.mcp.servers` entries, including the
 normalized per-server filters. NeMo Fabric MCP tool names remain bare
-server-local names; NAT exposes a selected member as `<server>__<tool>`.
+server-local names; NeMo Agent Toolkit exposes a selected member as
+`<server>__<tool>`.
 
 For `stdio` servers, NeMo Fabric expands `$VAR` references in `url` and forwards
 the result as the literal command without shell parsing. Structured `args` and
-`env` are forwarded to NAT. Only `url` supports variable expansion; `args` and
-`env` values are literal.
+`env` are forwarded to NeMo Agent Toolkit. Only `url` supports variable
+expansion; `args` and `env` values are literal.
 
-| NeMo Fabric server policy | Generated NAT function group |
+| NeMo Fabric server policy | Generated NeMo Agent Toolkit function group |
 | --- | --- |
 | `allowed_tools` omitted and `blocked_tools=[]` | No `include` or `exclude`; expose all discovered tools |
 | Nonempty `allowed_tools` only | `include=allowed_tools` |
@@ -82,24 +86,24 @@ the result as the literal command without shell parsing. Structured `args` and
 | Both lists configured | `include=allowed_tools`; NeMo Fabric requires `blocked_tools` to be disjoint, so those names are already outside the allowlist |
 | `allowed_tools=[]` | Omit the generated group; expose no tools from that server |
 
-NAT rejects a function group that sets both `include` and `exclude`, so the
-adapter emits only `include` whenever an allowlist is present. NeMo Fabric rejects
-blank names and an allow/block overlap before adapter startup. A nonempty
-generated MCP group is added to workflows that expose `tool_names`; callers do
-not repeat portable MCP servers in `harness.settings`. A workflow implementation
-that requires at least one tool can still reject a configuration whose effective
-tool set is empty.
+NeMo Agent Toolkit rejects a function group that sets both `include` and
+`exclude`, so the adapter emits only `include` whenever an allowlist is present.
+NeMo Fabric rejects blank names and an allow/block overlap before adapter
+startup. A nonempty generated MCP group is added to workflows that expose
+`tool_names`; callers do not repeat portable MCP servers in `harness.settings`.
+A workflow implementation that requires at least one tool can still reject a
+configuration whose effective tool set is empty.
 
 Per-server MCP filters and root `tools.enabled` or `tools.blocked` solve
 different problems. MCP filters select members within one server. Root tool
-policy selects across the effective NAT-native tool surface.
+policy selects across the effective native NeMo Agent Toolkit tool surface.
 
 ## Development Bootstrap
 
 This directory intentionally has no package metadata or discovery wiring. Until
 source resolution and third-party descriptor discovery are available, use one
-Python environment for NeMo Fabric, the common adapter host, NAT, and every NAT
-component referenced by the config:
+Python environment for NeMo Fabric, the common adapter host, NeMo Agent Toolkit,
+and every NeMo Agent Toolkit component referenced by the config:
 
 ```bash
 uv pip install \
@@ -128,9 +132,9 @@ uv run python external/nat/examples/calculator.py \
   --base-dir "$PWD/.tmp/nat-reference"
 ```
 
-The email-phishing example uses the NAT example component registered by
-`nat_email_phishing_analyzer`. Install that component from a NAT checkout, then
-run the example:
+The email-phishing example uses the NeMo Agent Toolkit example component
+registered by `nat_email_phishing_analyzer`. Install that component from a NeMo
+Agent Toolkit checkout, then run the example:
 
 ```bash
 uv pip install -e \

--- a/external/nat/README.md
+++ b/external/nat/README.md
@@ -3,7 +3,7 @@ SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All
 SPDX-License-Identifier: Apache-2.0
 -->
 
-# NeMo Agent Toolkit Reference Adapter for NVIDIA NeMo Fabric
+# NVIDIA NeMo Agent Toolkit Reference Adapter for NVIDIA NeMo Fabric
 
 This source-only adapter runs a NeMo Agent Toolkit workflow behind
 the NeMo Fabric lifecycle contract. It is a third-party adapter reference, not a

--- a/external/nat/examples/calculator.py
+++ b/external/nat/examples/calculator.py
@@ -1,7 +1,7 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-"""Run a NAT ReAct workflow with a portable calculator MCP server."""
+"""Run a NeMo Agent Toolkit ReAct workflow with a portable calculator MCP server."""
 
 from __future__ import annotations
 

--- a/external/nat/examples/calculator_mcp.py
+++ b/external/nat/examples/calculator_mcp.py
@@ -1,7 +1,7 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-"""Self-contained calculator MCP server for the NAT reference example."""
+"""Self-contained calculator MCP server for the NeMo Agent Toolkit reference example."""
 
 from __future__ import annotations
 

--- a/external/nat/examples/email_phishing.py
+++ b/external/nat/examples/email_phishing.py
@@ -1,7 +1,7 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-"""Run a NAT workflow with the installed email-phishing analyzer function."""
+"""Run a NeMo Agent Toolkit workflow with the installed email-phishing analyzer function."""
 
 from __future__ import annotations
 
@@ -24,7 +24,7 @@ from nemo_fabric import WorkflowEntrypointConfig
 
 
 def build_config() -> FabricConfig:
-    """Build the NAT-native email-phishing configuration."""
+    """Build the native NeMo Agent Toolkit email-phishing configuration."""
 
     tools = ToolsConfig()
     tools.add_definition(
@@ -38,7 +38,7 @@ def build_config() -> FabricConfig:
     config = FabricConfig(
         metadata=MetadataConfig(
             name="nat-email-phishing-analyzer",
-            description="Classifies an email with an installed NAT function.",
+            description="Classifies an email with an installed NeMo Agent Toolkit function.",
         ),
         harness=HarnessConfig(
             adapter_id="nvidia.fabric.nat",

--- a/external/nat/fabric-adapter.json
+++ b/external/nat/fabric-adapter.json
@@ -25,7 +25,7 @@
           },
           "ref": {
             "const": "fabric.agent.react",
-            "description": "Build Fabric's ReAct agent intent with the NAT react_agent factory."
+            "description": "Build Fabric's ReAct agent intent with the NeMo Agent Toolkit react_agent factory."
           }
         },
         "required": ["kind", "ref"],
@@ -37,7 +37,7 @@
           "_type": false
         },
         "additionalProperties": true,
-        "description": "NAT workflow component settings; _type is derived from entrypoint.ref."
+        "description": "NeMo Agent Toolkit workflow component settings; _type is derived from entrypoint.ref."
       }
     },
     "required": ["entrypoint"],
@@ -54,7 +54,7 @@
         "type": "string",
         "minLength": 1,
         "pattern": "^\\S+$",
-        "description": "NAT component type registered by an installed component package."
+        "description": "NeMo Agent Toolkit component type registered by an installed component package."
       },
       "settings": {
         "type": "object",
@@ -62,7 +62,7 @@
           "_type": false
         },
         "additionalProperties": true,
-        "description": "NAT component settings; _type is derived from ref."
+        "description": "NeMo Agent Toolkit component settings; _type is derived from ref."
       }
     },
     "required": ["kind", "ref"],

--- a/external/nat/src/nemo_fabric_adapters/nat/adapter.py
+++ b/external/nat/src/nemo_fabric_adapters/nat/adapter.py
@@ -4,8 +4,8 @@
 
 """NeMo Agent Toolkit adapter for NeMo Fabric.
 
-The adapter builds one in-memory NAT configuration from Fabric's normalized
-configuration and adapter-owned NAT component settings. One persistent adapter
+The adapter builds one in-memory NeMo Agent Toolkit configuration from Fabric's
+normalized configuration and adapter-owned NeMo Agent Toolkit component settings. One persistent adapter
 host owns the resulting workflow for the complete Fabric runtime lifecycle.
 """
 
@@ -53,7 +53,7 @@ LOGGER = logging.getLogger(__name__)
 
 
 class _NatStreamSerializationError(Exception):
-    """Internal marker for a NAT chunk that cannot cross the JSON boundary."""
+    """Internal marker for a NeMo Agent Toolkit chunk that cannot cross the JSON boundary."""
 
 
 def main() -> None:
@@ -72,7 +72,7 @@ def _runtime_id(payload: dict[str, Any]) -> str:
     except ValueError as error:
         raise _config_error(
             "nat_invalid_runtime_context",
-            "NAT lifecycle payload is missing a runtime ID",
+            "NeMo Agent Toolkit lifecycle payload is missing a runtime ID",
         ) from error
 
 
@@ -81,7 +81,7 @@ def _agent_config(payload: dict[str, Any]) -> AgentConfig:
     if not isinstance(config, AgentConfig):
         raise _config_error(
             "nat_invalid_agent_config",
-            "NAT requires a validated AgentConfig start payload",
+            "NeMo Agent Toolkit requires a validated AgentConfig start payload",
         )
     return config
 
@@ -105,7 +105,7 @@ def _nat_workflow(agent_config: AgentConfig) -> dict[str, Any]:
     if entrypoint.ref != FABRIC_REACT_AGENT:
         raise _config_error(
             "nat_invalid_workflow",
-            f"NAT does not support workflow factory {entrypoint.ref!r}",
+            f"NeMo Agent Toolkit does not support workflow factory {entrypoint.ref!r}",
             field="workflow.entrypoint.ref",
         )
 
@@ -131,7 +131,7 @@ def _nat_tool_component(
     if definition.kind not in {"function", "function_group"}:
         raise _config_error(
             "nat_unsupported_tool_definition",
-            f"NAT does not support tool definition kind {definition.kind!r}",
+            f"NeMo Agent Toolkit does not support tool definition kind {definition.kind!r}",
             definition=name,
             kind=definition.kind,
         )
@@ -151,7 +151,7 @@ def _nat_component_settings(agent_config: AgentConfig) -> dict[str, Any]:
     if agent_config.harness is not None and agent_config.harness.settings:
         raise _config_error(
             "nat_invalid_harness_settings",
-            "The shared NAT adapter does not accept harness settings",
+            "The shared NeMo Agent Toolkit adapter does not accept harness settings",
             fields=sorted(agent_config.harness.settings),
         )
 
@@ -171,9 +171,10 @@ def _nat_component_settings(agent_config: AgentConfig) -> dict[str, Any]:
 
 
 def _nat_llm_type(provider: str) -> str:
-    # NAT calls NVIDIA's OpenAI-compatible provider ``nim``. Other provider
-    # identifiers are already NAT component type names and are validated after
-    # installed NAT plugins register their config objects.
+    # NeMo Agent Toolkit calls NVIDIA's OpenAI-compatible provider ``nim``. Other
+    # provider identifiers are already NeMo Agent Toolkit component type names
+    # and are validated after installed NeMo Agent Toolkit plugins register their
+    # config objects.
     return "nim" if provider == "nvidia" else provider
 
 
@@ -233,7 +234,7 @@ def _apply_system_instruction(
     if not _is_react_agent(workflow):
         raise _config_error(
             "nat_system_instruction_unsupported",
-            "instructions.system is supported only for a NAT react_agent workflow",
+            "instructions.system is supported only for a NeMo Agent Toolkit react_agent workflow",
             workflow_type=workflow.get("_type"),
         )
     if "additional_instructions" in workflow:
@@ -266,14 +267,14 @@ def _string_list(value: Any, field: str, *, optional: bool = False) -> list[str]
 
 
 def nat_mcp_server_config(name: str, server: AgentMcpServerConfig) -> dict[str, Any]:
-    """Translate one normalized MCP server into a NAT server mapping."""
+    """Translate one normalized MCP server into a NeMo Agent Toolkit server mapping."""
 
     transport = server.transport.strip().lower().replace("_", "-")
     target = os.path.expandvars(server.url).strip()
     if not target:
         raise _config_error(
             "nat_invalid_mcp_server",
-            f"NAT MCP server {name!r} requires a non-empty url",
+            f"NeMo Agent Toolkit MCP server {name!r} requires a non-empty url",
             server=name,
         )
 
@@ -294,7 +295,7 @@ def nat_mcp_server_config(name: str, server: AgentMcpServerConfig) -> dict[str, 
     if transport not in {"sse", "streamable-http"}:
         raise _config_error(
             "nat_unsupported_mcp_transport",
-            f"NAT MCP server {name!r} has unsupported transport {transport!r}",
+            f"NeMo Agent Toolkit MCP server {name!r} has unsupported transport {transport!r}",
             server=name,
             transport=transport,
         )
@@ -309,7 +310,7 @@ def _workflow_tool_names(config: dict[str, Any], reason: str) -> list[str]:
     ):
         raise _config_error(
             "nat_workflow_tools_unsupported",
-            f"{reason} requires a NAT workflow with a string-list tool_names field",
+            f"{reason} requires a NeMo Agent Toolkit workflow with a string-list tool_names field",
             field="workflow.settings.tool_names",
         )
     return tool_names
@@ -332,7 +333,7 @@ def _mcp_group(name: str, server: AgentMcpServerConfig) -> dict[str, Any] | None
         if overlap:
             raise _config_error(
                 "nat_invalid_mcp_tool_policy",
-                f"NAT MCP server {name!r} cannot both allow and block a tool",
+                f"NeMo Agent Toolkit MCP server {name!r} cannot both allow and block a tool",
                 server=name,
                 tool=overlap[0],
             )
@@ -343,7 +344,7 @@ def _mcp_group(name: str, server: AgentMcpServerConfig) -> dict[str, Any] | None
         "_type": "mcp_client",
         "server": nat_mcp_server_config(name, server),
     }
-    # NAT forbids include and exclude together. A non-empty Fabric allowlist is
+    # NeMo Agent Toolkit forbids include and exclude together. A non-empty Fabric allowlist is
     # already the effective exposed set after the disjoint blocklist is applied.
     if allowed is not None:
         group["include"] = allowed
@@ -366,7 +367,7 @@ def _apply_mcp_servers(config: dict[str, Any], agent_config: AgentConfig) -> set
         if name in functions or name in function_groups:
             raise _config_error(
                 "nat_mcp_name_conflict",
-                f"NAT MCP server {name!r} conflicts with an existing function or function group",
+                f"NeMo Agent Toolkit MCP server {name!r} conflicts with an existing function or function group",
                 server=name,
             )
 
@@ -407,7 +408,7 @@ def _group_mapping(groups: dict[str, Any], name: str) -> dict[str, Any] | None:
     if not isinstance(value, dict):
         raise _config_error(
             "nat_invalid_harness_settings",
-            f"NAT function group {name!r} must be a mapping",
+            f"NeMo Agent Toolkit function group {name!r} must be a mapping",
             group=name,
         )
     return value
@@ -416,7 +417,7 @@ def _group_mapping(groups: dict[str, Any], name: str) -> dict[str, Any] | None:
 def _unknown_tool_selector(selector: str) -> lifecycle.LifecycleError:
     return _config_error(
         "nat_unknown_tool_selector",
-        f"Fabric tool selector {selector!r} does not match a configured NAT function or function group",
+        f"Fabric tool selector {selector!r} does not match a configured NeMo Agent Toolkit function or function group",
         selector=selector,
     )
 
@@ -599,14 +600,14 @@ def _apply_tool_policy(
 
 
 def apply_nat_capabilities(config: dict[str, Any], agent_config: AgentConfig) -> None:
-    """Compile normalized MCP routing and tool policy into a raw NAT config."""
+    """Compile normalized MCP routing and tool policy into a raw NeMo Agent Toolkit config."""
 
     suppressed = _apply_mcp_servers(config, agent_config)
     _apply_tool_policy(config, agent_config, suppressed)
 
 
 def build_nat_config_mapping(agent_config: AgentConfig) -> dict[str, Any]:
-    """Build the raw in-memory NAT mapping from typed southbound config."""
+    """Build the raw in-memory NeMo Agent Toolkit mapping from typed southbound config."""
 
     config = _nat_component_settings(agent_config)
     llms = _nat_llms(agent_config)
@@ -618,7 +619,7 @@ def build_nat_config_mapping(agent_config: AgentConfig) -> dict[str, Any]:
 
 
 def build_nat_config(agent_config: AgentConfig) -> Any:
-    """Build and validate a typed NAT Config without a workflow YAML file."""
+    """Build and validate a typed NeMo Agent Toolkit Config without a workflow YAML file."""
 
     raw_config = build_nat_config_mapping(agent_config)
 
@@ -636,7 +637,7 @@ def build_nat_config(agent_config: AgentConfig) -> Any:
     except Exception as error:
         raise _config_error(
             "nat_config_translation_failed",
-            "Fabric config could not be translated into a valid NAT config",
+            "Fabric config could not be translated into a valid NeMo Agent Toolkit config",
         ) from error
 
 
@@ -645,7 +646,9 @@ def _session_kwargs(request: dict[str, Any]) -> dict[str, str]:
     if context is None:
         context = {}
     if not isinstance(context, dict):
-        raise ValueError("NAT invocation request.context must be a mapping")
+        raise ValueError(
+            "NeMo Agent Toolkit invocation request.context must be a mapping"
+        )
 
     values = {
         "user_id": context.get("user_id"),
@@ -658,7 +661,7 @@ def _session_kwargs(request: dict[str, Any]) -> dict[str, str]:
             continue
         if not isinstance(value, str) or not value:
             raise ValueError(
-                f"NAT invocation request context {name} must be a non-empty string"
+                f"NeMo Agent Toolkit invocation request context {name} must be a non-empty string"
             )
         result[name] = value
     return result
@@ -699,13 +702,13 @@ async def _close_after_failed_start(stack: AsyncExitStack) -> None:
         raise
     except Exception as error:
         LOGGER.error(
-            "NAT workflow cleanup failed after start error (error_type=%s)",
+            "NeMo Agent Toolkit workflow cleanup failed after start error (error_type=%s)",
             type(error).__name__,
         )
 
 
 class NatRuntime:
-    """One NAT WorkflowBuilder and SessionManager owned by a Fabric runtime."""
+    """One NeMo Agent Toolkit WorkflowBuilder and SessionManager owned by a Fabric runtime."""
 
     def __init__(self) -> None:
         self._runtime_id: str | None = None
@@ -721,19 +724,19 @@ class NatRuntime:
         if self._sessions is None or self._runtime_id is None:
             raise lifecycle.LifecycleError(
                 "nat_runtime_not_started",
-                "NAT runtime is not started",
+                "NeMo Agent Toolkit runtime is not started",
             )
         if _runtime_id(payload) != self._runtime_id:
             raise lifecycle.LifecycleError(
                 "nat_runtime_mismatch",
-                "NAT invocation does not match the active runtime",
+                "NeMo Agent Toolkit invocation does not match the active runtime",
             )
 
         request = common_utils.request_payload(payload)
         if not isinstance(request, dict):
             return None, _failure_output(
                 "nat_invalid_request",
-                "NAT invocation request must be a mapping",
+                "NeMo Agent Toolkit invocation request must be a mapping",
             )
         return request, None
 
@@ -741,7 +744,7 @@ class NatRuntime:
         if self._exit_stack is not None:
             raise lifecycle.LifecycleError(
                 "nat_runtime_already_started",
-                "NAT runtime is already started",
+                "NeMo Agent Toolkit runtime is already started",
             )
 
         runtime_id = _runtime_id(payload)
@@ -770,7 +773,7 @@ class NatRuntime:
             await _close_after_failed_start(stack)
             raise lifecycle.LifecycleError(
                 "nat_workflow_start_failed",
-                "NAT workflow failed to load; inspect adapter stderr for details",
+                "NeMo Agent Toolkit workflow failed to load; inspect adapter stderr for details",
             ) from error
 
         self._runtime_id = runtime_id
@@ -800,12 +803,12 @@ class NatRuntime:
             raise
         except Exception as error:
             LOGGER.error(
-                "NAT workflow invocation failed (error_type=%s)",
+                "NeMo Agent Toolkit workflow invocation failed (error_type=%s)",
                 type(error).__name__,
             )
             return _failure_output(
                 "nat_workflow_invoke_failed",
-                "NAT workflow invocation failed; inspect adapter stderr for details",
+                "NeMo Agent Toolkit workflow invocation failed; inspect adapter stderr for details",
             )
 
         try:
@@ -814,12 +817,12 @@ class NatRuntime:
             response = to_jsonable_python(result, serialize_unknown=False)
         except (TypeError, ValueError) as error:
             LOGGER.error(
-                "NAT workflow returned a non-JSON result (error_type=%s)",
+                "NeMo Agent Toolkit workflow returned a non-JSON result (error_type=%s)",
                 type(error).__name__,
             )
             return _failure_output(
                 "nat_result_not_json_serializable",
-                "NAT workflow returned a result that cannot be represented as JSON",
+                "NeMo Agent Toolkit workflow returned a result that cannot be represented as JSON",
             )
         return _success_output(response)
 
@@ -828,7 +831,7 @@ class NatRuntime:
         payload: dict[str, Any],
         emit: lifecycle.OpenAIChunkEmitter,
     ) -> dict[str, Any]:
-        """Forward one NAT result stream declared as OpenAI chunks."""
+        """Forward one NeMo Agent Toolkit result stream declared as OpenAI chunks."""
 
         request, failure = self._invocation_request(payload)
         if failure is not None:
@@ -844,18 +847,18 @@ class NatRuntime:
             )
         except Exception as error:
             LOGGER.error(
-                "NAT workflow streaming schema lookup failed (error_type=%s)",
+                "NeMo Agent Toolkit workflow streaming schema lookup failed (error_type=%s)",
                 type(error).__name__,
             )
             return _failure_output(
                 "nat_workflow_stream_failed",
-                "NAT workflow streaming failed; inspect adapter stderr for details",
+                "NeMo Agent Toolkit workflow streaming failed; inspect adapter stderr for details",
             )
 
         if streaming_output_schema is not ChatResponseChunk:
             return _failure_output(
                 "nat_openai_stream_unsupported_schema",
-                "NAT native OpenAI streaming requires a ChatResponseChunk output schema",
+                "Native NeMo Agent Toolkit OpenAI streaming requires a ChatResponseChunk output schema",
             )
 
         try:
@@ -913,7 +916,7 @@ class NatRuntime:
                             await close_stream()
                         except BaseException as error:
                             LOGGER.error(
-                                "NAT workflow stream cleanup failed while preserving "
+                                "NeMo Agent Toolkit workflow stream cleanup failed while preserving "
                                 "the primary failure (error_type=%s)",
                                 type(error).__name__,
                             )
@@ -926,21 +929,21 @@ class NatRuntime:
             raise
         except _NatStreamSerializationError as error:
             LOGGER.error(
-                "NAT workflow returned a non-JSON stream chunk (error_type=%s)",
+                "NeMo Agent Toolkit workflow returned a non-JSON stream chunk (error_type=%s)",
                 type(error.__cause__ or error).__name__,
             )
             return _failure_output(
                 "nat_stream_chunk_not_json_serializable",
-                "NAT workflow returned a stream chunk that cannot be represented as JSON",
+                "NeMo Agent Toolkit workflow returned a stream chunk that cannot be represented as JSON",
             )
         except Exception as error:
             LOGGER.error(
-                "NAT workflow streaming failed (error_type=%s)",
+                "NeMo Agent Toolkit workflow streaming failed (error_type=%s)",
                 type(error).__name__,
             )
             return _failure_output(
                 "nat_workflow_stream_failed",
-                "NAT workflow streaming failed; inspect adapter stderr for details",
+                "NeMo Agent Toolkit workflow streaming failed; inspect adapter stderr for details",
             )
 
         return _success_output("".join(response_parts))
@@ -960,7 +963,7 @@ class NatRuntime:
         except Exception as error:
             raise lifecycle.LifecycleError(
                 "nat_runtime_stop_failed",
-                "NAT runtime failed to stop cleanly",
+                "NeMo Agent Toolkit runtime failed to stop cleanly",
             ) from error
 
 

--- a/tests/adapters/test_external_nat_adapter.py
+++ b/tests/adapters/test_external_nat_adapter.py
@@ -30,7 +30,7 @@ from nemo_fabric_adapters.nat import adapter  # noqa: E402
 
 
 class _AsyncChunkStream:
-    """Small controllable async stream used to verify NAT stream ownership."""
+    """Small controllable async stream used to verify NeMo Agent Toolkit stream ownership."""
 
     def __init__(
         self,
@@ -136,7 +136,7 @@ def make_payload_fixture(tmp_path: Path):
 
 @pytest.fixture(name="mock_nat")
 def mock_nat_fixture(monkeypatch: pytest.MonkeyPatch) -> dict[str, Any]:
-    """Install mocked NAT modules and return lifecycle call recorders."""
+    """Install mocked NeMo Agent Toolkit modules and return lifecycle call recorders."""
 
     mock_typed_config = MagicMock(name="typed_nat_config")
     mock_config_type = MagicMock(name="Config")
@@ -304,7 +304,7 @@ def test_descriptor_declares_exact_source_reference_contract():
 
 
 def test_installed_nat_chat_response_chunk_serializes_to_openai_mapping():
-    """Keep the adapter serializer aligned with NAT's public chunk model."""
+    """Keep the adapter serializer aligned with the NeMo Agent Toolkit public chunk model."""
 
     api_server = pytest.importorskip("nat.data_models.api_server")
     pydantic_core = pytest.importorskip("pydantic_core")
@@ -566,11 +566,11 @@ def test_build_typed_config_contract_with_installed_nat(
 ):
     config_module = pytest.importorskip(
         "nat.data_models.config",
-        reason="NAT is not installed in the base Fabric test environment",
+        reason="NeMo Agent Toolkit is not installed in the base Fabric test environment",
     )
     pytest.importorskip(
         "nat.plugins.langchain.agent.react_agent",
-        reason="The NAT LangChain extra is not installed",
+        reason="The NeMo Agent Toolkit LangChain extra is not installed",
     )
     monkeypatch.setenv("NVIDIA_API_KEY", "test-key")
     payload = make_payload(
@@ -1058,7 +1058,7 @@ async def test_openai_stream_rejects_non_openai_schema_before_session(
     assert result["error"] == {
         "code": "nat_openai_stream_unsupported_schema",
         "message": (
-            "NAT native OpenAI streaming requires a ChatResponseChunk output schema"
+            "Native NeMo Agent Toolkit OpenAI streaming requires a ChatResponseChunk output schema"
         ),
         "retryable": False,
     }
@@ -1093,7 +1093,7 @@ async def test_openai_stream_normalizes_partial_nat_failure_without_leaking_caus
 
     assert result["error"] == {
         "code": "nat_workflow_stream_failed",
-        "message": "NAT workflow streaming failed; inspect adapter stderr for details",
+        "message": "NeMo Agent Toolkit workflow streaming failed; inspect adapter stderr for details",
         "retryable": False,
     }
     emit.assert_awaited_once_with(chunk)
@@ -1139,7 +1139,7 @@ async def test_openai_stream_normalizes_chunk_serialization_failure(
     assert result["error"] == {
         "code": "nat_stream_chunk_not_json_serializable",
         "message": (
-            "NAT workflow returned a stream chunk that cannot be represented as JSON"
+            "NeMo Agent Toolkit workflow returned a stream chunk that cannot be represented as JSON"
         ),
         "retryable": False,
     }
@@ -1210,7 +1210,7 @@ async def test_start_rejects_an_already_started_runtime(make_payload, mock_nat):
         await runtime.stop()
 
     assert error.value.code == "nat_runtime_already_started"
-    assert error.value.message == "NAT runtime is already started"
+    assert error.value.message == "NeMo Agent Toolkit runtime is already started"
     mock_nat["workflow_builder"].from_config.assert_called_once()
 
 
@@ -1238,7 +1238,7 @@ async def test_invoke_rejects_a_runtime_that_has_not_started(
         await runtime.invoke(make_invocation_payload())
 
     assert error.value.code == "nat_runtime_not_started"
-    assert error.value.message == "NAT runtime is not started"
+    assert error.value.message == "NeMo Agent Toolkit runtime is not started"
 
 
 async def test_invoke_rejects_a_different_runtime_id(
@@ -1255,7 +1255,10 @@ async def test_invoke_rejects_a_different_runtime_id(
         await runtime.stop()
 
     assert error.value.code == "nat_runtime_mismatch"
-    assert error.value.message == "NAT invocation does not match the active runtime"
+    assert (
+        error.value.message
+        == "NeMo Agent Toolkit invocation does not match the active runtime"
+    )
     mock_nat["sessions"].session.assert_not_called()
 
 
@@ -1275,7 +1278,7 @@ async def test_invoke_normalizes_a_non_mapping_request(
 
     assert result["error"] == {
         "code": "nat_invalid_request",
-        "message": "NAT invocation request must be a mapping",
+        "message": "NeMo Agent Toolkit invocation request must be a mapping",
         "retryable": False,
     }
     mock_nat["sessions"].session.assert_not_called()
@@ -1297,7 +1300,7 @@ async def test_invoke_normalizes_a_non_mapping_request_context(
 
     assert result["error"] == {
         "code": "nat_invalid_request",
-        "message": "NAT invocation request.context must be a mapping",
+        "message": "NeMo Agent Toolkit invocation request.context must be a mapping",
         "retryable": False,
     }
     mock_nat["sessions"].session.assert_not_called()
@@ -1337,7 +1340,7 @@ def test_config_translation_failure_is_normalized_and_redacts_cause(
 
     assert error.value.code == "nat_config_translation_failed"
     assert error.value.message == (
-        "Fabric config could not be translated into a valid NAT config"
+        "Fabric config could not be translated into a valid NeMo Agent Toolkit config"
     )
     assert "super-secret" not in str(error.value)
 
@@ -1354,7 +1357,7 @@ async def test_stop_failure_clears_runtime_state_and_redacts_cause(
         await runtime.stop()
 
     assert error.value.code == "nat_runtime_stop_failed"
-    assert error.value.message == "NAT runtime failed to stop cleanly"
+    assert error.value.message == "NeMo Agent Toolkit runtime failed to stop cleanly"
     assert "super-secret" not in str(error.value)
     mock_nat["sessions"].shutdown.assert_awaited_once_with()
     assert mock_nat["builder_context"].__aexit__.await_count == 1
@@ -1384,7 +1387,7 @@ async def test_invoke_failure_is_normalized_and_redacts_cause(
     assert result["response"] is None
     assert result["error"] == {
         "code": "nat_workflow_invoke_failed",
-        "message": "NAT workflow invocation failed; inspect adapter stderr for details",
+        "message": "NeMo Agent Toolkit workflow invocation failed; inspect adapter stderr for details",
         "retryable": False,
     }
     assert "super-secret" not in json.dumps(result)
@@ -1408,7 +1411,7 @@ async def test_non_json_result_is_normalized_without_value_leak(
 
     assert result["error"] == {
         "code": "nat_result_not_json_serializable",
-        "message": "NAT workflow returned a result that cannot be represented as JSON",
+        "message": "NeMo Agent Toolkit workflow returned a result that cannot be represented as JSON",
         "retryable": False,
     }
     assert "secret-object-repr" not in json.dumps(result)
@@ -1486,7 +1489,7 @@ def test_mcp_stdio_rejects_a_whitespace_only_command():
 
     assert error.value.code == "nat_invalid_mcp_server"
     assert error.value.message == (
-        "NAT MCP server 'calculator' requires a non-empty url"
+        "NeMo Agent Toolkit MCP server 'calculator' requires a non-empty url"
     )
 
 


### PR DESCRIPTION
#### Overview

Replace the standalone `NAT` abbreviation with `NeMo Agent Toolkit` across the reference adapter documentation and user-facing text. This avoids conflating NeMo Agent Toolkit with NVIDIA Agent Toolkit.

Lowercase `nat` identifiers remain unchanged in package names, imports, paths, adapter IDs, symbols, and error codes. There are no API or package-name changes.

#### Details

- Rename the reference adapter heading, prose, table labels, and cross-links.
- Update related custom-agent documentation, descriptor descriptions, examples, docstrings, comments, and user-visible error messages.
- Update exact error-message assertions while preserving stable error codes.

#### Validation

- `uv run pytest tests/adapters/test_external_nat_adapter.py` — 58 passed, 2 skipped.
- `just test-python` — 1185 passed, 18 skipped.
- `RUSTUP_TOOLCHAIN=1.94.0 just docs` — passed; the unauthenticated Fern redirect check was skipped with one warning.
- `uv run --group dev pre-commit run --files ...` — all applicable hooks passed.
- Repository-wide terminology scan found no remaining standalone `NAT`, `NVIDIA Agent Toolkit`, or `NVIDIA NeMo Agent Toolkit` text.

#### Where should the reviewer start?

Start with `external/nat/README.md`, then review `external/nat/src/nemo_fabric_adapters/nat/adapter.py` for the corresponding user-visible message updates.

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- Relates to: none

- [x] I confirm this contribution is my own work, or I have the right to submit it under this project license.
- [x] I searched existing issues and open pull requests, and this does not duplicate existing work.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated references from “NAT” to “NeMo Agent Toolkit” across adapter guides, examples, configuration descriptions, and external adapter documentation.
  * Improved terminology consistency in setup instructions, workflow descriptions, tool settings, and error messages.

* **Tests**
  * Updated test descriptions, skip reasons, and expected messages to use the new terminology.

* **Bug Fixes**
  * No functional behavior changes; adapter workflows and runtime behavior remain unchanged.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->