### PR TITLE
feat: add Relay telemetry to mini-SWE-agent

### DIFF
--- a/adapters/README.md
+++ b/adapters/README.md
@@ -133,11 +133,11 @@ and additive extension maps because their support does not vary by adapter:
 | `skills.paths` | Yes | Yes | Yes | Yes | No | Yes |
 | `mcp.servers.<name>.transport`, `.url` with `harness_native` exposure | Yes | Yes | Yes | Yes | No | No |
 | `mcp.servers.<name>.exposure = "fabric_managed"` | No; not implemented | No; not implemented | No; not implemented | No; not implemented | No | No |
-| `telemetry.providers.relay` | Yes | Yes | Yes | Yes | No | No |
+| `telemetry.providers.relay` | Yes | Yes | Yes | Yes | Yes | No |
 | `telemetry.providers.native` | No | Yes; OpenTelemetry | Yes; OpenTelemetry and OpenInference | No | No | No |
-| `telemetry.providers.<provider>.config` | Declared-provider pass-through | Declared-provider pass-through | Declared-provider pass-through | Declared-provider pass-through | No | No |
-| `relay.project`, `.output_dir`, `.observability` | Yes | Yes | Yes | Yes | No | No |
-| `relay.components`, `.policy` | Yes | Yes | Yes | Yes | No | No |
+| `telemetry.providers.<provider>.config` | Declared-provider pass-through | Declared-provider pass-through | Declared-provider pass-through | Declared-provider pass-through | Declared-provider pass-through | No |
+| `relay.project`, `.output_dir`, `.observability` | Yes | Yes | Yes | Yes | Yes | No |
+| `relay.components`, `.policy` | Yes | Yes | Yes | Yes | Yes | No |
 | Additive `extensions` on typed config objects | Preserved; no portable adapter semantics | Preserved; no portable adapter semantics | Preserved; no portable adapter semantics | Preserved; no portable adapter semantics | Preserved; no portable adapter semantics | Not accepted unless declared by the Pi descriptor |
 
 The selected model role is `default`, or the sole configured role when no
@@ -166,14 +166,13 @@ and produces normalized trajectories in Agent Trajectory Interchange Format
 | [Codex](codex/README.md) | `AsyncCodex` app-server client and SDK thread | Runtime-owned Relay CLI gateway and Codex SDK hooks | Reuses the SDK thread and persists its thread ID | Closes the SDK client and app server, then stops the gateway | Not implemented |
 | [LangChain Deep Agents](deepagents/README.md) | Compiled LangGraph agent, checkpointer, and thread ID | NeMo Relay Python SDK integration added when the agent is compiled | Creates a fresh Relay request scope and callback for each invocation | Closes the checkpointer; no gateway process | Not implemented |
 | [Hermes Agent](hermes/README.md) | `AIAgent`, `SessionDB`, and conversation history | Hermes Agent NeMo Relay plugin context | Finalizes and flushes Relay after each invocation | Closes the agent and database, then exits the plugin context | Not implemented |
-| [mini-SWE-agent](mini-swe-agent/README.md) | Conversation history | Not supported | Not applicable | Not applicable | Not implemented |
+| [mini-SWE-agent](mini-swe-agent/README.md) | Conversation history | Adapter-owned subclass with NeMo Relay Python SDK scopes | Creates a fresh Relay plugin and request scope, emits step, model, and bash-action telemetry, and collects artifacts | Clears the agent and Relay state | Not implemented |
 | [Pi](typescript/pi/README.md) | In-memory Pi `AgentSession` | Not supported | Reuses the session and calls `prompt()` for ordered text input | Aborts work, emits extension shutdown, and disposes the session | Not implemented |
 
-Telemetry output names use the descriptor contract values. Claude, Codex, and
-Hermes Agent can emit NeMo Relay ATIF, OpenTelemetry, and OpenInference output. Deep
-Agents supports the same Relay outputs plus native OpenTelemetry and
-OpenInference; Codex also supports native OpenTelemetry. mini-SWE-agent does
-not support telemetry output.
+Telemetry output names use the descriptor contract values. Claude, Codex,
+Hermes Agent, and mini-SWE-agent can emit NeMo Relay ATIF, OpenTelemetry, and
+OpenInference output. Deep Agents supports the same Relay outputs plus native
+OpenTelemetry and OpenInference; Codex also supports native OpenTelemetry.
 
 Shared lifecycle, Relay gateway, hook, and payload helpers are documented in
 the [adapter utilities guide](common/README.md).

--- a/adapters/mini-swe-agent/README.md
+++ b/adapters/mini-swe-agent/README.md
@@ -158,7 +158,7 @@ request and invocation IDs as Relay metadata:
 | `invocation_id` | `nemo_fabric_invocation_id` | Identifies one concrete invocation attempt. NeMo Fabric assigns a new value to each invocation. |
 
 Nested step, LLM, and `bash` tool events are correlated through the Relay scope
-hierarchy; they do not repeat these metadata fields. The runtime's `runtime_id`
+hierarchy; they do not repeat these metadata fields. The `runtime_id`
 identifies the longer-lived retained runtime that can process multiple
 invocations, but the mini-SWE-agent adapter does not currently add it to Relay
 scope metadata.

--- a/adapters/mini-swe-agent/README.md
+++ b/adapters/mini-swe-agent/README.md
@@ -10,12 +10,14 @@ NVIDIA NeMo Fabric.
 
 ## Install
 
-| Installation | Runtime | Adapter | Harness |
-| --- | --- | --- | --- |
-| `pip install "nemo-fabric[mini-swe-agent]"` | Yes | Yes | Yes |
-| `pip install "nemo-fabric-adapters-mini-swe-agent[harness]"` | No | Yes | Yes |
-| `pip install "nemo-fabric-adapters-mini-swe-agent[full]"` | No | Yes | Yes |
-| `pip install nemo-fabric-adapters-mini-swe-agent` | No | Yes | No |
+| Installation | Runtime | Adapter | Harness | Relay Python |
+| --- | --- | --- | --- | --- |
+| `pip install "nemo-fabric[mini-swe-agent]"` | Yes | Yes | Yes | No |
+| `pip install "nemo-fabric[mini-swe-agent,relay]"` | Yes | Yes | Yes | Yes |
+| `pip install "nemo-fabric-adapters-mini-swe-agent[harness]"` | No | Yes | Yes | No |
+| `pip install "nemo-fabric-adapters-mini-swe-agent[relay]"` | No | Yes | No | Yes |
+| `pip install "nemo-fabric-adapters-mini-swe-agent[full]"` | No | Yes | Yes | Yes |
+| `pip install nemo-fabric-adapters-mini-swe-agent` | No | Yes | No | No |
 
 The `harness` and `full` extras install the latest compatible mini-SWE-agent
 2.x release.
@@ -30,7 +32,7 @@ default is `30` seconds.
 
 Set `models.<role>.api_key_env` to the environment variable containing the
 model-provider credential. This adapter does not support MCP, skills, tool
-policy, streaming, or telemetry output.
+policy, or native OpenAI streaming.
 
 ```python
 import asyncio
@@ -71,3 +73,26 @@ result = asyncio.run(main())
 ```
 
 The result includes the submitted final text and API-call usage.
+
+## Relay Telemetry
+
+When Relay is enabled, the adapter uses a Relay-specific mini-SWE-agent subclass
+to emit an Agent scope for each invocation, Function scopes for agent steps,
+and LLM and tool events for model queries and bash actions. Relay is imported
+and the subclass is selected only for Relay-enabled runtimes; otherwise the
+adapter uses the existing retaining agent without Relay instrumentation.
+
+Install both the harness and Relay, then enable Relay on the configuration:
+
+```bash
+pip install "nemo-fabric[mini-swe-agent,relay]"
+```
+
+```python
+config.enable_relay()
+```
+
+Relay-enabled runs support configured ATOF and ATIF outputs and live ATOF
+records through `Runtime.invoke_stream()`. Live telemetry uses ordinary
+adapter `invoke()` and is independent of native OpenAI streaming, so the
+adapter's `capabilities.streaming` value remains `false`.

--- a/adapters/mini-swe-agent/README.md
+++ b/adapters/mini-swe-agent/README.md
@@ -147,6 +147,22 @@ subclass explicitly emits nested step, LLM, and `bash` tool events using Relay
 handles. This produces a correlated Agent, Function, LLM, and tool scope
 hierarchy without requiring upstream changes.
 
+### Correlation IDs
+
+The top-level `mini-swe-agent.request` Agent scope stores the NeMo Fabric
+request and invocation IDs as Relay metadata:
+
+| NeMo Fabric ID | Relay metadata key | Meaning |
+| --- | --- | --- |
+| `request_id` | `nemo_fabric_request_id` | Correlates the caller's logical request. A caller can provide the same value when it wants to correlate retries or related processing. |
+| `invocation_id` | `nemo_fabric_invocation_id` | Identifies one concrete invocation attempt. NeMo Fabric assigns a new value to each invocation. |
+
+Nested step, LLM, and `bash` tool events are correlated through the Relay scope
+hierarchy; they do not repeat these metadata fields. The runtime's `runtime_id`
+identifies the longer-lived retained runtime that can process multiple
+invocations, but the mini-SWE-agent adapter does not currently add it to Relay
+scope metadata.
+
 Install both the harness and Relay:
 
 ```bash
@@ -159,7 +175,7 @@ Enable Relay on the configuration:
 config.enable_relay()
 ```
 
-Relay-enabled runs support configured ATOF and ATIF outputs and live ATOF
-records through `Runtime.invoke_stream()`. Live telemetry uses ordinary
-adapter `invoke()` and is independent of native OpenAI streaming, so the
-adapter's `capabilities.streaming` value remains `false`.
+Relay-enabled runs support configured ATIF, OpenTelemetry, and OpenInference
+outputs. `Runtime.invoke_stream()` also provides live ATOF records. Live
+telemetry uses ordinary adapter `invoke()` and is independent of native OpenAI
+streaming, so the adapter's `capabilities.streaming` value remains `false`.

--- a/adapters/mini-swe-agent/README.md
+++ b/adapters/mini-swe-agent/README.md
@@ -10,6 +10,9 @@ NVIDIA NeMo Fabric.
 
 ## Install
 
+Choose an installation option based on the components required in the target
+environment:
+
 | Installation | Runtime | Adapter | Harness | Relay Python |
 | --- | --- | --- | --- | --- |
 | `pip install "nemo-fabric[mini-swe-agent]"` | Yes | Yes | Yes | No |
