### PR TITLE
ci: avoid anonymous Hermes source fetches

### DIFF
--- a/.github/workflows/ci_check.yml
+++ b/.github/workflows/ci_check.yml
@@ -29,6 +29,14 @@ jobs:
         with:
           persist-credentials: false
 
+      - name: Checkout Hermes Agent
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          repository: NousResearch/hermes-agent
+          ref: f80f453ae0679347e38abc917c7f94f717bf96c5
+          path: external/hermes-agent
+          persist-credentials: false
+
       - name: Set up uv
         uses: astral-sh/setup-uv@cec208311dfd045dd5311c1add060b2062131d57 # v8
         with:

--- a/.github/workflows/ci_python.yml
+++ b/.github/workflows/ci_python.yml
@@ -68,6 +68,15 @@ jobs:
           persist-credentials: false
           ref: ${{ inputs.ref || github.sha }}
 
+      - name: Checkout Hermes Agent
+        if: ${{ matrix.python-version != '3.14' }}
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          repository: NousResearch/hermes-agent
+          ref: f80f453ae0679347e38abc917c7f94f717bf96c5
+          path: external/hermes-agent
+          persist-credentials: false
+
       # Rust is needed both to build the native extension (maturin backend) and
       # because the CLI-backed smokes shell out to `cargo run -p nemo-fabric-cli`.
       - name: Set up Rust
@@ -136,6 +145,14 @@ jobs:
           persist-credentials: false
           fetch-depth: 0
           ref: ${{ inputs.ref || github.sha }}
+
+      - name: Checkout Hermes Agent
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          repository: NousResearch/hermes-agent
+          ref: f80f453ae0679347e38abc917c7f94f717bf96c5
+          path: external/hermes-agent
+          persist-credentials: false
 
       - name: Set up Rust
         uses: actions-rust-lang/setup-rust-toolchain@150fca883cd4034361b621bd4e6a9d34e5143606 # v1.15.4

--- a/.github/workflows/fern-docs.yml
+++ b/.github/workflows/fern-docs.yml
@@ -71,6 +71,14 @@ jobs:
           fetch-depth: 1
           persist-credentials: false
 
+      - name: Checkout Hermes Agent
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          repository: NousResearch/hermes-agent
+          ref: f80f453ae0679347e38abc917c7f94f717bf96c5
+          path: source-checkout/external/hermes-agent
+          persist-credentials: false
+
       - name: Install just
         uses: taiki-e/install-action@c070f87102a1c75b3183910f391c1cb887fe13c8 # v2.77.6
         with:

--- a/justfile
+++ b/justfile
@@ -366,8 +366,11 @@ install-hermes-agent:
         echo "ERROR: Hermes Agent checkout has tracked changes: $hermes_checkout" >&2
         exit 1
     fi
-    git -C "$hermes_checkout" fetch --depth 1 origin "$hermes_commit"
-    git -C "$hermes_checkout" checkout --quiet --detach FETCH_HEAD
+    hermes_head="$(git -C "$hermes_checkout" rev-parse --verify HEAD 2>/dev/null || true)"
+    if [[ "$hermes_head" != "$hermes_commit" ]]; then
+        git -C "$hermes_checkout" fetch --depth 1 origin "$hermes_commit"
+        git -C "$hermes_checkout" checkout --quiet --detach FETCH_HEAD
+    fi
     uv sync --inexact --reinstall-package hermes-agent
 
 # Build the TypeScript contract and adapter packages using their locked dependencies.


### PR DESCRIPTION
#### Overview

Replace anonymous Hermes Agent fetches in GitHub Actions with authenticated, commit-pinned secondary checkouts. This prevents the Python, wheel, pre-commit, and Fern preview jobs from independently hitting GitHub's anonymous Git rate limit while preserving the existing local installation workflow.

#### Details

- Check out `NousResearch/hermes-agent` at the Fabric-pinned commit with the existing full-SHA-pinned `actions/checkout` action.
- Place the source at the editable path already declared by Fabric: `external/hermes-agent`.
- Teach `just install-hermes-agent` to validate the current `HEAD` and skip `git fetch` when CI has already supplied the exact pinned commit.
- Retain the existing shallow-fetch fallback for local development when the checkout is missing or points at another commit.
- Continue using `uv sync` and its existing lockfile-backed cache for installation.

#### Validation

- `just --fmt --check`
- `git diff --check`
- `pre-commit run copyright-header --files .github/workflows/ci_check.yml .github/workflows/ci_python.yml .github/workflows/fern-docs.yml justfile`
- `pre-commit run actionlint --all-files`
- Focused mocked recipe validation proving that an exact pinned checkout skips `git fetch` and a mismatched checkout retains the fetch-and-checkout fallback

The full Python matrix was not run locally because no Python or product behavior changed; the pull request's ordinary GitHub Actions jobs provide the end-to-end checkout and installation validation. NVSkills was not invoked.

#### Where should the reviewer start?

Start with `justfile` and then compare the secondary checkout in `.github/workflows/ci_python.yml` with the existing Hermes installation step.

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- Relates to: none

- [x] I confirm this contribution is my own work, or I have the right to submit it under this project's license.
- [x] I searched existing issues and open pull requests, and this does not duplicate existing work.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Improved automated setup for the pinned Hermes Agent component across testing, build, and documentation workflows.
  - Reduced unnecessary repository updates when the required Hermes Agent version is already available.
  - Ensured consistent Hermes Agent availability during CI checks, package builds, and documentation previews.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->