### PR TITLE
fix: preserve explicit empty tool policy

### DIFF
--- a/sdk/python/nemo-fabric-runtime/src/nemo_fabric/models.py
+++ b/sdk/python/nemo-fabric-runtime/src/nemo_fabric/models.py
@@ -969,6 +969,14 @@ class ToolsConfig(FabricBaseModel):
                 raise ValueError(f"tool {name!r} cannot be both enabled and blocked")
         return self
 
+    def to_mapping(self) -> dict[str, Any]:
+        """Return the tool mapping without collapsing an explicit empty policy."""
+
+        data = super().to_mapping()
+        if self.enabled == []:
+            data["enabled"] = []
+        return data
+
     def add_definition(
         self,
         name: str,

--- a/tests/python/test_sdk_contract.py
+++ b/tests/python/test_sdk_contract.py
@@ -583,6 +583,20 @@ def test_typed_tools_config_serializes_blocked_policy():
     assert config.to_mapping()["tools"] == {"blocked": ["browser", "shell"]}
 
 
+@pytest.mark.parametrize(
+    ("enabled", "expected"),
+    [
+        (None, {}),
+        ([], {"enabled": []}),
+    ],
+)
+def test_typed_tools_config_preserves_explicit_empty_policy(
+    enabled: list[str] | None,
+    expected: dict[str, object],
+):
+    assert ToolsConfig(enabled=enabled).to_mapping() == expected
+
+
 def test_typed_config_serializes_normalized_execution_fields():
     config = FabricConfig(
         metadata=MetadataConfig(name="demo"),


### PR DESCRIPTION
#### Overview

Preserve the semantic distinction between an unspecified tool policy and an explicitly empty tool policy when serializing `ToolsConfig` directly.

Before this change, `ToolsConfig(enabled=[]).to_mapping()` returned `{}`, which changed an explicit expose-no-tools policy into harness-default behavior. `enabled=None` remains omitted. There are no breaking changes, dependency changes, schema changes, or generated artifacts.

#### Details

- Add a `ToolsConfig.to_mapping()` override that restores `enabled: []` after the shared empty-value filter runs.
- Keep the fix local to `ToolsConfig`; unrelated SDK models retain their current empty-value behavior.
- Add parameterized regression coverage for both `None` and `[]`.
- Retain existing coverage showing nested `FabricConfig` serialization preserves `enabled: []`.

#### Validation

- `uv run --no-sync pytest tests/python/test_sdk_contract.py::test_typed_tools_config_preserves_explicit_empty_policy tests/python/test_sdk_contract.py::test_typed_config_serializes_normalized_execution_fields` (`3 passed`)
- `just test-python` (`1200 passed, 18 skipped`)
- `uvx --from pre-commit pre-commit run --files sdk/python/nemo-fabric-runtime/src/nemo_fabric/models.py tests/python/test_sdk_contract.py`
- `git diff --check`

#### Where should the reviewer start?

Start with `ToolsConfig.to_mapping()` in `sdk/python/nemo-fabric-runtime/src/nemo_fabric/models.py`, then review the two-case regression test in `tests/python/test_sdk_contract.py`.

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- Closes [FABRIC-210](https://linear.app/nvidia/issue/FABRIC-210/preserve-explicit-empty-tool-policy-during-sdk-serialization)

- [x] I confirm this contribution is my own work, or I have the right to submit it under this project license.
- [x] I searched existing issues and open pull requests, and this does not duplicate existing work.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Preserved an explicitly configured empty tools list when settings are serialized.
  * Continued omitting the tools setting when it has not been configured.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->