### PR TITLE
docs: align adapter contract package readmes

### DIFF
--- a/adapter-contract/python/README.md
+++ b/adapter-contract/python/README.md
@@ -1,0 +1,53 @@
+<!--
+SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+SPDX-License-Identifier: Apache-2.0
+-->
+
+# NVIDIA NeMo Fabric Adapter Contract
+
+[![License](https://img.shields.io/github/license/NVIDIA/NeMo-Fabric)](https://github.com/NVIDIA/NeMo-Fabric/blob/main/LICENSE)
+[![GitHub](https://img.shields.io/badge/github-repo-blue?logo=github)](https://github.com/NVIDIA/NeMo-Fabric/)
+[![Release](https://img.shields.io/github/v/release/NVIDIA/NeMo-Fabric?color=green)](https://github.com/NVIDIA/NeMo-Fabric/releases)
+
+![Diagram showing NeMo Fabric connecting applications, evaluations, and reinforcement learning rollouts to Hermes, Codex, Claude, and Deep Agents, with results, artifacts, and telemetry as outputs.](https://raw.githubusercontent.com/NVIDIA/NeMo-Fabric/refs/heads/main/assets/fabric-hero-option2.png)
+
+`nemo-fabric-adapter-contract` provides the typed Python configuration and
+execution contract implemented by NeMo Fabric adapters. It does not include a
+lifecycle host, harness integration, or NeMo Relay integration.
+
+Python adapters can use the package's standard-library dataclasses without an
+additional runtime dependency. Adapters in other languages can consume the JSON
+Schemas published by NeMo Fabric without a Python package dependency.
+
+The dataclasses provide strict `from_mapping()` validation and JSON-compatible
+`to_mapping()` serialization. Install the optional `pydantic` extra when an
+adapter uses Pydantic models for typed extensions or wants Pydantic
+interoperability. Both paths use the same contract dataclasses.
+
+Import `AgentConfig` from the contract models module:
+
+```python
+from nemo_fabric_adapter_contract.models import AgentConfig
+```
+
+An adapter descriptor opts into the southbound configuration with
+`config.input=agent_config`. Python adapters using the optional common
+lifecycle host pass `AgentConfig.from_mapping` as the `config_loader`.
+
+## Install
+
+Install the package directly when developing a Python adapter:
+
+```bash
+pip install nemo-fabric-adapter-contract
+```
+
+Install the optional `pydantic` extra to enable Pydantic interoperability.
+
+```bash
+pip install "nemo-fabric-adapter-contract[pydantic]"
+```
+
+Refer to the [NeMo Fabric documentation](https://docs.nvidia.com/nemo/fabric)
+for adapter and configuration guidance. Source code is available in the
+[NVIDIA NeMo Fabric repository](https://github.com/NVIDIA/NeMo-Fabric).

--- a/adapter-contract/python/README.md
+++ b/adapter-contract/python/README.md
@@ -5,12 +5,6 @@ SPDX-License-Identifier: Apache-2.0
 
 # NVIDIA NeMo Fabric Adapter Contract
 
-[![License](https://img.shields.io/github/license/NVIDIA/NeMo-Fabric)](https://github.com/NVIDIA/NeMo-Fabric/blob/main/LICENSE)
-[![GitHub](https://img.shields.io/badge/github-repo-blue?logo=github)](https://github.com/NVIDIA/NeMo-Fabric/)
-[![Release](https://img.shields.io/github/v/release/NVIDIA/NeMo-Fabric?color=green)](https://github.com/NVIDIA/NeMo-Fabric/releases)
-
-![Diagram showing NeMo Fabric connecting applications, evaluations, and reinforcement learning rollouts to Hermes, Codex, Claude, and Deep Agents, with results, artifacts, and telemetry as outputs.](https://raw.githubusercontent.com/NVIDIA/NeMo-Fabric/refs/heads/main/assets/fabric-hero-option2.png)
-
 `nemo-fabric-adapter-contract` provides the typed Python configuration and
 execution contract implemented by NeMo Fabric adapters. It does not include a
 lifecycle host, harness integration, or NeMo Relay integration.

--- a/adapter-contract/typescript/README.md
+++ b/adapter-contract/typescript/README.md
@@ -3,7 +3,7 @@ SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All
 SPDX-License-Identifier: Apache-2.0
 -->
 
-# NVIDIA NeMo Fabric Adapter Contract for TypeScript
+# NVIDIA NeMo Fabric Adapter Contract
 
 Dependency-free TypeScript types for implementing adapters against the NVIDIA
 NeMo Fabric adapter contract. The package is generated from the versioned JSON


### PR DESCRIPTION
#### Overview

Align the adapter-contract package README titles and add the missing repository-facing README for the Python package.

#### Details

- add `adapter-contract/python/README.md` with package content from `pypi.md`, excluding PyPI-only badges and the hero image;
- use the shared `NVIDIA NeMo Fabric Adapter Contract` title in the TypeScript package README.

This is documentation-only and does not change package metadata or runtime behavior.

#### Validation

- `/Users/athorve/Dev/mdemoret-team/nemo-fabric/.venv/bin/pre-commit run --files adapter-contract/python/README.md adapter-contract/typescript/README.md`
- `sed 8,13d adapter-contract/python/pypi.md | cmp - adapter-contract/python/README.md`
- `git diff --check`

`just docs` was not run because no Fern docs or generated API references changed.

#### Where should the reviewer start?

Start with `adapter-contract/python/README.md`, then confirm the shared title in `adapter-contract/typescript/README.md`.

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- Relates to: none

- [x] I confirm this contribution is my own work, or I have the right to submit it under this project's license.
- [x] I searched existing issues and open pull requests, and this does not duplicate existing work.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive Python package documentation covering contract usage, validation, serialization, configuration, installation, and interoperability.
  * Simplified the TypeScript package README title for consistency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
