### PR TITLE
feat: propagate UUID request IDs to Relay

### DIFF
--- a/adapters/deepagents/src/nemo_fabric_adapters/deepagents/adapter.py
+++ b/adapters/deepagents/src/nemo_fabric_adapters/deepagents/adapter.py
@@ -963,12 +963,14 @@ def _join_faults(*faults: str | None) -> str | None:
 
 
 def _relay_request_context(request_id: str) -> tuple[Any, dict[str, str]]:
-    """Use a UUID request id as Relay's propagated root, or preserve it as metadata."""
+    """Use a UUID request id as Relay's propagated root and preserve its metadata."""
+
+    metadata = {"nemo_fabric_request_id": request_id}
 
     try:
         request_uuid = str(uuid.UUID(request_id))
     except ValueError:
-        return nullcontext(), {"nemo_fabric_request_id": request_id}
+        return nullcontext(), metadata
 
     from nemo_relay import PropagationContext
     from nemo_relay import create_scope_stack_from_propagation
@@ -976,7 +978,7 @@ def _relay_request_context(request_id: str) -> tuple[Any, dict[str, str]]:
 
     propagation = PropagationContext(request_uuid, root_uuid=request_uuid)
     stack = create_scope_stack_from_propagation(propagation)
-    return use_scope_stack(stack), {}
+    return use_scope_stack(stack), metadata
 
 
 def _relay_dependency_error() -> RuntimeError:

--- a/adapters/deepagents/src/nemo_fabric_adapters/deepagents/adapter.py
+++ b/adapters/deepagents/src/nemo_fabric_adapters/deepagents/adapter.py
@@ -18,6 +18,7 @@ import math
 import os
 import uuid
 from collections.abc import Callable
+from contextlib import nullcontext
 from pathlib import Path
 from typing import Any
 from typing import NamedTuple
@@ -689,7 +690,7 @@ class DeepAgentsRuntime:
     async def _invoke_with_telemetry(
         self,
         user_message: str,
-        request_id: str | None,
+        request_id: str,
     ) -> TurnOutcome:
         """Run one turn inside the Relay plugin/scope, isolating telemetry faults.
 
@@ -718,15 +719,17 @@ class DeepAgentsRuntime:
                 # plugin's ``__aexit__`` is replaced by any fault the plugin raises in
                 # turn, which would lose one of the two.
                 try:
-                    with self._relay_scope.scope(
-                        "deepagents-request",
-                        self._relay_scope_type.Agent,
-                        metadata={"nemo_fabric_request_id": request_id},
-                    ):
-                        outcome = await self._invoke_agent(
-                            user_message,
-                            callbacks=[callback_handler],
-                        )
+                    request_context, metadata = _relay_request_context(request_id)
+                    with request_context:
+                        with self._relay_scope.scope(
+                            "deepagents-request",
+                            self._relay_scope_type.Agent,
+                            metadata=metadata,
+                        ):
+                            outcome = await self._invoke_agent(
+                                user_message,
+                                callbacks=[callback_handler],
+                            )
                 except Exception as exc:
                     scope_error = _error_text(exc)
         except Exception as exc:  # telemetry lifecycle fault
@@ -957,6 +960,23 @@ def _join_faults(*faults: str | None) -> str | None:
     if not present:
         return None
     return "; ".join(present)
+
+
+def _relay_request_context(request_id: str) -> tuple[Any, dict[str, str]]:
+    """Use a UUID request id as Relay's propagated root, or preserve it as metadata."""
+
+    try:
+        request_uuid = str(uuid.UUID(request_id))
+    except ValueError:
+        return nullcontext(), {"nemo_fabric_request_id": request_id}
+
+    from nemo_relay import PropagationContext
+    from nemo_relay import create_scope_stack_from_propagation
+    from nemo_relay import use_scope_stack
+
+    propagation = PropagationContext(request_uuid, root_uuid=request_uuid)
+    stack = create_scope_stack_from_propagation(propagation)
+    return use_scope_stack(stack), {}
 
 
 def _relay_dependency_error() -> RuntimeError:

--- a/tests/adapters/test_deepagents.py
+++ b/tests/adapters/test_deepagents.py
@@ -262,13 +262,14 @@ def fake_relay_fixture(monkeypatch):
     class ScopeType:
         Agent = "agent"
 
