### PR TITLE
chore: update fast-uri to patched release

### DIFF
--- a/ATTRIBUTIONS-Node.md
+++ b/ATTRIBUTIONS-Node.md
@@ -17833,7 +17833,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 ```
 
-## fast-uri - 3.1.5
+## fast-uri - 3.1.7
 **Repository URL**: https://github.com/fastify/fast-uri
 **License Type(s)**: BSD-3-Clause
 ### License: https://spdx.org/licenses/BSD-3-Clause.html

--- a/adapters/typescript/package-lock.json
+++ b/adapters/typescript/package-lock.json
@@ -2894,9 +2894,9 @@
       "license": "MIT"
     },
     "node_modules/fast-uri": {
-      "version": "3.1.5",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.5.tgz",
-      "integrity": "sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw==",
+      "version": "3.1.7",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.7.tgz",
+      "integrity": "sha512-dOvZVzjdZdz7phd9v6jCbwxrBW3fK6n8Rc0CtdmM4bumzMnxywBYhuph6J819RRw/ku+rLbelwfMunktuzVVHg==",
       "funding": [
         {
           "type": "github",


### PR DESCRIPTION
#### Overview

Refresh the locked transitive `fast-uri` dependency from 3.1.5 to 3.1.7 after four newly published high-severity advisories caused `npm audit --audit-level=high` to fail on `main`.

The patched release remains within AJV's existing `^3.0.1` range, so no manifest or direct-dependency change is needed. The license remains BSD-3-Clause; `ATTRIBUTIONS-Node.md` is regenerated to record the patched version.

- [x] I confirm this contribution is my own work, or I have the right to submit it under this project's license.
- [x] I searched existing issues and open pull requests, and this does not duplicate existing work.

#### Details

- Update `fast-uri` from 3.1.5 to 3.1.7 in the TypeScript adapter lockfile.
- Regenerate the Node attribution inventory.
- Preserve the existing `npm audit` gate rather than suppressing the new security findings.

#### Validation

- `just test-typescript-adapters`
- `uv run --no-project python scripts/licensing/license_diff.py --base-ref upstream/main`
- `uvx --from pre-commit pre-commit run --all-files attributions-rust`
- `uvx --from pre-commit pre-commit run --all-files attributions-python`
- `uvx --from pre-commit pre-commit run --all-files attributions-node`
- `just --fmt --check`
- `git diff --check`

No breaking changes.

#### Where should the reviewer start?

Start with `adapters/typescript/package-lock.json`; the only resolution change is `fast-uri` 3.1.5 to 3.1.7. Then verify the corresponding version update in `ATTRIBUTIONS-Node.md`.

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- Relates to: none


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the listed `fast-uri` attribution from version 3.1.5 to 3.1.7.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->