### PR TITLE
docs: fix spacing in Hermes installation instructions

### DIFF
--- a/sdk/python/nemo-fabric/pypi.md
+++ b/sdk/python/nemo-fabric/pypi.md
@@ -67,7 +67,7 @@ pip install "nemo-fabric[deepagents]"
 pip install "nemo-fabric[mini-swe-agent]"
 ```
 
-Hermes Agent 0.20 and later is not installable from PyPI. For this reason the Hermes Agent adapter does not provide a `harness` extra.Follow the
+Hermes Agent 0.20 and later is not installable from PyPI. For this reason the Hermes Agent adapter does not provide a `harness` extra. Follow the
 [Hermes Agent installation guide](https://hermes-agent.nousresearch.com/docs/installation),
 then install `nemo-fabric` and `nemo-fabric-adapters-hermes` into the Python
 environment that runs Hermes Agent.


### PR DESCRIPTION
#### Overview

Fixes a missing space in Hermes installation instructions.

#### Where should the reviewer start?

See `sdk/python/nemo-fabric/pypi.md`.

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- Relates to: none

#### Validation
- `uv run --no-sync pre-commit run --files sdk/python/nemo-fabric/pypi.md` 

#### Breaking changes

- None


- [x] I confirm this contribution is my own work, or I have the right to submit it under this project's license.
- [x] I searched existing issues and open pull requests, and this does not duplicate existing work.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Corrected spacing in the Hermes Agent installation guidance for improved readability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->