-    class PropagationContext:
-        def __init__(self, parent_uuid: str, root_uuid: str | None = None) -> None:
-            self.parent_uuid = parent_uuid
-            self.root_uuid = root_uuid
-            calls.setdefault("propagation_contexts", []).append(
-                (parent_uuid, root_uuid)
-            )
+    def build_propagation_context(
+        parent_uuid: str,
+        root_uuid: str | None = None,
+    ) -> types.SimpleNamespace:
+        calls.setdefault("propagation_contexts", []).append((parent_uuid, root_uuid))
+        return types.SimpleNamespace(parent_uuid=parent_uuid, root_uuid=root_uuid)
+
+    propagation_context = MagicMock(side_effect=build_propagation_context)
 
     class _Handle:
         """Stand-in for nemo_relay ScopeHandle; the adapter compares ``uuid``."""
@@ -304,13 +305,13 @@ def fake_relay_fixture(monkeypatch):
         return stack[-1]
 
     def create_scope_stack_from_propagation(
-        context: PropagationContext,
-    ) -> PropagationContext:
+        context: types.SimpleNamespace,
+    ) -> types.SimpleNamespace:
         calls.setdefault("propagation_stacks", []).append(context)
         return context
 
     @contextlib.contextmanager
-    def use_scope_stack(context: PropagationContext) -> Iterator[None]:
+    def use_scope_stack(context: types.SimpleNamespace) -> Iterator[None]:
         calls.setdefault("used_propagation_stacks", []).append(context)
         yield
 
@@ -330,7 +331,7 @@ def fake_relay_fixture(monkeypatch):
     relay_root.plugin = plugin_mod
     relay_root.scope = scope_mod
     relay_root.ScopeType = ScopeType
-    relay_root.PropagationContext = PropagationContext
+    relay_root.PropagationContext = propagation_context
     relay_root.create_scope_stack_from_propagation = create_scope_stack_from_propagation
     relay_root.use_scope_stack = use_scope_stack
     integrations_pkg = types.ModuleType("nemo_relay.integrations")

--- a/tests/adapters/test_deepagents.py
+++ b/tests/adapters/test_deepagents.py
@@ -262,6 +262,14 @@ def fake_relay_fixture(monkeypatch):
     class ScopeType:
         Agent = "agent"
 
+    class PropagationContext:
+        def __init__(self, parent_uuid: str, root_uuid: str | None = None) -> None:
+            self.parent_uuid = parent_uuid
+            self.root_uuid = root_uuid
+            calls.setdefault("propagation_contexts", []).append(
+                (parent_uuid, root_uuid)
+            )
+
     class _Handle:
         """Stand-in for nemo_relay ScopeHandle; the adapter compares ``uuid``."""
 
@@ -295,6 +303,17 @@ def fake_relay_fixture(monkeypatch):
     def get_handle() -> _Handle:
         return stack[-1]
 
+    def create_scope_stack_from_propagation(
+        context: PropagationContext,
+    ) -> PropagationContext:
+        calls.setdefault("propagation_stacks", []).append(context)
+        return context
+
+    @contextlib.contextmanager
+    def use_scope_stack(context: PropagationContext) -> Iterator[None]:
+        calls.setdefault("used_propagation_stacks", []).append(context)
+        yield
+
     class NemoRelayDeepAgentsCallbackHandler:
         def __init__(self, *_args: object, **_kwargs: object) -> None:
             calls["callback_handler"] = self
@@ -311,6 +330,9 @@ def fake_relay_fixture(monkeypatch):
     relay_root.plugin = plugin_mod
     relay_root.scope = scope_mod
     relay_root.ScopeType = ScopeType
+    relay_root.PropagationContext = PropagationContext
+    relay_root.create_scope_stack_from_propagation = create_scope_stack_from_propagation
+    relay_root.use_scope_stack = use_scope_stack
     integrations_pkg = types.ModuleType("nemo_relay.integrations")
     da_integ = types.ModuleType("nemo_relay.integrations.deepagents")
     da_integ.add_nemo_relay_integration = add_nemo_relay_integration