@@ -82,11 +85,13 @@ and LLM and tool events for model queries and bash actions. Relay is imported
 and the subclass is selected only for Relay-enabled runtimes; otherwise the
 adapter uses the existing retaining agent without Relay instrumentation.
 
-Install both the harness and Relay, then enable Relay on the configuration:
+Install both the harness and Relay:
 
 ```bash
 pip install "nemo-fabric[mini-swe-agent,relay]"
 ```
+
+Enable Relay on the configuration:
 
 ```python
 config.enable_relay()

--- a/adapters/mini-swe-agent/README.md
+++ b/adapters/mini-swe-agent/README.md
@@ -77,6 +77,62 @@ result = asyncio.run(main())
 
 The result includes the submitted final text and API-call usage.
 
+## Continue a Task Across Invocations
+
+Use one runtime for ordered invocations that should share mini-SWE-agent
+conversation history:
+
+```python
+async def continue_task():
+    async with await Fabric().start_runtime(
+        config,
+        base_dir="/workspace",
+    ) as runtime:
+        first = await runtime.invoke(
+            input="Inspect calculator.py and identify the bug."
+        )
+        second = await runtime.invoke(input="Fix it and run the tests.")
+    return first, second
+```
+
+For example, the first invocation can produce this conversation:
+
+```text
+system: You are a coding agent.
+user: Inspect calculator.py and identify the bug.
+assistant: I will inspect the file.
+assistant action: bash {"command": "cat calculator.py"}
+tool: def divide(a, b): return a // b
+assistant: The divide function uses // instead of /.
+assistant action: bash {"command": "printf 'COMPLETE_TASK_AND_SUBMIT_FINAL_OUTPUT\\nThe divide function uses integer division.\\n'"}
+tool: COMPLETE_TASK_AND_SUBMIT_FINAL_OUTPUT
+      The divide function uses integer division.
+exit: Submitted
+```
+
+Before the second model call, the adapter removes the terminal `exit` message
+and appends the new input. The retained context resembles the following
+conversation:
+
+```text
+system: You are a coding agent.
+user: Inspect calculator.py and identify the bug.
+assistant: I will inspect the file.
+assistant action: bash {"command": "cat calculator.py"}
+tool: def divide(a, b): return a // b
+assistant: The divide function uses // instead of /.
+assistant action: bash {"command": "printf 'COMPLETE_TASK_AND_SUBMIT_FINAL_OUTPUT\\nThe divide function uses integer division.\\n'"}
+tool: COMPLETE_TASK_AND_SUBMIT_FINAL_OUTPUT
+      The divide function uses integer division.
+user: Fix it and run the tests.
+```
+
+Assistant messages and output from commands executed through the `bash` tool
+are part of the retained model context. Unrelated terminal output is not
+retained. History lasts only for the same runtime and is discarded when the
+runtime stops. The adapter does not currently truncate or summarize retained
+history, so repeated invocations can increase model context usage.
+
 ## Relay Telemetry
 
 When Relay is enabled, the adapter uses a Relay-specific mini-SWE-agent subclass

--- a/adapters/mini-swe-agent/README.md
+++ b/adapters/mini-swe-agent/README.md
@@ -141,6 +141,12 @@ and LLM and tool events for model queries and bash actions. Relay is imported
 and the subclass is selected only for Relay-enabled runtimes; otherwise the
 adapter uses the existing retaining agent without Relay instrumentation.
 
+The adapter wraps each invocation with `nemo_relay.scope.scope(...)`. Because
+mini-SWE-agent does not provide native observability hooks, the adapter-owned
+subclass explicitly emits nested step, LLM, and `bash` tool events using Relay
+handles. This produces a correlated Agent, Function, LLM, and tool scope
+hierarchy without requiring upstream changes.
+
 Install both the harness and Relay:
 
 ```bash

--- a/adapters/mini-swe-agent/README.md
+++ b/adapters/mini-swe-agent/README.md
@@ -137,7 +137,7 @@ history, so repeated invocations can increase model context usage.
 
 When Relay is enabled, the adapter uses a Relay-specific mini-SWE-agent subclass
 to emit an Agent scope for each invocation, Function scopes for agent steps,
-and LLM and tool events for model queries and bash actions. Relay is imported
+and LLM and tool events for model queries and `bash` actions. Relay is imported
 and the subclass is selected only for Relay-enabled runtimes; otherwise the
 adapter uses the existing retaining agent without Relay instrumentation.
 

--- a/adapters/mini-swe-agent/mini-swe-agent.fabric-adapter.json
+++ b/adapters/mini-swe-agent/mini-swe-agent.fabric-adapter.json
@@ -51,5 +51,12 @@
     "streaming": false,
     "updates": false,
     "cancellation": false
+  },
+  "telemetry": {
+    "providers": {
+      "relay": {
+        "outputs": ["atif", "otel", "openinference"]
+      }
+    }
   }
 }

--- a/adapters/mini-swe-agent/pypi.md
+++ b/adapters/mini-swe-agent/pypi.md
@@ -16,12 +16,18 @@ adapter contract into mini-SWE-agent's native shell-only execution loop.
 
 The following table shows which components each installation provides:
 
