### PR TITLE
ci: exclude generated skill artifacts from checks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,9 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
+# Generated agent-skill artifacts are managed independently and must not trigger repository checks.
+exclude: '^skills/[^/]+/(?:BENCHMARK\.md|skill-card\.md|skill\.oms\.sig)$'
+
 repos:
   # SPDX copyright header check
   - repo: local


### PR DESCRIPTION
#### Overview

Exclude generated skill artifacts from repository pre-commit hooks. These files are generated, benchmarked, signed, and managed independently, so repository hooks should not modify them.

Only `BENCHMARK.md`, `skill-card.md`, and `skill.oms.sig` immediately below a skill directory are skipped. Normal skill source and reference files remain checked.

#### Where should reviewer start?

`.pre-commit-config.yaml`

#### Validation

- `copyright-header --all-files` passes with the generated artifacts excluded
- `ruff`, `actionlint`, Cargo lock, and attribution checks passed during the partial local pre-commit run
- Remaining validation is delegated to PR CI

#### Related Issues

- Relates to #232

- [x] I am willing to contribute a fix for this issue
- [x] I am willing to contribute tests for this issue


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Excluded generated agent-skill artifact files from pre-commit repository checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->