@@ -550,6 +572,46 @@ async def test_relay_telemetry_wraps_agent_and_reports_artifacts(
     assert fake_relay["callback_handler"] in (fake_sdks["config"] or {}).get(
         "callbacks", []
     )
+
+
+@pytest.mark.parametrize(
+    ("request_id", "expected_contexts", "expected_metadata"),
+    [
+        (
+            "018f47a4-3af7-7d94-8e61-9f0f89b5d312",
+            [("018f47a4-3af7-7d94-8e61-9f0f89b5d312",) * 2],
+            {},
+        ),
+        ("request-1", [], {"nemo_fabric_request_id": "request-1"}),
+    ],
+)
+async def test_request_id_relay_correlation(
+    tmp_path,
+    make_payload,
+    monkeypatch,
+    fake_relay,
+    request_id,
+    expected_contexts,
+    expected_metadata,
+):
+    monkeypatch.setattr(
+        adapter.common_utils,
+        "load_relay_plugin_config",
+        lambda _payload: {"version": 1, "components": []},
+    )
+    payload = make_payload(tmp_path)
+    payload["request"]["request_id"] = request_id
+    payload["runtime_context"]["telemetry"] = {
+        "relay_enabled": True,
+        "metadata": {"telemetry_providers": ["relay"]},
+    }
+
+    await invoke_once(payload)
+
+    assert fake_relay.get("propagation_contexts", []) == expected_contexts
+    assert fake_relay["scope_metadata"] == [expected_metadata]
+    if expected_contexts:
+        assert fake_relay["used_propagation_stacks"] == fake_relay["propagation_stacks"]
 
 
 async def test_ambient_relay_config_fails_runtime_start_before_agent_creation(

--- a/tests/adapters/test_deepagents.py
+++ b/tests/adapters/test_deepagents.py
@@ -581,7 +581,9 @@ async def test_relay_telemetry_wraps_agent_and_reports_artifacts(
         (
             "018f47a4-3af7-7d94-8e61-9f0f89b5d312",
             [("018f47a4-3af7-7d94-8e61-9f0f89b5d312",) * 2],
-            {},
+            {
+                "nemo_fabric_request_id": "018f47a4-3af7-7d94-8e61-9f0f89b5d312"
+            },
         ),
         ("request-1", [], {"nemo_fabric_request_id": "request-1"}),
     ],

--- a/tests/e2e/test_deepagents.py
+++ b/tests/e2e/test_deepagents.py
@@ -59,7 +59,7 @@ async def test_deepagents_persistent_host_with_relay_and_mock_model(
 ):
     pytest.importorskip("deepagents")
     from examples.code_review_agent import deepagents_config, with_relay
-    from nemo_fabric import EnvironmentConfig, Fabric, RuntimeConfig
+    from nemo_fabric import EnvironmentConfig, Fabric, RunRequest, RuntimeConfig
 
     config = with_relay(deepagents_config())
     config.models["default"].base_url = f"{api_server}/v1"
@@ -81,17 +81,28 @@ async def test_deepagents_persistent_host_with_relay_and_mock_model(
             base_dir=tmp_path,
             streaming=True,
         ) as runtime:
-            first_stream = runtime.invoke_stream(input="first")
+            first_request = RunRequest(input="first", request_id=str(uuid.uuid4()))
+            first_stream = runtime.invoke_stream(request=first_request)
             first_records = [record async for record in first_stream]
             first = await first_stream.result()
 
-            second_stream = runtime.invoke_stream(input="second")
+            second_request = RunRequest(input="second", request_id=str(uuid.uuid4()))
+            second_stream = runtime.invoke_stream(request=second_request)
             second_records = [record async for record in second_stream]
             second = await second_stream.result()
 
     results = (first.to_mapping(), second.to_mapping())
     assert first_records
     assert second_records
+    for request, records in (
+        (first_request, first_records),
+        (second_request, second_records),
+    ):
+        assert any(
+            record.get("metadata", {}).get("nemo_fabric_request_id")
+            == request.request_id
+            for record in records
+        ), records
     assert first["status"] == second["status"] == "succeeded", results
     assert first["metadata"]["host_pid"] == second["metadata"]["host_pid"], results
     assert first["output"]["thread_id"] == second["output"]["thread_id"], results

--- a/tests/integrations/test_relay_scope_leak.py
+++ b/tests/integrations/test_relay_scope_leak.py
@@ -171,7 +171,7 @@ async def test_uuid_request_id_seeds_real_relay_parent(monkeypatch):
     assert outcome.error is None
     assert outcome.telemetry_error is None
     assert recording_scope.parent_uuids == [request_id]
-    assert recording_scope.metadata == [{}]
+    assert recording_scope.metadata == [{"nemo_fabric_request_id": request_id}]
     assert nemo_relay.scope.get_handle().uuid == baseline.uuid
 
 

--- a/tests/integrations/test_relay_scope_leak.py
+++ b/tests/integrations/test_relay_scope_leak.py
@@ -129,10 +129,14 @@ class _RecordingScope:
 
     def __init__(self) -> None:
         self.opened: list[str] = []
+        self.parent_uuids: list[str] = []
+        self.metadata: list[object] = []
 
     @contextlib.contextmanager
     def scope(self, name: str, scope_type: object, **kwargs: object):
         self.opened.append(name)
+        self.parent_uuids.append(str(nemo_relay.scope.get_handle().uuid))
+        self.metadata.append(kwargs.get("metadata"))
         with nemo_relay.scope.scope(name, scope_type, **kwargs):
             yield
 
@@ -143,6 +147,32 @@ class _NoopPlugin:
     @contextlib.asynccontextmanager
     async def plugin(self, config: object):
         yield {"diagnostics": [], "runtime_diagnostics": []}
+
+
+async def test_uuid_request_id_seeds_real_relay_parent(monkeypatch):
+    async def fake_invoke(agent, user_message, thread_id, callbacks=None):
+        return {"messages": []}, [], []
+
+    monkeypatch.setattr(adapter, "invoke_compiled_agent", fake_invoke)
+
+    baseline = nemo_relay.scope.get_handle()
+    recording_scope = _RecordingScope()
+    runtime = adapter.DeepAgentsRuntime()
+    runtime._agent = object()
+    runtime._relay_plugin = _NoopPlugin()
+    runtime._relay_plugin_config = {}
+    runtime._relay_scope = recording_scope
+    runtime._relay_scope_type = nemo_relay.ScopeType
+    runtime._callback_handler_type = NemoRelayCallbackHandler
+    request_id = "018f47a4-3af7-7d94-8e61-9f0f89b5d312"
+
+    outcome = await runtime._invoke_with_telemetry("hello", request_id)
+
+    assert outcome.error is None
+    assert outcome.telemetry_error is None
+    assert recording_scope.parent_uuids == [request_id]
+    assert recording_scope.metadata == [{}]
+    assert nemo_relay.scope.get_handle().uuid == baseline.uuid
 
 
 async def test_a_poisoned_runtime_quarantines_its_next_turn(monkeypatch):
@@ -187,3 +217,4 @@ async def test_a_poisoned_runtime_quarantines_its_next_turn(monkeypatch):
     assert second.telemetry_error == runtime._telemetry_quarantine
     assert "not at the top of the stack" not in second.telemetry_error
     assert recording_scope.opened == ["deepagents-request"]
+    assert recording_scope.metadata == [{"nemo_fabric_request_id": "request-1"}]


### PR DESCRIPTION
#### Overview

Use a UUID Fabric `request_id` as the propagated Relay root for Deep Agents telemetry. When the request ID is not a UUID, preserve the existing correlation behavior by recording it as `nemo_fabric_request_id` metadata.

This is intentionally a Fabric-only adapter change: it does not add a session field or change the RunRequest, runtime-context, or adapter schemas.

#### Details

- Validate `runtime_context.request_id` with Python's UUID parser.
- For UUID values, create an isolated Relay scope stack whose parent and root are the request UUID, then open the existing Agent scope beneath it.
- For non-UUID values, keep Relay's default scope root and attach the request ID to the Agent scope metadata.
- Restore the prior Relay scope stack after every UUID request.
- Add unit coverage for both branches and an integration test against the real Relay propagation API.

With `session_id_source = "propagation_root"` from NVIDIA/NeMo-Relay#959, the same UUID is emitted as the ATIF `session_id` while Relay retains a distinct Agent/trajectory UUID.

#### Validation

- `uv run --no-sync pytest tests/adapters/test_deepagents.py tests/integrations/test_relay_scope_leak.py` — 80 passed
- `just --set no_uv true test-python` — 1,247 passed, 17 skipped
- Ruff format and lint checks on all three changed files
- `git diff --check`
- Cross-repository ATIF smoke test against NVIDIA/NeMo-Relay#959 confirmed `request_id == session_id` and a distinct `trajectory_id`

Not run: Rust and TypeScript suites because this change does not touch Rust, TypeScript, schemas, or native bindings.

#### Where should the reviewer start?

Start with `_relay_request_context` and its use around the Agent scope in `adapters/deepagents/src/nemo_fabric_adapters/deepagents/adapter.py`. The main design decision is to treat a UUID request ID as an explicit propagation signal while retaining metadata fallback for existing non-UUID IDs.

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- Relates to NVIDIA/NeMo-Relay#958

- [x] I confirm this contribution is my own work, or I have the right to submit it under this project's license.
- [x] I searched existing issues and open pull requests, and this does not duplicate existing work.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Relay telemetry now correlates requests using valid UUID request IDs and propagated request context.
  * Non-UUID request IDs continue to use request metadata for tracking.
  * Streaming requests now include their corresponding request identifiers in telemetry records.

* **Bug Fixes**
  * Improved telemetry scope handling and request correlation.
  * Scopes are restored after each request, preventing telemetry data from leaking between requests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->