-| Installation | Runtime | Adapter | Harness |
-| --- | --- | --- | --- |
-| `pip install "nemo-fabric[mini-swe-agent]"` | Yes | Yes | Yes |
-| `pip install "nemo-fabric-adapters-mini-swe-agent[harness]"` | No | Yes | Yes |
-| `pip install "nemo-fabric-adapters-mini-swe-agent[full]"` | No | Yes | Yes |
-| `pip install nemo-fabric-adapters-mini-swe-agent` | No | Yes | No |
+| Installation | Runtime | Adapter | Harness | Relay Python |
+| --- | --- | --- | --- | --- |
+| `pip install "nemo-fabric[mini-swe-agent]"` | Yes | Yes | Yes | No |
+| `pip install "nemo-fabric[mini-swe-agent,relay]"` | Yes | Yes | Yes | Yes |
+| `pip install "nemo-fabric-adapters-mini-swe-agent[harness]"` | No | Yes | Yes | No |
+| `pip install "nemo-fabric-adapters-mini-swe-agent[relay]"` | No | Yes | No | Yes |
+| `pip install "nemo-fabric-adapters-mini-swe-agent[full]"` | No | Yes | Yes | Yes |
+| `pip install nemo-fabric-adapters-mini-swe-agent` | No | Yes | No | No |
+
+The optional Relay integration emits live model, tool, step, and invocation
+telemetry and supports Relay-backed ATOF streaming. It does not enable native
+OpenAI token streaming.
 
 For configuration and behavior, see the
 [mini-SWE-agent adapter README](https://github.com/NVIDIA/NeMo-Fabric/tree/main/adapters/mini-swe-agent/README.md).

--- a/adapters/mini-swe-agent/pyproject.toml
+++ b/adapters/mini-swe-agent/pyproject.toml
@@ -33,8 +33,12 @@ dependencies = [
 harness = [
   "mini-swe-agent>=2.0,<3",
 ]
+relay = [
+  "nemo-relay>=0.7.2,<0.8",
+]
 full = [
   "mini-swe-agent>=2.0,<3",
+  "nemo-relay>=0.7.2,<0.8",
 ]
 
 [project.urls]

--- a/adapters/mini-swe-agent/src/nemo_fabric_adapters/mini_swe_agent/adapter.py
+++ b/adapters/mini-swe-agent/src/nemo_fabric_adapters/mini_swe_agent/adapter.py
@@ -5,21 +5,26 @@
 from __future__ import annotations
 
 import asyncio
+import importlib.util
 import json
 import os
 from typing import Any
 
 from nemo_fabric_adapter_contract import models as contract
 from nemo_fabric_adapters.common import lifecycle
+from nemo_fabric_adapters.common import utils as common_utils
 
 SYSTEM_TEMPLATE = "{{system_instruction}}"
 INSTANCE_TEMPLATE = """Solve this task in the current workspace:
 
 {{task}}
 
-Use the bash tool. When complete, run
-`echo COMPLETE_TASK_AND_SUBMIT_FINAL_OUTPUT` by itself, then provide final output.
+Use the bash tool. When complete, run one final command that prints
+`COMPLETE_TASK_AND_SUBMIT_FINAL_OUTPUT` on its first line and your final response
+on the following lines. The command output after the first line is submitted as
+your final response, so include it in the same command.
 """
+_UNREADABLE = object()
 
 
 def _selected_model(config: contract.AgentConfig) -> contract.AgentModelConfig:
@@ -37,73 +42,45 @@ class MiniSweAgentRuntime:
     def __init__(self) -> None:
         self._model = self._environment = self._agent = None
         self._system_instruction = ""
+        self._relay_enabled = False
+        self._relay_plugin = self._relay_scope = self._relay_scope_type = None
+        self._relay_plugin_config: dict[str, Any] | None = None
+        self._telemetry_quarantine: str | None = None
 
     async def start(self, payload: dict[str, Any]) -> None:
         config: contract.AgentConfig = payload["config"]
         from minisweagent.environments.local import LocalEnvironment
-        from minisweagent.exceptions import Submitted
         from minisweagent.models.litellm_model import LitellmModel
-        from minisweagent.agents.default import DefaultAgent
+        from nemo_fabric_adapters.mini_swe_agent.agents import (
+            RelayRetainingDefaultAgent,
+        )
+        from nemo_fabric_adapters.mini_swe_agent.agents import RetainingDefaultAgent
 
-        class RetainingDefaultAgent(DefaultAgent):
-            _retain_messages = _skip_initial_messages = False
-
-            @property
-            def messages(self) -> list[dict[str, Any]]:
-                return self._messages
-
-            @messages.setter
-            def messages(self, messages: list[dict[str, Any]]) -> None:
-                if self._retain_messages and not messages:
-                    self._retain_messages = False
-                    self._skip_initial_messages = True
-                else:
-                    self._messages = messages
-
-            def add_messages(self, *messages: dict[str, Any]) -> list[dict[str, Any]]:
-                if self._skip_initial_messages:
-                    self._skip_initial_messages = False
-                    return []
-                return super().add_messages(*messages)
-
-            def run(self, task: str = "", **kwargs: Any) -> dict[str, Any]:
-                if self.messages:
-                    self.n_calls = self.cost = self.n_consecutive_format_errors = 0
-                    self.messages.pop()
-                    self.add_messages(
-                        self.model.format_message(role="user", content=task)
-                    )
-                    self._retain_messages = True
-                return super().run(task, **kwargs)
-
-            def execute_actions(self, message: dict[str, Any]) -> list[dict[str, Any]]:
-                actions = message.get("extra", {}).get("actions", [])
-                outputs = []
-                for action in actions:
-                    try:
-                        outputs.append(self.env.execute(action))
-                    except Submitted as error:
-                        outputs.append(
-                            {
-                                "output": (
-                                    "COMPLETE_TASK_AND_SUBMIT_FINAL_OUTPUT\n"
-                                    f"{error.messages[0]['content']}"
-                                ),
-                                "returncode": 0,
-                                "exception_info": "",
-                            }
-                        )
-                        self.add_messages(
-                            *self.model.format_observation_messages(
-                                message, outputs, self.get_template_vars()
-                            )
-                        )
-                        raise
-                return self.add_messages(
-                    *self.model.format_observation_messages(
-                        message, outputs, self.get_template_vars()
-                    )
+        runtime_context = contract.RuntimeContext.from_mapping(
+            payload.get("runtime_context")
+        )
+        self._relay_enabled = bool(
+            runtime_context.telemetry and runtime_context.telemetry.relay_enabled
+        )
+        agent_type = RetainingDefaultAgent
+        if self._relay_enabled:
+            if importlib.util.find_spec("nemo_relay") is None:
+                raise RuntimeError(
+                    "telemetry is enabled but a compatible 'nemo-relay' package is "
+                    "not installed; install the Relay extra (pip install "
+                    "'nemo-fabric-adapters-mini-swe-agent[relay]')."
                 )
+            common_utils.reject_ambient_relay_plugin_config()
+            relay_payload = {**payload, "config": config.to_mapping()}
+            self._relay_plugin_config = common_utils.load_relay_plugin_config(
+                relay_payload
+            )
+            from nemo_relay import ScopeType, plugin, scope
+
+            self._relay_plugin = plugin
+            self._relay_scope = scope
+            self._relay_scope_type = ScopeType
+            agent_type = RelayRetainingDefaultAgent
 
         model = _selected_model(config)
         model_kwargs: dict[str, Any] = {}
@@ -127,12 +104,16 @@ class MiniSweAgentRuntime:
             if config.instructions and config.instructions.system
             else ""
         )
-        self._agent = RetainingDefaultAgent(
+        agent_kwargs: dict[str, Any] = {}
+        if self._relay_enabled:
+            agent_kwargs["relay_model_name"] = self._model.config.model_name
+        self._agent = agent_type(
             self._model,
             self._environment,
             system_template=SYSTEM_TEMPLATE,
             instance_template=INSTANCE_TEMPLATE,
             step_limit=config.runtime.max_turns if config.runtime else 0,
+            **agent_kwargs,
         )
 
     async def invoke(
@@ -140,17 +121,40 @@ class MiniSweAgentRuntime:
         request: contract.AgentRunRequest,
         context: contract.RuntimeContext,
     ) -> contract.AgentRunResult:
-        del context
         raw_task = request.input
         task = raw_task if isinstance(raw_task, str) else json.dumps(raw_task)
-        result = await asyncio.to_thread(
-            self._agent.run, task, system_instruction=self._system_instruction
-        )
+        inherited_quarantine = self._telemetry_quarantine is not None
+        telemetry_errors: list[str] = []
+        if self._relay_enabled:
+            result, telemetry_errors = await self._run_with_relay(task, context)
+        else:
+            result = await self._run_agent(task)
         failed = result.get("exit_status") != "Submitted"
         output: dict[str, Any] = {
             "output": result.get("submission", ""),
             "usage": {"api_calls": self._agent.n_calls},
         }
+        if self._relay_enabled:
+            output["telemetry"] = {
+                "enabled": True,
+                "provider": "relay",
+                "emitter": "mini-swe-agent.subclass/nemo_relay",
+            }
+            if not inherited_quarantine:
+                try:
+                    assert self._relay_plugin_config is not None
+                    output["relay_artifacts"] = common_utils.collect_relay_artifacts(
+                        self._relay_plugin_config
+                    )
+                except Exception as error:
+                    telemetry_errors.append(_error_text(error))
+            if telemetry_errors:
+                output["telemetry"].update(
+                    {
+                        "degraded": True,
+                        "error": "; ".join(telemetry_errors),
+                    }
+                )
         error = (
             contract.AgentRunError(
                 code="mini_swe_agent_incomplete",
@@ -170,8 +174,89 @@ class MiniSweAgentRuntime:
             error=error,
         )
 
+    async def _run_agent(self, task: str) -> dict[str, Any]:
+        return await asyncio.to_thread(
+            self._agent.run, task, system_instruction=self._system_instruction
+        )
+
+    async def _run_with_relay(
+        self,
+        task: str,
+        context: contract.RuntimeContext,
+    ) -> tuple[dict[str, Any], list[str]]:
+        if self._telemetry_quarantine is not None:
+            self._agent.begin_relay_invocation(None)
+            try:
+                result = await self._run_agent(task)
+            finally:
+                self._agent.end_relay_invocation()
+            return result, [self._telemetry_quarantine]
+
+        baseline = _current_scope_handle()
+        result: dict[str, Any] | None = None
+        telemetry_errors: list[str] = []
+        try:
+            common_utils.reject_ambient_relay_plugin_config()
+            assert self._relay_plugin_config is not None
+            async with self._relay_plugin.plugin(
+                self._relay_plugin_config
+            ) as activation_report:
+                common_utils.reject_inherited_relay_plugin_config(activation_report)
+                with self._relay_scope.scope(
+                    "mini-swe-agent.request",
+                    self._relay_scope_type.Agent,
+                    metadata={
+                        "nemo_fabric_request_id": context.request_id,
+                        "nemo_fabric_invocation_id": context.invocation_id,
+                    },
+                ) as handle:
+                    self._agent.begin_relay_invocation(handle)
+                    try:
+                        result = await self._run_agent(task)
+                    finally:
+                        telemetry_errors.extend(self._agent.end_relay_invocation())
+        except Exception as error:
+            if result is None:
+                raise
+            telemetry_errors.append(_error_text(error))
+
+        if telemetry_errors and not _scope_top_unchanged(baseline):
+            self._telemetry_quarantine = (
+                "telemetry unreliable for the rest of this runtime: an earlier "
+                "turn left the Relay scope stack dirty"
+            )
+            telemetry_errors.append(self._telemetry_quarantine)
+        assert result is not None
+        return result, telemetry_errors
+
     async def stop(self) -> None:
         self.__init__()
+
+
+def _error_text(error: BaseException) -> str:
+    return f"{type(error).__name__}: {error}"
+
+
+def _current_scope_handle() -> Any:
+    try:
+        import nemo_relay
+
+        return nemo_relay.scope.get_handle()
+    except Exception:
+        return None
+
+
+def _scope_top_unchanged(baseline: Any) -> bool:
+    if baseline is None:
+        return False
+    current = _current_scope_handle()
+    if current is None:
+        return False
+    baseline_uuid = getattr(baseline, "uuid", _UNREADABLE)
+    current_uuid = getattr(current, "uuid", _UNREADABLE)
+    if baseline_uuid is _UNREADABLE or current_uuid is _UNREADABLE:
+        return False
+    return bool(current_uuid == baseline_uuid)
 
 
 def main() -> None:

--- a/adapters/mini-swe-agent/src/nemo_fabric_adapters/mini_swe_agent/adapter.py
+++ b/adapters/mini-swe-agent/src/nemo_fabric_adapters/mini_swe_agent/adapter.py
@@ -65,10 +65,11 @@ class MiniSweAgentRuntime:
         agent_type = RetainingDefaultAgent
         if self._relay_enabled:
             if importlib.util.find_spec("nemo_relay") is None:
-                raise RuntimeError(
+                raise lifecycle.LifecycleError(
+                    "mini_swe_agent_relay_missing",
                     "telemetry is enabled but a compatible 'nemo-relay' package is "
                     "not installed; install the Relay extra (pip install "
-                    "'nemo-fabric-adapters-mini-swe-agent[relay]')."
+                    "'nemo-fabric-adapters-mini-swe-agent[relay]').",
                 )
             common_utils.reject_ambient_relay_plugin_config()
             relay_payload = {**payload, "config": config.to_mapping()}
@@ -247,9 +248,9 @@ def _current_scope_handle() -> Any:
 
 
 def _scope_top_unchanged(baseline: Any) -> bool:
-    if baseline is None:
-        return False
     current = _current_scope_handle()
+    if baseline is None:
+        return current is None
     if current is None:
         return False
     baseline_uuid = getattr(baseline, "uuid", _UNREADABLE)

--- a/adapters/mini-swe-agent/src/nemo_fabric_adapters/mini_swe_agent/agents.py
+++ b/adapters/mini-swe-agent/src/nemo_fabric_adapters/mini_swe_agent/agents.py
@@ -27,7 +27,13 @@ def _submitted_output(error: Submitted) -> dict[str, Any]:
 
 
 class RetainingDefaultAgent(DefaultAgent):
-    """Preserve mini-SWE-agent history across ordered Fabric invocations."""
+    """Preserve mini-SWE-agent history across ordered Fabric invocations.
+
+    Before a later run, remove the prior terminal exit message, append the new
+    task as a user message, and suppress ``DefaultAgent`` history
+    initialization. History remains in memory without truncation until the
+    runtime stops.
+    """
 
     _retain_messages = _skip_initial_messages = False
 

--- a/adapters/mini-swe-agent/src/nemo_fabric_adapters/mini_swe_agent/agents.py
+++ b/adapters/mini-swe-agent/src/nemo_fabric_adapters/mini_swe_agent/agents.py
@@ -18,10 +18,9 @@ def _error_text(error: BaseException) -> str:
 
 
 def _submitted_output(error: Submitted) -> dict[str, Any]:
+    content = error.messages[0].get("content", "") if error.messages else ""
     return {
-        "output": (
-            f"COMPLETE_TASK_AND_SUBMIT_FINAL_OUTPUT\n{error.messages[0]['content']}"
-        ),
+        "output": f"COMPLETE_TASK_AND_SUBMIT_FINAL_OUTPUT\n{content}",
         "returncode": 0,
         "exception_info": "",
     }

--- a/adapters/mini-swe-agent/src/nemo_fabric_adapters/mini_swe_agent/agents.py
+++ b/adapters/mini-swe-agent/src/nemo_fabric_adapters/mini_swe_agent/agents.py
@@ -1,0 +1,287 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""mini-SWE-agent subclasses used by the NVIDIA NeMo Fabric adapter."""
+
+from __future__ import annotations
+
+from copy import deepcopy
+from typing import Any
+
+from minisweagent.agents.default import DefaultAgent
+from minisweagent.exceptions import InterruptAgentFlow
+from minisweagent.exceptions import Submitted
+
+
+def _error_text(error: BaseException) -> str:
+    return f"{type(error).__name__}: {error}"
+
+
+def _submitted_output(error: Submitted) -> dict[str, Any]:
+    return {
+        "output": (
+            f"COMPLETE_TASK_AND_SUBMIT_FINAL_OUTPUT\n{error.messages[0]['content']}"
+        ),
+        "returncode": 0,
+        "exception_info": "",
+    }
+
+
+class RetainingDefaultAgent(DefaultAgent):
+    """Preserve mini-SWE-agent history across ordered Fabric invocations."""
+
+    _retain_messages = _skip_initial_messages = False
+
+    @property
+    def messages(self) -> list[dict[str, Any]]:
+        return self._messages
+
+    @messages.setter
+    def messages(self, messages: list[dict[str, Any]]) -> None:
+        if self._retain_messages and not messages:
+            self._retain_messages = False
+            self._skip_initial_messages = True
+        else:
+            self._messages = messages
+
+    def add_messages(self, *messages: dict[str, Any]) -> list[dict[str, Any]]:
+        if self._skip_initial_messages:
+            self._skip_initial_messages = False
+            return []
+        return super().add_messages(*messages)
+
+    def run(self, task: str = "", **kwargs: Any) -> dict[str, Any]:
+        if self.messages:
+            self.n_calls = self.cost = self.n_consecutive_format_errors = 0
+            self.messages.pop()
+            self.add_messages(self.model.format_message(role="user", content=task))
+            self._retain_messages = True
+        return super().run(task, **kwargs)
+
+    def _execute_action(self, action: dict[str, Any]) -> dict[str, Any]:
+        return self.env.execute(action)
+
+    def execute_actions(self, message: dict[str, Any]) -> list[dict[str, Any]]:
+        actions = message.get("extra", {}).get("actions", [])
+        outputs = []
+        for action in actions:
+            try:
+                outputs.append(self._execute_action(action))
+            except Submitted as error:
+                outputs.append(_submitted_output(error))
+                self.add_messages(
+                    *self.model.format_observation_messages(
+                        message, outputs, self.get_template_vars()
+                    )
+                )
+                raise
+        return self.add_messages(
+            *self.model.format_observation_messages(
+                message, outputs, self.get_template_vars()
+            )
+        )
+
+
+class RelayRetainingDefaultAgent(RetainingDefaultAgent):
+    """Emit Relay scopes around mini-SWE-agent steps, model calls, and actions."""
+
+    def __init__(self, *args: Any, relay_model_name: str, **kwargs: Any) -> None:
+        super().__init__(*args, **kwargs)
+        self._relay_model_name = relay_model_name
+        self._relay_invocation_handle: Any = None
+        self._relay_step_handle: Any = None
+        self._relay_errors: list[str] = []
+
+    def begin_relay_invocation(self, handle: Any) -> None:
+        self._relay_invocation_handle = handle
+        self._relay_step_handle = None
+        self._relay_errors = []
+
+    def end_relay_invocation(self) -> list[str]:
+        errors = list(self._relay_errors)
+        self._relay_invocation_handle = None
+        self._relay_step_handle = None
+        self._relay_errors = []
+        return errors
+
+    def _record_relay_error(self, error: BaseException) -> None:
+        self._relay_errors.append(_error_text(error))
+
+    def _parent_handle(self) -> Any:
+        return self._relay_step_handle or self._relay_invocation_handle
+
+    def step(self) -> list[dict[str, Any]]:
+        parent = self._relay_invocation_handle
+        if parent is None:
+            return super().step()
+
+        from nemo_relay import ScopeType
+        from nemo_relay import scope
+
+        try:
+            handle = scope.push(
+                "mini-swe-agent.step",
+                ScopeType.Function,
+                handle=parent,
+                metadata={"step_index": self.n_calls + 1},
+            )
+        except Exception as error:
+            self._record_relay_error(error)
+            return super().step()
+
+        self._relay_step_handle = handle
+        outcome: dict[str, Any] = {"status": "succeeded"}
+        try:
+            return super().step()
+        except InterruptAgentFlow as error:
+            outcome = {
+                "status": "interrupted",
+                "interrupt_type": type(error).__name__,
+            }
+            raise
+        except Exception as error:
+            outcome = {"status": "error", "error_type": type(error).__name__}
+            raise
+        finally:
+            self._relay_step_handle = None
+            try:
+                scope.pop(handle, output=outcome)
+            except Exception as error:
+                self._record_relay_error(error)
+
+    def query(self) -> dict[str, Any]:
+        parent = self._parent_handle()
+        if parent is None:
+            return super().query()
+
+        from nemo_relay import LLMRequest
+        from nemo_relay import llm
+
+        request_messages = [
+            {key: value for key, value in message.items() if key != "extra"}
+            for message in self.messages
+        ]
+        try:
+            handle = llm.call(
+                "mini-swe-agent.model",
+                LLMRequest(
+                    {},
+                    {
+                        "model": self._relay_model_name,
+                        "messages": request_messages,
+                    },
+                ),
+                handle=parent,
+                model_name=self._relay_model_name,
+            )
+        except Exception as error:
+            self._record_relay_error(error)
+            return super().query()
+
+        response: Any = None
+        metadata: dict[str, Any] = {"status": "succeeded"}
+        try:
+            message = super().query()
+            response = _relay_response(message)
+            return message
+        except Exception as error:
+            response = _relay_exception_response(error)
+            metadata = {"status": "error", "error_type": type(error).__name__}
+            raise
+        finally:
+            try:
+                response_codec = None
+                if isinstance(response, dict) and isinstance(
+                    response.get("choices"), list
+                ):
+                    from nemo_relay.codecs import OpenAIChatCodec
+
+                    response_codec = OpenAIChatCodec()
+                llm.call_end(
+                    handle,
+                    response,
+                    metadata=metadata,
+                    response_codec=response_codec,
+                )
+            except Exception as error:
+                self._record_relay_error(error)
+
+    def _execute_action(self, action: dict[str, Any]) -> dict[str, Any]:
+        parent = self._parent_handle()
+        if parent is None:
+            return super()._execute_action(action)
+
+        from nemo_relay import tools
+
+        tool_call_id = action.get("tool_call_id")
+        arguments = {
+            key: value for key, value in action.items() if key != "tool_call_id"
+        }
+        try:
+            handle = tools.call(
+                "bash",
+                arguments,
+                handle=parent,
+                tool_call_id=(tool_call_id if isinstance(tool_call_id, str) else None),
+            )
+        except Exception as error:
+            self._record_relay_error(error)
+            return super()._execute_action(action)
+
+        try:
+            output = super()._execute_action(action)
+        except Submitted as error:
+            self._end_tool_call(
+                handle, _submitted_output(error), metadata={"status": "submitted"}
+            )
+            raise
+        except Exception as error:
+            self._end_tool_call(
+                handle,
+                None,
+                metadata={"status": "error", "error_type": type(error).__name__},
+            )
+            raise
+        self._end_tool_call(handle, output, metadata={"status": "succeeded"})
+        return output
+
+    def _end_tool_call(
+        self,
+        handle: Any,
+        output: Any,
+        *,
+        metadata: dict[str, Any],
+    ) -> None:
+        from nemo_relay import tools
+
+        try:
+            tools.call_end(handle, output, metadata=metadata)
+        except Exception as error:
+            self._record_relay_error(error)
+
+
+def _relay_response(message: dict[str, Any]) -> Any:
+    extra = message.get("extra", {})
+    response = extra.get("response")
+    if not isinstance(response, dict):
+        return {key: value for key, value in message.items() if key != "extra"}
+
+    response = deepcopy(response)
+    cost = extra.get("cost")
+    if isinstance(cost, (int, float)) and not isinstance(cost, bool):
+        usage = response.setdefault("usage", {})
+        if isinstance(usage, dict):
+            usage.setdefault("cost", float(cost))
+    return response
+
+
+def _relay_exception_response(error: BaseException) -> Any:
+    messages = getattr(error, "messages", None)
+    if isinstance(messages, list) and messages and isinstance(messages[0], dict):
+        response = messages[0].get("extra", {}).get("response")
+        if (
+            isinstance(response, (dict, list, str, int, float, bool))
+            or response is None
+        ):
+            return response
+    return None

--- a/adapters/mini-swe-agent/uv.lock
+++ b/adapters/mini-swe-agent/uv.lock
@@ -1169,9 +1169,13 @@ dependencies = [
 [package.optional-dependencies]
 full = [
     { name = "mini-swe-agent" },
+    { name = "nemo-relay" },
 ]
 harness = [
     { name = "mini-swe-agent" },
+]
+relay = [
+    { name = "nemo-relay" },
 ]
 
 [package.metadata]
@@ -1180,8 +1184,25 @@ requires-dist = [
     { name = "mini-swe-agent", marker = "extra == 'harness'", specifier = ">=2.0,<3" },
     { name = "nemo-fabric-adapter-contract", editable = "../../adapter-contract/python" },
     { name = "nemo-fabric-adapters-common", editable = "../common" },
+    { name = "nemo-relay", marker = "extra == 'full'", specifier = ">=0.7.2,<0.8" },
+    { name = "nemo-relay", marker = "extra == 'relay'", specifier = ">=0.7.2,<0.8" },
 ]
-provides-extras = ["harness", "full"]
+provides-extras = ["harness", "relay", "full"]
+
+[[package]]
+name = "nemo-relay"
+version = "0.7.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/cd/e5/a259aac8df4aa78c0b3a6f3ad0fbf6305666bfaad5c29d9adc26db0f9e27/nemo_relay-0.7.3.tar.gz", hash = "sha256:ea5a1bb52e25e001dcbf6af1830616be181845e978cc848df58562556bba5604", size = 1299430, upload-time = "2026-08-14T14:40:44.832Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ed/9e/4eb80d2307cadcbb839dad2212a8d888667cd8c531ad0d8c0c1afc841181/nemo_relay-0.7.3-cp311-abi3-macosx_11_0_arm64.whl", hash = "sha256:301dfc8334032ac52c09cc0b1421181e7c4df601abe7c82dfe51aa74ddbb3732", size = 9251369, upload-time = "2026-08-14T14:40:07.668Z" },
+    { url = "https://files.pythonhosted.org/packages/c7/a9/9fb77f7142b1381d8c3c81fdbb76782a02dcff1ee403ac6c93b13fa46b24/nemo_relay-0.7.3-cp311-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:49c70c0a94cebb6cba3dd7521be11f63eac4cd9386881eb29827ac91b1bd780b", size = 8458046, upload-time = "2026-08-14T14:40:10.181Z" },
+    { url = "https://files.pythonhosted.org/packages/ae/ab/b2f246f971f561a982d234d9f3ec1b29dfa4c72bf4882f3e32ce6db54dfa/nemo_relay-0.7.3-cp311-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:8eeaaf8c6a18440e473dd14eb1bb82e56c6514e70adee7456eddf9ce217cff89", size = 8957931, upload-time = "2026-08-14T14:40:12.547Z" },
+    { url = "https://files.pythonhosted.org/packages/8f/d8/d8c25ba915467bab457d175b84a3af5c33291655867d472c49eada3b77e6/nemo_relay-0.7.3-cp311-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:90ff984a89c42ebd0cfe26a0af3f180b1970e2ebcd743d19a960e547949ad2ef", size = 10325640, upload-time = "2026-08-14T14:40:15.722Z" },
+    { url = "https://files.pythonhosted.org/packages/7d/fd/6ec48f47eb5ca4cca566b197ade8514baf183dddf53d6de3a296b8bc1102/nemo_relay-0.7.3-cp311-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:d4895a4df39a92ecbac3633fb4ec59cf1f83286c0369f433760ab28fb8d6dddf", size = 10706736, upload-time = "2026-08-14T14:40:18.377Z" },
+    { url = "https://files.pythonhosted.org/packages/6b/cb/8a6f8d5f9922e75100f135c1dc4451bafc15f5d51608081f72b894e0caf4/nemo_relay-0.7.3-cp311-abi3-win_amd64.whl", hash = "sha256:f123cd45a27fca3d570559f2c26850138763411f66f387559d757e5d88bfa3c1", size = 8807604, upload-time = "2026-08-14T14:40:20.98Z" },
+    { url = "https://files.pythonhosted.org/packages/f1/ac/558a05e6b9e28464b64fee8327d9e8a2aab3fb356363b8b82597b6b35b2a/nemo_relay-0.7.3-cp311-abi3-win_arm64.whl", hash = "sha256:6d5444e9a03b8b5d4bba2409105a121349580cb51481d441c6b5e699713a8763", size = 8442944, upload-time = "2026-08-14T14:40:23.433Z" },
+]
 
 [[package]]
 name = "numpy"

--- a/docs/adapter-contract/examples.md
+++ b/docs/adapter-contract/examples.md
@@ -13,7 +13,7 @@ field.
 | Integration Shape | Start With | What It Demonstrates |
 | --- | --- | --- |
 | Harness adapter | [Hermes Agent descriptor](https://github.com/NVIDIA/NeMo-Fabric/blob/main/adapters/hermes/hermes.fabric-adapter.json) and [runtime](https://github.com/NVIDIA/NeMo-Fabric/blob/main/adapters/hermes/src/nemo_fabric_adapters/hermes/adapter.py) | A complete harness integration with normalized configuration, persistent state, and telemetry. |
-| Minimum-surface harness adapter | [mini-SWE-agent descriptor](https://github.com/NVIDIA/NeMo-Fabric/blob/main/adapters/mini-swe-agent/mini-swe-agent.fabric-adapter.json) and [runtime](https://github.com/NVIDIA/NeMo-Fabric/blob/main/adapters/mini-swe-agent/src/nemo_fabric_adapters/mini_swe_agent/adapter.py) | The required typed config boundary and `start`/`invoke`/`stop` with little optional behavior. |
+| Minimum-surface harness adapter | [mini-SWE-agent descriptor](https://github.com/NVIDIA/NeMo-Fabric/blob/main/adapters/mini-swe-agent/mini-swe-agent.fabric-adapter.json) and [runtime](https://github.com/NVIDIA/NeMo-Fabric/blob/main/adapters/mini-swe-agent/src/nemo_fabric_adapters/mini_swe_agent/adapter.py) | The required typed config boundary and `start`/`invoke`/`stop`, plus an optional subclass-based Relay integration. |
 | Shared framework adapter | [NeMo Agent Toolkit adapter descriptor](https://github.com/NVIDIA/NeMo-Fabric/blob/main/external/nat/nat.fabric-adapter.json), [runtime](https://github.com/NVIDIA/NeMo-Fabric/blob/main/external/nat/src/nemo_fabric_adapters/nat/adapter.py), and [targets](https://github.com/NVIDIA/NeMo-Fabric/tree/main/external/nat/targets) | One adapter plus independently registered calculator and email-phishing workflows. |
 | Dedicated custom-agent adapter | [LangGraph descriptor](https://github.com/NVIDIA/NeMo-Fabric/blob/main/examples/langgraph_custom_agent/adapter/email-phishing.fabric-adapter.json) and [runtime](https://github.com/NVIDIA/NeMo-Fabric/blob/main/examples/langgraph_custom_agent/adapter/runtime.py) | A custom graph with an adjacent adapter and no generic workflow loader. |
 
@@ -29,12 +29,14 @@ understand the required boundary at a glance. Its package contains:
 
 - A static Adapter Descriptor that accepts a small normalized config surface
 - One runtime class with `start`, `invoke`, and `stop`
+- One optional mini-SWE-agent subclass for Relay telemetry
 - The optional common Python lifecycle host
 - One package README with a complete consumer configuration
 
 The adapter retains the model, environment, agent, and conversation state in
-one runtime instance. It does not implement MCP, skills, telemetry, or native
-streaming, which keeps the required path visible.
+one runtime instance. It does not implement MCP, skills, or native streaming.
+When Relay is enabled, it selects an adapter-owned subclass that emits live
+invocation, step, LLM, and tool telemetry without changing the default path.
 
 ## Shared Adapter With Registered Custom Agents
 

--- a/docs/getting-started/install.mdx
+++ b/docs/getting-started/install.mdx
@@ -33,15 +33,17 @@ be managed separately.
 | `nemo-fabric-adapters-claude[harness]` | No | Yes | Yes | No | Yes |
 | `nemo-fabric-adapters-claude[full]` | No | Yes | Yes | No | Yes |
 | `nemo-fabric-adapters-deepagents[full]` | No | Yes | Yes | Yes | No |
+| `nemo-fabric-adapters-mini-swe-agent[full]` | No | Yes | Yes | Yes | No |
 | `nemo-fabric-adapters-hermes[relay]` | No | Yes | No | Yes | No |
 | `nemo-fabric-adapters-claude` | No | Yes | No | No | No |
 
 An adapter package's `full` extra is scoped to the adapter environment and does
 not install the NeMo Fabric runtime. For Claude and Codex, `full` is equivalent
 to `harness`; both install the supported harness and `nemo-relay` CLI. For
-LangChain Deep Agents, `full` installs the harness and NeMo Relay Python package
-without the CLI. For Hermes Agent, `full` installs only the adapter and NeMo
-Relay Python package; Hermes Agent must be installed separately.
+LangChain Deep Agents and mini-SWE-agent, `full` installs the harness and NeMo
+Relay Python package without the CLI. For Hermes Agent, `full` installs only
+the adapter and NeMo Relay Python package; Hermes Agent must be installed
+separately.
 
 ### Install the NeMo Fabric Runtime
 
@@ -159,28 +161,33 @@ to be compatible with the installed version of NeMo Fabric:
 pip install "nemo-fabric[relay]"
 ```
 
-LangChain Deep Agents and Hermes Agent import the NeMo Relay Python package
-directly. Their adapter packages provide `relay` and `full` extras:
+LangChain Deep Agents, Hermes Agent, and mini-SWE-agent import the NeMo Relay
+Python package directly. Their adapter packages provide `relay` and `full`
+extras:
 
 ```bash
 pip install "nemo-fabric-adapters-deepagents[relay]"
 pip install "nemo-fabric-adapters-hermes[relay]"
+pip install "nemo-fabric-adapters-mini-swe-agent[relay]"
 pip install "nemo-fabric-adapters-deepagents[full]"
 pip install "nemo-fabric-adapters-hermes[full]"
+pip install "nemo-fabric-adapters-mini-swe-agent[full]"
 ```
 
-Use `relay` when the environment already manages the harness. For Deep Agents,
-use `full` to install the harness and Relay package together. For Hermes Agent,
-`relay` and `full` install the adapter and Relay package, but neither installs
-Hermes Agent. Claude and Codex do not provide a `relay` extra because their
-adapters launch the external CLI instead of importing this Python package.
+Use `relay` when the environment already manages the harness. For Deep Agents
+and mini-SWE-agent, use `full` to install the harness and Relay package
+together. For Hermes Agent, `relay` and `full` install the adapter and Relay
+package, but neither installs Hermes Agent. Claude and Codex do not provide a
+`relay` extra because their adapters launch the external CLI instead of
+importing this Python package.
 
 NeMo Fabric requires `nemo-relay>=0.7.2,<0.8`. For Python-backed Relay
 integrations, NeMo Fabric does not merge user or workspace `plugins.toml`
 files with its runtime-owned configuration. Remove or relocate a user
 `plugins.toml` or the nearest `.nemo-relay/plugins.toml` before starting a
-Relay-enabled Deep Agents or Hermes Agent runtime. System configuration in
-`/etc/nemo-relay/plugins.toml` remains administrator controlled.
+Relay-enabled Deep Agents, Hermes Agent, or mini-SWE-agent runtime. System
+configuration in `/etc/nemo-relay/plugins.toml` remains administrator
+controlled.
 
 #### Migrate Relay Observability Configurations from 0.6
 

--- a/docs/integrations/harness/mini-swe-agent.mdx
+++ b/docs/integrations/harness/mini-swe-agent.mdx
@@ -25,8 +25,8 @@ pip install "nemo-fabric-adapters-mini-swe-agent[harness]"
 ```
 
 The `harness` and `full` extras install the latest compatible mini-SWE-agent
-2.x release. To use an environment-managed compatible package, install the
-bare adapter:
+2.x release. The `full` extra also installs NeMo Relay. To use an
+environment-managed compatible package, install the bare adapter:
 
 ```bash
 pip install nemo-fabric-adapters-mini-swe-agent
@@ -59,8 +59,8 @@ model-provider credential.
 `harness.settings.timeout` to set the maximum duration of one command; the
 default is `30` seconds.
 
-This adapter does not support MCP, skills, tool policy, streaming, or telemetry
-output.
+This adapter does not support MCP, skills, tool policy, or native OpenAI
+streaming.
 
 ## Run a Task
 
@@ -102,3 +102,28 @@ result = asyncio.run(main())
 ```
 
 The result includes the submitted final output and API-call usage.
+
+## Stream Relay Telemetry
+
+Install the runtime, mini-SWE-agent harness, and NeMo Relay Python package in
+one environment:
+
+```bash
+pip install "nemo-fabric[mini-swe-agent,relay]"
+```
+
+Enable Relay on the configuration:
+
+```python
+config.enable_relay()
+```
+
+For a Relay-enabled runtime, the adapter selects a Relay-specific
+mini-SWE-agent subclass that emits invocation, step, model, and bash-action
+events. Relay is not imported and the subclass is not used when Relay is
+disabled.
+
+Use `Fabric.start_runtime(config, streaming=True)` and
+`Runtime.invoke_stream()` to receive correlated ATOF records while ordinary
+adapter `invoke()` runs. This Relay-backed stream is independent of native
+OpenAI streaming; `capabilities.streaming` remains `false`.

--- a/docs/integrations/harness/mini-swe-agent.mdx
+++ b/docs/integrations/harness/mini-swe-agent.mdx
@@ -104,6 +104,29 @@ result = asyncio.run(main())
 
 The result includes the submitted final output and API-call usage.
 
+## Continue a Task Across Invocations
+
+Use one runtime to retain mini-SWE-agent conversation history across ordered
+invocations:
+
+```python
+async with await Fabric().start_runtime(
+    config,
+    base_dir="/workspace",
+) as runtime:
+    first = await runtime.invoke(
+        input="Inspect calculator.py and identify the bug."
+    )
+    second = await runtime.invoke(input="Fix it and run the tests.")
+```
+
+Before the second model call, the adapter removes the previous terminal `exit`
+message and appends the new input as a user message. Earlier system, user,
+assistant, and `bash` tool observation messages remain in the model context,
+including command output. History lasts only for the same runtime and is
+discarded when the runtime stops. The adapter does not currently truncate or
+summarize retained history.
+
 ## Stream Relay Telemetry
 
 Install the runtime, mini-SWE-agent harness, and NeMo Relay Python package in

--- a/docs/integrations/harness/mini-swe-agent.mdx
+++ b/docs/integrations/harness/mini-swe-agent.mdx
@@ -25,8 +25,9 @@ pip install "nemo-fabric-adapters-mini-swe-agent[harness]"
 ```
 
 The `harness` and `full` extras install the latest compatible mini-SWE-agent
-2.x release. The `full` extra also installs NeMo Relay. To use an
-environment-managed compatible package, install the bare adapter:
+2.x release. The `full` extra also installs the NeMo Relay Python package
+without the NeMo Relay CLI. To use an environment-managed compatible package,
+install the bare adapter:
 
 ```bash
 pip install nemo-fabric-adapters-mini-swe-agent

--- a/docs/sdk/python.mdx
+++ b/docs/sdk/python.mdx
@@ -194,11 +194,11 @@ by adapter:
 | `mcp.servers.<name>.transport`, `.url` with `harness_native` exposure | Yes | Yes | Yes | Yes | No |
 | `mcp.servers.<name>.allowed_tools`, `.blocked_tools` | No | No | No | No | No |
 | `mcp.servers.<name>.exposure = "fabric_managed"` | No; not implemented | No; not implemented | No; not implemented | No; not implemented | No |
-| `telemetry.providers.relay` | Yes | Yes | Yes | Yes | No |
+| `telemetry.providers.relay` | Yes | Yes | Yes | Yes | Yes |
 | `telemetry.providers.native` | No | Yes; OpenTelemetry | Yes; OpenTelemetry and OpenInference | No | No |
-| `telemetry.providers.<provider>.config` | Declared-provider pass-through | Declared-provider pass-through | Declared-provider pass-through | Declared-provider pass-through | No |
-| `relay.project`, `.output_dir`, `.observability` | Yes | Yes | Yes | Yes | No |
-| `relay.components`, `.policy` | Yes | Yes | Yes | Yes | No |
+| `telemetry.providers.<provider>.config` | Declared-provider pass-through | Declared-provider pass-through | Declared-provider pass-through | Declared-provider pass-through | Declared-provider pass-through |
+| `relay.project`, `.output_dir`, `.observability` | Yes | Yes | Yes | Yes | Yes |
+| `relay.components`, `.policy` | Yes | Yes | Yes | Yes | Yes |
 | Additive `extensions` on typed config objects | Preserved; no portable adapter semantics | Preserved; no portable adapter semantics | Preserved; no portable adapter semantics | Preserved; no portable adapter semantics | Preserved; no portable adapter semantics |
 
 Model selection is deterministic: the `default` role wins; otherwise a single

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,7 +51,9 @@ adapters = [
   "nemo-fabric-adapters-deepagents[relay]",
   "nemo-fabric-adapters-hermes; python_version < '3.14'",
   "hermes-agent==0.20.1; python_version < '3.14'",
-  "nemo-fabric-adapters-mini-swe-agent",
+  # Install the mini-SWE-agent adapter with Relay so focused adapter tests cover
+  # its optional subclass-based telemetry integration.
+  "nemo-fabric-adapters-mini-swe-agent[relay]",
 ]
 
 adapter-tests = [

--- a/sdk/python/nemo-fabric/uv.lock
+++ b/sdk/python/nemo-fabric/uv.lock
@@ -1986,8 +1986,10 @@ requires-dist = [
     { name = "mini-swe-agent", marker = "extra == 'harness'", specifier = ">=2.0,<3" },
     { name = "nemo-fabric-adapter-contract", editable = "../../../adapter-contract/python" },
     { name = "nemo-fabric-adapters-common", editable = "../../../adapters/common" },
+    { name = "nemo-relay", marker = "extra == 'full'", specifier = ">=0.7.2,<0.8" },
+    { name = "nemo-relay", marker = "extra == 'relay'", specifier = ">=0.7.2,<0.8" },
 ]
-provides-extras = ["harness", "full"]
+provides-extras = ["harness", "relay", "full"]
 
 [[package]]
 name = "nemo-fabric-runtime"

--- a/tests/adapters/test_mini_swe_agent.py
+++ b/tests/adapters/test_mini_swe_agent.py
@@ -21,6 +21,7 @@ from nemo_fabric_adapter_contract.models import RuntimeContext
 from nemo_fabric_adapters.mini_swe_agent import adapter
 from nemo_fabric_adapters.mini_swe_agent.agents import RelayRetainingDefaultAgent
 from nemo_fabric_adapters.mini_swe_agent.agents import RetainingDefaultAgent
+from nemo_fabric_adapters.mini_swe_agent.agents import _submitted_output
 from minisweagent.exceptions import Submitted
 
 ROOT = Path(__file__).resolve().parents[2]
@@ -418,17 +419,27 @@ async def test_relay_event_failure_degrades_telemetry_without_failing_agent(
     assert result.output["output"] == "done"
     assert result.output["telemetry"]["degraded"] is True
     assert "RuntimeError: relay llm end failed" in result.output["telemetry"]["error"]
-    assert (
-        "telemetry unreliable for the rest of this runtime"
-        in result.output["telemetry"]["error"]
-    )
+    assert "telemetry unreliable" not in result.output["telemetry"]["error"]
+    assert result.output["relay_artifacts"] == mock_relay["artifacts"]
 
     second = await runtime.invoke(*invocation(mini_payload))
 
     assert second.status == "succeeded"
     assert second.output["telemetry"]["degraded"] is True
-    assert "relay_artifacts" not in second.output
-    assert len(mock_relay["request_scopes"]) == 1
+    assert second.output["relay_artifacts"] == mock_relay["artifacts"]
+    assert len(mock_relay["request_scopes"]) == 2
+
+
+@pytest.mark.parametrize(
+    "error",
+    [Submitted(), Submitted({"role": "exit"})],
+)
+def test_submitted_output_handles_missing_content(error):
+    assert _submitted_output(error) == {
+        "output": "COMPLETE_TASK_AND_SUBMIT_FINAL_OUTPUT\n",
+        "returncode": 0,
+        "exception_info": "",
+    }
 
 
 async def test_stop_resets_relay_quarantine():
@@ -450,8 +461,12 @@ async def test_relay_enabled_requires_optional_dependency(
     runtime = adapter.MiniSweAgentRuntime()
     start = {**mini_payload, "config": AgentConfig.from_mapping(mini_payload["config"])}
 
-    with pytest.raises(RuntimeError, match=r"mini-swe-agent\[relay\]"):
+    with pytest.raises(
+        adapter.lifecycle.LifecycleError,
+        match=r"mini-swe-agent\[relay\]",
+    ) as exc_info:
         await runtime.start(start)
+    assert exc_info.value.code == "mini_swe_agent_relay_missing"
 
 
 def test_mini_swe_agent_module_entrypoint_exits_cleanly():

--- a/tests/adapters/test_mini_swe_agent.py
+++ b/tests/adapters/test_mini_swe_agent.py
@@ -8,7 +8,10 @@ from __future__ import annotations
 import json
 import subprocess
 import sys
+from contextlib import asynccontextmanager
+from contextlib import contextmanager
 from pathlib import Path
+from types import SimpleNamespace
 from unittest.mock import MagicMock
 
 import pytest
@@ -16,9 +19,19 @@ from nemo_fabric_adapter_contract.models import AgentConfig
 from nemo_fabric_adapter_contract.models import AgentRunRequest
 from nemo_fabric_adapter_contract.models import RuntimeContext
 from nemo_fabric_adapters.mini_swe_agent import adapter
+from nemo_fabric_adapters.mini_swe_agent.agents import RelayRetainingDefaultAgent
+from nemo_fabric_adapters.mini_swe_agent.agents import RetainingDefaultAgent
 from minisweagent.exceptions import Submitted
 
 ROOT = Path(__file__).resolve().parents[2]
+
+
+@pytest.fixture(autouse=True)
+def run_agent_inline_fixture(monkeypatch: pytest.MonkeyPatch):
+    async def run_inline(func, *args, **kwargs):
+        return func(*args, **kwargs)
+
+    monkeypatch.setattr(adapter.asyncio, "to_thread", run_inline)
 
 
 def invocation(payload: dict) -> tuple[AgentRunRequest, RuntimeContext]:
@@ -34,6 +47,7 @@ def invocation(payload: dict) -> tuple[AgentRunRequest, RuntimeContext]:
 @pytest.fixture(name="mock_mini")
 def mock_mini_fixture(monkeypatch):
     model = MagicMock()
+    model.config.model_name = "nvidia/test-model"
     model.format_message.side_effect = lambda **message: message
     environment = MagicMock()
     queries = []
@@ -43,7 +57,26 @@ def mock_mini_fixture(monkeypatch):
         return {
             "role": "assistant",
             "content": "Working.",
-            "extra": {"actions": [{"command": "submit", "tool_call_id": "call-1"}]},
+            "extra": {
+                "actions": [{"command": "submit", "tool_call_id": "call-1"}],
+                "cost": 0.25,
+                "response": {
+                    "id": "chatcmpl-mini-1",
+                    "model": "nvidia/test-model",
+                    "choices": [
+                        {
+                            "index": 0,
+                            "message": {"role": "assistant", "content": "Working."},
+                            "finish_reason": "tool_calls",
+                        }
+                    ],
+                    "usage": {
+                        "prompt_tokens": 8,
+                        "completion_tokens": 4,
+                        "total_tokens": 12,
+                    },
+                },
+            },
         }
 
     model.query.side_effect = query
@@ -114,6 +147,81 @@ def mini_payload_fixture(tmp_path: Path) -> dict:
     }
 
 
+@pytest.fixture(name="mock_relay")
+def mock_relay_fixture(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> dict:
+    import nemo_relay
+
+    calls: dict[str, list] = {
+        "plugin_configs": [],
+        "request_scopes": [],
+        "step_starts": [],
+        "step_ends": [],
+        "llm_starts": [],
+        "llm_ends": [],
+        "tool_starts": [],
+        "tool_ends": [],
+    }
+    request_handle = SimpleNamespace(uuid="request-scope")
+    step_handle = SimpleNamespace(uuid="step-scope")
+    llm_handle = SimpleNamespace(uuid="llm-scope")
+    tool_handle = SimpleNamespace(uuid="tool-scope")
+
+    @asynccontextmanager
+    async def plugin_context(config):
+        calls["plugin_configs"].append(config)
+        yield {"diagnostics": []}
+
+    @contextmanager
+    def request_scope(name, scope_type, **kwargs):
+        calls["request_scopes"].append((name, scope_type, kwargs))
+        yield request_handle
+
+    def push_step(name, scope_type, **kwargs):
+        calls["step_starts"].append((name, scope_type, kwargs))
+        return step_handle
+
+    def pop_step(handle, **kwargs):
+        calls["step_ends"].append((handle, kwargs))
+
+    def llm_start(name, request, **kwargs):
+        calls["llm_starts"].append((name, request, kwargs))
+        return llm_handle
+
+    def llm_end(handle, response, **kwargs):
+        calls["llm_ends"].append((handle, response, kwargs))
+
+    def tool_start(name, arguments, **kwargs):
+        calls["tool_starts"].append((name, arguments, kwargs))
+        return tool_handle
+
+    def tool_end(handle, output, **kwargs):
+        calls["tool_ends"].append((handle, output, kwargs))
+
+    monkeypatch.setattr(nemo_relay.plugin, "plugin", plugin_context)
+    monkeypatch.setattr(nemo_relay.scope, "scope", request_scope)
+    monkeypatch.setattr(nemo_relay.scope, "push", push_step)
+    monkeypatch.setattr(nemo_relay.scope, "pop", pop_step)
+    monkeypatch.setattr(nemo_relay.scope, "get_handle", lambda: None)
+    monkeypatch.setattr(nemo_relay.llm, "call", llm_start)
+    monkeypatch.setattr(nemo_relay.llm, "call_end", llm_end)
+    monkeypatch.setattr(nemo_relay.tools, "call", tool_start)
+    monkeypatch.setattr(nemo_relay.tools, "call_end", tool_end)
+
+    plugin_config = {"version": 1, "components": []}
+    artifacts = [{"kind": "atof", "path": str(tmp_path / "events.atof.jsonl")}]
+    monkeypatch.setattr(
+        adapter.common_utils, "load_relay_plugin_config", lambda _payload: plugin_config
+    )
+    monkeypatch.setattr(
+        adapter.common_utils, "collect_relay_artifacts", lambda _config: artifacts
+    )
+    calls["plugin_config"] = plugin_config
+    calls["artifacts"] = artifacts
+    calls["request_handle"] = request_handle
+    calls["step_handle"] = step_handle
+    return calls
+
+
 def test_mini_swe_agent_descriptor_is_narrow_and_versioned():
     descriptor = json.loads(
         (ROOT / "adapters/mini-swe-agent/mini-swe-agent.fabric-adapter.json").read_text(
@@ -140,6 +248,11 @@ def test_mini_swe_agent_descriptor_is_narrow_and_versioned():
         "streaming": False,
         "updates": False,
         "cancellation": False,
+    }
+    assert descriptor["telemetry"] == {
+        "providers": {
+            "relay": {"outputs": ["atif", "otel", "openinference"]},
+        }
     }
 
 
@@ -169,6 +282,8 @@ async def test_mini_swe_agent_maps_config_and_returns_normalized_output(
     assert mock_mini["queries"][0][0]["content"] == (
         "Work with the literal {{template}}."
     )
+    assert "include it in the same command" in mock_mini["queries"][0][1]["content"]
+    assert type(runtime._agent) is RetainingDefaultAgent
     assert result.output == {
         "output": "done",
         "usage": {"api_calls": 1},
@@ -230,6 +345,113 @@ async def test_mini_swe_agent_retains_history_between_invocations(
         "exit",
     ]
     assert agent.messages[4]["content"] == "Continue the task."
+
+
+async def test_relay_enabled_uses_instrumented_subclass_and_reports_artifacts(
+    mock_mini,
+    mini_payload,
+    mock_relay,
+):
+    mini_payload["runtime_context"]["telemetry"] = {
+        "relay_enabled": True,
+        "metadata": {"telemetry_providers": ["relay"]},
+    }
+    runtime = adapter.MiniSweAgentRuntime()
+    start = {**mini_payload, "config": AgentConfig.from_mapping(mini_payload["config"])}
+    await runtime.start(start)
+
+    result = await runtime.invoke(*invocation(mini_payload))
+
+    assert type(runtime._agent) is RelayRetainingDefaultAgent
+    assert result.status == "succeeded"
+    assert result.output["telemetry"] == {
+        "enabled": True,
+        "provider": "relay",
+        "emitter": "mini-swe-agent.subclass/nemo_relay",
+    }
+    assert result.output["relay_artifacts"] == mock_relay["artifacts"]
+    assert mock_relay["plugin_configs"] == [mock_relay["plugin_config"]]
+
+    request_scope = mock_relay["request_scopes"][0]
+    assert request_scope[0] == "mini-swe-agent.request"
+    assert request_scope[2]["metadata"] == {
+        "nemo_fabric_request_id": "mini-request",
+        "nemo_fabric_invocation_id": "mini-invocation",
+    }
+    assert mock_relay["step_starts"][0][2]["handle"] is mock_relay["request_handle"]
+    assert mock_relay["llm_starts"][0][2]["handle"] is mock_relay["step_handle"]
+    assert mock_relay["llm_starts"][0][1].content["model"] == "nvidia/test-model"
+    assert mock_relay["llm_ends"][0][1]["usage"]["cost"] == 0.25
+    assert mock_relay["tool_starts"][0][0:2] == (
+        "bash",
+        {"command": "submit"},
+    )
+    assert mock_relay["tool_starts"][0][2]["tool_call_id"] == "call-1"
+    assert mock_relay["tool_ends"][0][2]["metadata"]["status"] == "submitted"
+    assert mock_relay["step_ends"][0][1]["output"] == {
+        "status": "interrupted",
+        "interrupt_type": "Submitted",
+    }
+
+
+async def test_relay_event_failure_degrades_telemetry_without_failing_agent(
+    mock_mini,
+    mini_payload,
+    mock_relay,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    import nemo_relay
+
+    mini_payload["runtime_context"]["telemetry"] = {"relay_enabled": True}
+    monkeypatch.setattr(
+        nemo_relay.llm,
+        "call_end",
+        MagicMock(side_effect=RuntimeError("relay llm end failed")),
+    )
+    runtime = adapter.MiniSweAgentRuntime()
+    start = {**mini_payload, "config": AgentConfig.from_mapping(mini_payload["config"])}
+    await runtime.start(start)
+
+    result = await runtime.invoke(*invocation(mini_payload))
+
+    assert result.status == "succeeded"
+    assert result.output["output"] == "done"
+    assert result.output["telemetry"]["degraded"] is True
+    assert "RuntimeError: relay llm end failed" in result.output["telemetry"]["error"]
+    assert (
+        "telemetry unreliable for the rest of this runtime"
+        in result.output["telemetry"]["error"]
+    )
+
+    second = await runtime.invoke(*invocation(mini_payload))
+
+    assert second.status == "succeeded"
+    assert second.output["telemetry"]["degraded"] is True
+    assert "relay_artifacts" not in second.output
+    assert len(mock_relay["request_scopes"]) == 1
+
+
+async def test_stop_resets_relay_quarantine():
+    runtime = adapter.MiniSweAgentRuntime()
+    runtime._telemetry_quarantine = "dirty scope"
+
+    await runtime.stop()
+
+    assert runtime._telemetry_quarantine is None
+
+
+async def test_relay_enabled_requires_optional_dependency(
+    mock_mini,
+    mini_payload,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    mini_payload["runtime_context"]["telemetry"] = {"relay_enabled": True}
+    monkeypatch.setattr(adapter.importlib.util, "find_spec", lambda _name: None)
+    runtime = adapter.MiniSweAgentRuntime()
+    start = {**mini_payload, "config": AgentConfig.from_mapping(mini_payload["config"])}
+
+    with pytest.raises(RuntimeError, match=r"mini-swe-agent\[relay\]"):
+        await runtime.start(start)
 
 
 def test_mini_swe_agent_module_entrypoint_exits_cleanly():

--- a/tests/e2e/test_mini_swe_agent.py
+++ b/tests/e2e/test_mini_swe_agent.py
@@ -6,13 +6,18 @@
 from __future__ import annotations
 
 import asyncio
+import sys
+import warnings
 from pathlib import Path
 
 import pytest
 import requests
+from _utils.utils import atof_records
 from nemo_fabric import EnvironmentConfig, Fabric, FabricConfig, HarnessConfig
 from nemo_fabric import InstructionConfig, InstructionsConfig, MetadataConfig
 from nemo_fabric import ModelConfig, RuntimeConfig
+from nemo_fabric import RelayAtifConfig, RelayAtofConfig, RelayAtofFileSinkConfig
+from nemo_fabric import RelayObservabilityConfig
 
 
 def mini_config(api_server: str, workspace: Path) -> FabricConfig:
@@ -35,10 +40,15 @@ def mini_config(api_server: str, workspace: Path) -> FabricConfig:
         instructions=InstructionsConfig(
             system=InstructionConfig(content="Make the requested change.")
         ),
-        runtime=RuntimeConfig(max_turns=2, timeout_seconds=60),
+        runtime=RuntimeConfig(
+            max_turns=2,
+            timeout_seconds=60,
+            artifacts=workspace / "artifacts",
+        ),
         environment=EnvironmentConfig(
             provider="local",
             workspace=workspace,
+            artifacts=workspace / "artifacts",
             env={"FABRIC_TEST_API_KEY": "test-key"},
         ),
     )
@@ -67,6 +77,7 @@ async def test_mini_swe_agent_plans_diagnoses_and_runs(
     monkeypatch.setenv("MSWEA_SILENT_STARTUP", "1")
     monkeypatch.setenv("MSWEA_COST_TRACKING", "ignore_errors")
     monkeypatch.setenv("MSWEA_GLOBAL_CONFIG_DIR", str(tmp_path / "mini-config"))
+    monkeypatch.setenv("ADAPTER_PYTHON", sys.executable)
     config = mini_config(api_server, tmp_path)
     client = Fabric()
 
@@ -81,3 +92,88 @@ async def test_mini_swe_agent_plans_diagnoses_and_runs(
     assert result.status == "succeeded", result.to_mapping()
     assert result.output["output"] == "done\n"
     assert result.output["usage"]["api_calls"] == 1
+
+
+@pytest.mark.usefixtures("nemo_relay")
+async def test_mini_swe_agent_streams_relay_telemetry(
+    api_server: str,
+    repo_root: Path,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    response = await asyncio.to_thread(
+        requests.post,
+        f"{api_server}/_scenario",
+        json={
+            "tool_call": {
+                "name": "bash",
+                "arguments": {
+                    "command": "printf 'COMPLETE_TASK_AND_SUBMIT_FINAL_OUTPUT\\ndone\\n'"
+                },
+            }
+        },
+        timeout=5,
+    )
+    response.raise_for_status()
+    monkeypatch.setenv("MSWEA_SILENT_STARTUP", "1")
+    monkeypatch.setenv("MSWEA_COST_TRACKING", "ignore_errors")
+    monkeypatch.setenv("MSWEA_GLOBAL_CONFIG_DIR", str(tmp_path / "mini-config"))
+    monkeypatch.setenv("ADAPTER_PYTHON", sys.executable)
+    config = mini_config(api_server, tmp_path)
+    relay_output = tmp_path / "artifacts" / "relay"
+    config.enable_relay(
+        output_dir=relay_output,
+        observability=RelayObservabilityConfig(
+            atif=RelayAtifConfig(
+                enabled=True,
+                output_directory=relay_output,
+                agent_name="mini-swe-agent-test",
+            ),
+            atof=RelayAtofConfig(
+                enabled=True,
+                sinks=[
+                    RelayAtofFileSinkConfig(
+                        output_directory=relay_output,
+                        filename="events.atof.jsonl",
+                        mode="overwrite",
+                    )
+                ],
+            ),
+        ),
+    )
+
+    with warnings.catch_warnings():
+        warnings.simplefilter("error", RuntimeWarning)
+        async with await Fabric().start_runtime(
+            config,
+            base_dir=repo_root,
+            streaming=True,
+        ) as runtime:
+            stream = runtime.invoke_stream(input="Finish the task.")
+            records = [record async for record in stream]
+            result = await stream.result()
+
+    assert records
+    assert result.status == "succeeded", result.to_mapping()
+    assert result.output["output"] == "done\n"
+    assert result.telemetry[0].provider == "relay"
+    assert {artifact["kind"] for artifact in result.output["relay_artifacts"]} >= {
+        "atof",
+        "atif",
+    }
+    categories = {record["category"] for record in records}
+    assert {"agent", "function", "llm", "tool"} <= categories
+    persisted_records = atof_records(result.output)
+    llm_start = next(
+        record
+        for record in persisted_records
+        if record["category"] == "llm" and record["scope_category"] == "start"
+    )
+    tool_start = next(
+        record
+        for record in persisted_records
+        if record["category"] == "tool" and record["scope_category"] == "start"
+    )
+    assert llm_start["data"]["content"]["model"] == "openai/gpt-4o-mini"
+    assert tool_start["name"] == "bash"
+    assert tool_start["data"]["command"].startswith("printf ")

--- a/uv.lock
+++ b/uv.lock
@@ -2552,6 +2552,9 @@ dependencies = [
 harness = [
     { name = "mini-swe-agent" },
 ]
+relay = [
+    { name = "nemo-relay" },
+]
 
 [package.metadata]
 requires-dist = [
@@ -2559,8 +2562,10 @@ requires-dist = [
     { name = "mini-swe-agent", marker = "extra == 'harness'", specifier = ">=2.0,<3" },
     { name = "nemo-fabric-adapter-contract", editable = "adapter-contract/python" },
     { name = "nemo-fabric-adapters-common", editable = "adapters/common" },
+    { name = "nemo-relay", marker = "extra == 'full'", specifier = ">=0.7.2,<0.8" },
+    { name = "nemo-relay", marker = "extra == 'relay'", specifier = ">=0.7.2,<0.8" },
 ]
-provides-extras = ["harness", "full"]
+provides-extras = ["harness", "relay", "full"]
 
 [[package]]
 name = "nemo-fabric-development"
@@ -2610,7 +2615,7 @@ adapters = [
     { name = "nemo-fabric-adapters-common" },
     { name = "nemo-fabric-adapters-deepagents", extra = ["relay"] },
     { name = "nemo-fabric-adapters-hermes", marker = "python_full_version < '3.14'" },
-    { name = "nemo-fabric-adapters-mini-swe-agent" },
+    { name = "nemo-fabric-adapters-mini-swe-agent", extra = ["relay"] },
 ]
 dev = [
     { name = "ipython" },
@@ -2681,7 +2686,7 @@ adapters = [
     { name = "nemo-fabric-adapters-common", editable = "adapters/common" },
     { name = "nemo-fabric-adapters-deepagents", extras = ["relay"], editable = "adapters/deepagents" },
     { name = "nemo-fabric-adapters-hermes", marker = "python_full_version < '3.14'", editable = "adapters/hermes" },
-    { name = "nemo-fabric-adapters-mini-swe-agent", editable = "adapters/mini-swe-agent" },
+    { name = "nemo-fabric-adapters-mini-swe-agent", extras = ["relay"], editable = "adapters/mini-swe-agent" },
 ]
 dev = [
     { name = "ipython", specifier = "~=8.20" },


### PR DESCRIPTION
#### Overview

Add opt-in Relay telemetry to the mini-SWE-agent adapter through an adapter-owned agent subclass, following the upstream maintainer's recommendation in SWE-agent/mini-swe-agent#853.

When Relay is enabled, the adapter now emits agent, function, LLM, and tool events for live ATOF streaming and downstream ATIF/OpenTelemetry/OpenInference export. When Relay is disabled, the adapter continues to use `RetainingDefaultAgent` and does not import Relay. Native OpenAI token streaming is intentionally unchanged.

This adds the optional `nemo-relay>=0.7.2,<0.8` dependency through `relay` and `full` extras. Relay is already used elsewhere in this repository, and the license diff against `upstream/main` reports no dependency or license changes. There are no breaking changes.

#### Details

- Add an adapter-owned `RelayDefaultAgent` subclass with agent/function/LLM/tool scopes.
- Preserve mini-SWE-agent behavior while degrading telemetry failures without failing the agent run.
- Support live ATOF events alongside the existing artifact collection and ATIF conversion path.
- Select the subclass only when Relay is enabled; keep the existing non-Relay path isolated from the optional dependency.
- Update the adapter descriptor, package extras and locks, SDK/integration/install docs, and unit/E2E coverage.
- Correct the submission protocol so the final command prints the sentinel and response together, matching mini-SWE-agent's immediate exit behavior.

Quick ATIF reference: Phoenix rendering of the exported trajectory, including LLM and bash tool spans.
<img width="706" height="664" alt="image" src="https://github.com/user-attachments/assets/a24a79a5-15b2-4eff-99bc-bb067cadf6c3" />

#### Where should the reviewer start?

Start with `adapters/mini-swe-agent/src/nemo_fabric_adapters/mini_swe_agent/agents.py`, then review the selection/wiring in `adapter.py` and the assertions in `tests/adapters/test_mini_swe_agent.py` and `tests/e2e/test_mini_swe_agent.py`.


#### Validation

- `uv run --no-sync pytest tests/adapters/test_mini_swe_agent.py tests/e2e/test_mini_swe_agent.py` — 13 passed.
- `uv run --no-sync pytest --ignore=tests/scripts/test_attributions_lockfile_md.py` — 1244 passed, 17 skipped. The ignored path is an unrelated untracked local file and is not part of this PR.
- `just lock-python`
- `just wheels`
- `just check-wheel-licenses`
- `just docs` — passed; the expected Fern redirect check was skipped because Fern authentication is unavailable.
- `uvx --from pre-commit==4.6.0 pre-commit run --all-files --show-diff-on-failure`
- `uv run --no-project python scripts/licensing/license_diff.py --base-ref upstream/main` — no Rust, Node, or Python license changes.
- NVIDIA-hosted model smoke run with `nvidia/nemotron-3-nano-omni-30b-a3b-reasoning` — succeeded and produced agent, function, LLM, and tool telemetry plus ATOF and ATIF artifacts.

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- Relates to https://github.com/SWE-agent/mini-swe-agent/issues/853

- [x] I confirm this contribution is my own work, or I have the right to submit it under this project's license.
- [x] I searched existing issues and open pull requests, and this does not duplicate existing work.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added optional Relay telemetry for mini-SWE-agent.
  * Added ATIF, OpenTelemetry, and OpenInference outputs, streaming telemetry, and artifact collection.
  * Added support for Relay projects, components, policies, and observability settings.
  * Preserved conversation state across invocations and improved final output submission handling.

* **Documentation**
  * Expanded installation, configuration, compatibility, and telemetry guidance.
  * Clarified unsupported MCP, skills, tool policy, and native OpenAI streaming capabilities.

* **Tests**
  * Added coverage for telemetry, artifacts, streaming, degraded telemetry, and validation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
