### PR TITLE
ci: isolate docs dependency sync

### DIFF
--- a/justfile
+++ b/justfile
@@ -409,7 +409,7 @@ docs:
     #!/usr/bin/env bash
     set -euo pipefail
     if [[ "{{ no_uv }}" != "true" ]]; then
-        uv sync --group docs
+        uv sync --frozen --no-default-groups --group docs
     fi
     npm ci --prefix docs --ignore-scripts
     PATH="{{ REPO_ROOT }}/.venv/bin:$PATH" bash scripts/generate_api_docs.sh


### PR DESCRIPTION
#### Overview

Make the docs recipe install only the locked documentation dependency group. This prevents docs builds from resolving the default adapter group and requiring the optional `external/hermes-agent` checkout.

#### Details

- Add `--frozen` so uv consumes the committed lockfile without resolving the absent editable Hermes source.
- Add `--no-default-groups` so docs builds do not install adapter and test dependencies.
- Keep the fix in the shared `just docs` recipe so preview, post-merge, release, and local docs builds use the same behavior.

#### Validation

- Reproduced the merged-main failure with `just docs` in a pristine worktree.
- Ran `just docs` successfully from a clean checkout with no `external/hermes-agent` directory.
- Ran `just --set no_uv true docs` successfully as a final generation and Fern validation pass.
- Ran `just --fmt --check` and `git diff --check`.
- Fern reported only the expected unauthenticated missing-redirects warning because no `FERN_TOKEN` was supplied locally.

#### Where should the reviewer start?

`justfile`: the `docs` recipe dependency sync.

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- Relates to: #234

- [x] I confirm this contribution is my own work, or I have the right to submit it under this project's license.
- [x] I searched existing issues and open pull requests, and this does not duplicate existing work.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated documentation setup to use a locked dependency configuration, improving consistency and reproducibility when installing documentation dependencies.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->