### PR TITLE
fix: map Deep Agents max turns to recursion limit

### DIFF
--- a/adapters/README.md
+++ b/adapters/README.md
@@ -126,7 +126,7 @@ and additive extension maps because their support does not vary by adapter:
 | `instructions.system` | `replace`, `append` | `replace`; base instructions | `replace` | `replace` | `replace` | `replace`; Pi base instructions | `replace` |
 | `runtime.input_schema`, `.output_schema` | Core | Core | Core | Core | Core | Core | Core |
 | `runtime.artifacts`, `.timeout_seconds` | Core | Core | Core | Core | Core | Core | Core |
-| `runtime.max_turns` | Yes | No | No | Yes; iteration limit | Yes | No | No |
+| `runtime.max_turns` | Yes | No | Yes; maps to LangGraph supersteps | Yes; iteration limit | Yes | No | No |
 | `environment.provider`, `.control_location`, `.ownership` | Core | Core | Core | Core | Core | Core | Core |
 | `environment.workspace`, `.artifacts`, `.env` | Core | Core | Core | Core | Core | Core | Core |
 | `environment.connection`, `.metadata`, `.settings` | Environment-provider-owned | Environment-provider-owned | Environment-provider-owned | Environment-provider-owned | Environment-provider-owned | Environment-provider-owned | Environment-provider-owned |

--- a/adapters/deepagents/README.md
+++ b/adapters/deepagents/README.md
@@ -55,9 +55,10 @@ NeMo Fabric maps the following into the harness:
 - `instructions.system` supports `replace` and becomes the Deep Agents
   `system_prompt`. Deep Agents rejects `append`.
 - `runtime.timeout_seconds` sets the NeMo Fabric invocation deadline.
-- `runtime.max_turns` maps directly to LangGraph's `recursion_limit`, which
-  counts graph supersteps rather than model calls or tool calls. Omitting the
-  field preserves the Deep Agents default.
+- `runtime.max_turns=10` configures LangGraph with `recursion_limit=10`. This
+  is a graph-superstep budget, not a promise of ten model responses or tool
+  calls; one interaction can consume multiple supersteps. Omitting the field
+  preserves the Deep Agents default.
 - `environment.workspace` roots the Deep Agents filesystem backend
   (`FilesystemBackend(root_dir=..., virtual_mode=True)`). `virtual_mode`
   confines the agent to the workspace: absolute paths and `..` cannot escape
@@ -132,14 +133,16 @@ subagent **inherits** the parent run's model, tools, skills, workspace,
 telemetry, and permissions. When a normalized tools policy is configured,
 NeMo Fabric supplies an explicitly gated `general-purpose` subagent so
 delegation cannot broaden capabilities beyond the parent. Caller-defined
-declarative subagents run through the same local graph. Agent Protocol
-subagents run asynchronously on their configured server. Precompiled
+declarative subagents are separate locally compiled graphs invoked through the
+`task` tool. Agent Protocol subagents run asynchronously on their configured
+server. Precompiled
 subagents are not exposed through the public NeMo Fabric SDK because their
 `runnable` objects cannot cross the JSON configuration boundary.
 
-The configured `runtime.max_turns` limit applies to the local graph and its
-declarative subagents. Agent Protocol subagents manage their own recursion
-limit in the remote service.
+The configured `runtime.max_turns` limit applies as `recursion_limit` to the
+main local graph. Declarative subagent graphs retain their Deep Agents limits,
+and Agent Protocol subagents manage their own recursion limit in the remote
+service.
 
 The normalized result includes the final response, buffered messages and
 per-step events, LangGraph thread id, token usage (and cost when the provider

--- a/adapters/deepagents/README.md
+++ b/adapters/deepagents/README.md
@@ -57,8 +57,8 @@ NeMo Fabric maps the following into the harness:
 - `runtime.timeout_seconds` sets the NeMo Fabric invocation deadline.
 - `runtime.max_turns=10` configures LangGraph with `recursion_limit=10`. This
   is a graph-superstep budget, not a promise of ten model responses or tool
-  calls; one interaction can consume multiple supersteps. Omitting the field
-  preserves the Deep Agents default.
+  calls. One interaction can consume multiple supersteps. Omit the field
+  to preserve the Deep Agents default.
 - `environment.workspace` roots the Deep Agents filesystem backend
   (`FilesystemBackend(root_dir=..., virtual_mode=True)`). `virtual_mode`
   confines the agent to the workspace: absolute paths and `..` cannot escape

--- a/adapters/deepagents/README.md
+++ b/adapters/deepagents/README.md
@@ -55,6 +55,9 @@ NeMo Fabric maps the following into the harness:
 - `instructions.system` supports `replace` and becomes the Deep Agents
   `system_prompt`. Deep Agents rejects `append`.
 - `runtime.timeout_seconds` sets the NeMo Fabric invocation deadline.
+- `runtime.max_turns` maps directly to LangGraph's `recursion_limit`, which
+  counts graph supersteps rather than model calls or tool calls. Omitting the
+  field preserves the Deep Agents default.
 - `environment.workspace` roots the Deep Agents filesystem backend
   (`FilesystemBackend(root_dir=..., virtual_mode=True)`). `virtual_mode`
   confines the agent to the workspace: absolute paths and `..` cannot escape
@@ -133,6 +136,10 @@ declarative subagents run through the same local graph. Agent Protocol
 subagents run asynchronously on their configured server. Precompiled
 subagents are not exposed through the public NeMo Fabric SDK because their
 `runnable` objects cannot cross the JSON configuration boundary.
+
+The configured `runtime.max_turns` limit applies to the local graph and its
+declarative subagents. Agent Protocol subagents manage their own recursion
+limit in the remote service.
 
 The normalized result includes the final response, buffered messages and
 per-step events, LangGraph thread id, token usage (and cost when the provider

--- a/adapters/deepagents/deepagents.fabric-adapter.json
+++ b/adapters/deepagents/deepagents.fabric-adapter.json
@@ -168,6 +168,7 @@
       "models.base_url",
       "models.temperature",
       "instructions.system",
+      "runtime.max_turns",
       "tools.enabled",
       "tools.blocked",
       "mcp",

--- a/adapters/deepagents/src/nemo_fabric_adapters/deepagents/adapter.py
+++ b/adapters/deepagents/src/nemo_fabric_adapters/deepagents/adapter.py
@@ -24,6 +24,7 @@ from typing import NamedTuple
 
 from langchain.agents.middleware import AgentMiddleware
 from langchain_core.messages import ToolMessage
+from langgraph.errors import GraphRecursionError
 from nemo_fabric_adapter_contract.models import AgentConfig
 from nemo_fabric_adapter_contract.models import AgentMcpServerConfig
 from nemo_fabric_adapter_contract.models import AgentModelConfig
@@ -684,7 +685,7 @@ class DeepAgentsRuntime:
             output=output,
             error=(
                 AgentRunError(
-                    code="deepagents_invocation_failed",
+                    code=outcome.error_code or "deepagents_invocation_failed",
                     message=str(reported_error or "Deep Agents invocation failed"),
                 )
                 if failed
@@ -774,6 +775,11 @@ class DeepAgentsRuntime:
                 user_message,
                 self._thread_id,
                 callbacks=callbacks,
+            )
+        except GraphRecursionError:
+            return TurnOutcome(
+                error="Deep Agents reached its graph recursion limit.",
+                error_code="deepagents_recursion_limit_reached",
             )
         except Exception as exc:  # normalized adapter failure
             return TurnOutcome(error=_error_text(exc))
@@ -925,6 +931,7 @@ class TurnOutcome(NamedTuple):
     events: list[dict[str, Any]] | None = None
     turn_messages: list[dict[str, Any]] | None = None
     error: str | None = None
+    error_code: str | None = None
     telemetry_error: str | None = None
 
 

--- a/adapters/deepagents/src/nemo_fabric_adapters/deepagents/adapter.py
+++ b/adapters/deepagents/src/nemo_fabric_adapters/deepagents/adapter.py
@@ -171,6 +171,10 @@ def selected_model_config(config: AgentConfig) -> AgentModelConfig:
     )
 
 
+def _max_turns(config: AgentConfig) -> int | None:
+    return config.runtime.max_turns if config.runtime is not None else None
+
+
 def build_chat_model(model_config: AgentModelConfig) -> tuple[Any, str, str | None]:
     """Build a LangChain chat model from Fabric model config.
 
@@ -560,9 +564,13 @@ class DeepAgentsRuntime:
 
             from deepagents import create_deep_agent
 
-            self._agent = create_deep_agent(
+            agent = create_deep_agent(
                 **_supported_kwargs(create_deep_agent, agent_kwargs)
             )
+            max_turns = _max_turns(agent_config)
+            if max_turns is not None:
+                agent = agent.with_config({"recursion_limit": max_turns})
+            self._agent = agent
             self._start_payload = payload
             self._started = True
         except BaseException:

--- a/crates/fabric-cli/assets/adapters/deepagents/deepagents.fabric-adapter.json
+++ b/crates/fabric-cli/assets/adapters/deepagents/deepagents.fabric-adapter.json
@@ -168,6 +168,7 @@
       "models.base_url",
       "models.temperature",
       "instructions.system",
+      "runtime.max_turns",
       "tools.enabled",
       "tools.blocked",
       "mcp",

--- a/crates/fabric-core/src/config.rs
+++ b/crates/fabric-core/src/config.rs
@@ -5138,25 +5138,42 @@ mod tests {
 
     #[test]
     fn unsupported_normalized_scalar_reports_adapter_config_incompatibility() {
-        for adapter_id in ["nvidia.fabric.codex", "nvidia.fabric.langchain.deepagents"] {
-            let mut config = typed_config(adapter_id);
-            config.runtime.max_turns = Some(3);
+        let adapter_id = "nvidia.fabric.codex";
+        let mut config = typed_config(adapter_id);
+        config.runtime.max_turns = Some(3);
 
-            let error = resolve_run_plan_from_config(
-                config,
-                ResolveContext::new("/tmp/fabric-incompatible"),
-            )
-            .expect_err("adapter does not advertise max_turns");
+        let error =
+            resolve_run_plan_from_config(config, ResolveContext::new("/tmp/fabric-incompatible"))
+                .expect_err("adapter does not advertise max_turns");
 
-            assert!(matches!(
-                error,
-                FabricError::AdapterCompatibility {
-                    adapter_id: actual,
-                    field,
-                    ..
-                } if actual == adapter_id && field == "runtime.max_turns"
-            ));
-        }
+        assert!(matches!(
+            error,
+            FabricError::AdapterCompatibility {
+                adapter_id: actual,
+                field,
+                ..
+            } if actual == adapter_id && field == "runtime.max_turns"
+        ));
+    }
+
+    #[test]
+    fn deepagents_max_turns_projects_to_agent_config() {
+        let mut config = typed_config("nvidia.fabric.langchain.deepagents");
+        config.runtime.max_turns = Some(3);
+
+        let plan = resolve_run_plan_from_config(
+            config,
+            ResolveContext::new("/tmp/fabric-deepagents-max-turns"),
+        )
+        .expect("Deep Agents advertises max_turns");
+
+        assert_eq!(
+            plan.agent_config
+                .runtime
+                .expect("projected runtime config")
+                .max_turns,
+            Some(3)
+        );
     }
 
     #[test]

--- a/docs/integrations/harness/deepagents.mdx
+++ b/docs/integrations/harness/deepagents.mdx
@@ -103,9 +103,10 @@ harness = HarnessConfig(
 
 The descriptor closes both `harness.settings` and its nested `deepagents`
 object, so planning rejects unknown settings before runtime start.
-`runtime.max_turns` maps directly to LangGraph's `recursion_limit`. LangGraph
-counts graph supersteps rather than model calls or tool calls. When
-`runtime.max_turns` is omitted, the adapter keeps the Deep Agents default.
+`runtime.max_turns=10` configures LangGraph with `recursion_limit=10`. This is
+a graph-superstep budget, not a promise of ten model responses or tool calls;
+one interaction can consume multiple supersteps. When `runtime.max_turns` is
+omitted, the adapter keeps the Deep Agents default.
 `interrupt_on` maps tool names to booleans or an object with
 `allowed_decisions`; supported decisions are `approve`, `edit`, `reject`, and
 `respond`. The object can also contain a static `description` and an
@@ -123,11 +124,13 @@ because a local tools policy cannot gate remote tools.
 ## Understand the Runtime Lifecycle
 
 Each NeMo Fabric runtime compiles one Deep Agents graph and retains its
-checkpointer and LangGraph thread across ordered invocations. The built-in
-subagent inherits the parent run's model, tools, skills, workspace, telemetry,
-permissions, and recursion limit. Declarative subagents run in the same local
-graph. Agent Protocol subagents run in a separate service and manage their own
-recursion limit.
+checkpointer and LangGraph thread across ordered invocations. The built-in and
+caller-defined declarative subagents are separate locally compiled graphs
+invoked through the `task` tool. They inherit the parent run's model, tools,
+skills, workspace, telemetry, and permissions. `runtime.max_turns` configures
+only the main local graph; declarative subagent graphs retain their Deep Agents
+limits. Agent Protocol subagents run in a separate service and manage their
+own recursion limit.
 
 NeMo Relay provides the SDK-native observability integration for this adapter.
 Native OpenTelemetry and OpenInference exporters are also available through the

--- a/docs/integrations/harness/deepagents.mdx
+++ b/docs/integrations/harness/deepagents.mdx
@@ -128,7 +128,7 @@ checkpointer and LangGraph thread across ordered invocations. The built-in and
 caller-defined declarative subagents are separate locally compiled graphs
 invoked through the `task` tool. They inherit the parent run's model, tools,
 skills, workspace, telemetry, and permissions. `runtime.max_turns` configures
-only the main local graph; declarative subagent graphs retain their Deep Agents
+only the main local graph, while declarative subagent graphs retain their Deep Agents
 limits. Agent Protocol subagents run in a separate service and manage their
 own recursion limit.
 

--- a/docs/integrations/harness/deepagents.mdx
+++ b/docs/integrations/harness/deepagents.mdx
@@ -103,6 +103,9 @@ harness = HarnessConfig(
 
 The descriptor closes both `harness.settings` and its nested `deepagents`
 object, so planning rejects unknown settings before runtime start.
+`runtime.max_turns` maps directly to LangGraph's `recursion_limit`. LangGraph
+counts graph supersteps rather than model calls or tool calls. When
+`runtime.max_turns` is omitted, the adapter keeps the Deep Agents default.
 `interrupt_on` maps tool names to booleans or an object with
 `allowed_decisions`; supported decisions are `approve`, `edit`, `reject`, and
 `respond`. The object can also contain a static `description` and an
@@ -122,7 +125,9 @@ because a local tools policy cannot gate remote tools.
 Each NeMo Fabric runtime compiles one Deep Agents graph and retains its
 checkpointer and LangGraph thread across ordered invocations. The built-in
 subagent inherits the parent run's model, tools, skills, workspace, telemetry,
-and permissions.
+permissions, and recursion limit. Declarative subagents run in the same local
+graph. Agent Protocol subagents run in a separate service and manage their own
+recursion limit.
 
 NeMo Relay provides the SDK-native observability integration for this adapter.
 Native OpenTelemetry and OpenInference exporters are also available through the

--- a/docs/integrations/harness/deepagents.mdx
+++ b/docs/integrations/harness/deepagents.mdx
@@ -104,8 +104,8 @@ harness = HarnessConfig(
 The descriptor closes both `harness.settings` and its nested `deepagents`
 object, so planning rejects unknown settings before runtime start.
 `runtime.max_turns=10` configures LangGraph with `recursion_limit=10`. This is
-a graph-superstep budget, not a promise of ten model responses or tool calls;
-one interaction can consume multiple supersteps. When `runtime.max_turns` is
+a graph-superstep budget, not a promise of ten model responses or tool calls.
+One interaction can consume multiple supersteps. When `runtime.max_turns` is
 omitted, the adapter keeps the Deep Agents default.
 `interrupt_on` maps tool names to booleans or an object with
 `allowed_decisions`; supported decisions are `approve`, `edit`, `reject`, and

--- a/docs/sdk/python.mdx
+++ b/docs/sdk/python.mdx
@@ -189,7 +189,7 @@ by adapter:
 | `instructions.system` | `replace`, `append` | `replace`; maps to Codex base instructions | `replace` | `replace` | `replace` |
 | `runtime.input_schema`, `.output_schema` | Core | Core | Core | Core | Core |
 | `runtime.artifacts`, `.timeout_seconds` | Core | Core | Core | Core | Core |
-| `runtime.max_turns` | Yes | No | No | Yes; maps to Hermes iterations | Yes |
+| `runtime.max_turns` | Yes | No | Yes; maps to LangGraph supersteps | Yes; maps to Hermes iterations | Yes |
 | `environment.provider`, `.control_location`, `.ownership` | Core | Core | Core | Core | Core |
 | `environment.workspace`, `.artifacts`, `.env` | Core | Core | Core | Core | Core |
 | `environment.connection`, `.metadata`, `.settings` | Environment-provider-owned | Environment-provider-owned | Environment-provider-owned | Environment-provider-owned | Environment-provider-owned |

--- a/tests/adapters/test_deepagents.py
+++ b/tests/adapters/test_deepagents.py
@@ -25,6 +25,7 @@ from unittest.mock import AsyncMock
 from unittest.mock import MagicMock
 
 import pytest
+from langgraph.errors import GraphRecursionError
 from nemo_fabric_adapter_contract.codec import ContractValidationError
 from nemo_fabric_adapter_contract.models import AgentConfig
 from nemo_fabric_adapter_contract.models import AgentMcpServerConfig
@@ -39,7 +40,7 @@ from nemo_fabric_adapters.deepagents import adapter  # noqa: E402
 ROOT = Path(__file__).resolve().parents[2]
 
 
-def test_descriptor_declares_replace_system_instruction_mode():
+def test_descriptor_declares_supported_normalized_config():
     descriptor = json.loads(
         (ROOT / "adapters/deepagents/deepagents.fabric-adapter.json").read_text(
             encoding="utf-8"
@@ -47,6 +48,7 @@ def test_descriptor_declares_replace_system_instruction_mode():
     )
 
     assert descriptor["config"]["system_instruction_modes"] == ["replace"]
+    assert "runtime.max_turns" in descriptor["config"]["accepts"]
 
 
 def lifecycle_start_payload(payload: dict[str, Any]) -> dict[str, Any]:
@@ -123,6 +125,8 @@ def fake_sdks_fixture(monkeypatch):
         recorder["create_kwargs"] = kwargs
 
         async def astream(inputs, config=None, *, stream_mode=None, subgraphs=False):
+            if "stream_error" in recorder:
+                raise recorder["stream_error"]
             recorder["config"] = config
             recorder["subgraphs"] = subgraphs
             recorder["checkpointer"] = kwargs.get("checkpointer")
@@ -140,6 +144,8 @@ def fake_sdks_fixture(monkeypatch):
 
         agent = MagicMock()
         agent.astream = astream
+        agent.with_config.return_value = agent
+        recorder["agent"] = agent
         return agent
 
     deepagents_mod = types.ModuleType("deepagents")
@@ -1412,6 +1418,42 @@ async def test_checkpointer_closed_on_success_and_failure(
             lifecycle_start_payload(make_payload(tmp_path))
         )
     assert fake_sdks["saver_exits"] == 2
+
+
+async def test_max_turns_configures_langgraph_recursion_limit(
+    tmp_path, make_payload, fake_sdks
+):
+    payload = make_payload(tmp_path)
+    payload["config"]["runtime"] = {"max_turns": 7}
+
+    result = await invoke_once(payload)
+
+    assert result["failed"] is False
+    fake_sdks["agent"].with_config.assert_called_once_with({"recursion_limit": 7})
+
+
+async def test_omitted_max_turns_preserves_deepagents_default(
+    tmp_path, make_payload, fake_sdks
+):
+    result = await invoke_once(make_payload(tmp_path))
+
+    assert result["failed"] is False
+    fake_sdks["agent"].with_config.assert_not_called()
+
+
+async def test_recursion_limit_failure_is_normalized(
+    tmp_path, make_payload, fake_sdks
+):
+    fake_sdks["stream_error"] = GraphRecursionError("recursion limit reached")
+
+    result = await invoke_once(make_payload(tmp_path))
+
+    assert result["failed"] is True
+    assert result["error"] == {
+        "code": "deepagents_invocation_failed",
+        "message": "GraphRecursionError: recursion limit reached",
+        "retryable": False,
+    }
 
 
 async def test_mcp_servers_become_adapter_tools(

--- a/tests/adapters/test_deepagents.py
+++ b/tests/adapters/test_deepagents.py
@@ -124,9 +124,15 @@ def fake_sdks_fixture(monkeypatch):
     def build_agent(**kwargs):
         recorder["create_kwargs"] = kwargs
 
-        async def astream(inputs, config=None, *, stream_mode=None, subgraphs=False):
+        async def stream(
+            agent_name, inputs, config=None, *, stream_mode=None, subgraphs=False
+        ):
             if "stream_error" in recorder:
                 raise recorder["stream_error"]
+            recorder["astream_agent"] = agent_name
+            recorder["astream_recursion_limit"] = recorder.get(
+                "bound_recursion_limit" if agent_name == "bound" else "original_recursion_limit"
+            )
             recorder["config"] = config
             recorder["subgraphs"] = subgraphs
             recorder["checkpointer"] = kwargs.get("checkpointer")
@@ -143,9 +149,39 @@ def fake_sdks_fixture(monkeypatch):
             yield ((), "values", {"messages": [{"role": "user", "content": user}, ai]})
 
         agent = MagicMock()
+        bound_agent = MagicMock()
+
+        async def astream(inputs, config=None, *, stream_mode=None, subgraphs=False):
+            async for item in stream(
+                "original",
+                inputs,
+                config,
+                stream_mode=stream_mode,
+                subgraphs=subgraphs,
+            ):
+                yield item
+
+        async def bound_astream(
+            inputs, config=None, *, stream_mode=None, subgraphs=False
+        ):
+            async for item in stream(
+                "bound",
+                inputs,
+                config,
+                stream_mode=stream_mode,
+                subgraphs=subgraphs,
+            ):
+                yield item
+
+        def with_config(config):
+            recorder["bound_recursion_limit"] = config["recursion_limit"]
+            return bound_agent
+
         agent.astream = astream
-        agent.with_config.return_value = agent
+        agent.with_config.side_effect = with_config
+        bound_agent.astream = bound_astream
         recorder["agent"] = agent
+        recorder["bound_agent"] = bound_agent
         return agent
 
     deepagents_mod = types.ModuleType("deepagents")
@@ -1373,7 +1409,10 @@ async def test_invoke_compiled_agent_wires_callbacks_into_run_config(fake_sdks):
 
     agent = create_deep_agent(model=object())
     await adapter.invoke_compiled_agent(
-        agent, "hello", "thread-1", callbacks=["cb-a", "cb-b"]
+        agent,
+        "hello",
+        "thread-1",
+        callbacks=["cb-a", "cb-b"],
     )
 
     config = fake_sdks["config"]
@@ -1430,6 +1469,8 @@ async def test_max_turns_configures_langgraph_recursion_limit(
 
     assert result["failed"] is False
     fake_sdks["agent"].with_config.assert_called_once_with({"recursion_limit": 7})
+    assert fake_sdks["astream_agent"] == "bound"
+    assert fake_sdks["astream_recursion_limit"] == 7
 
 
 async def test_omitted_max_turns_preserves_deepagents_default(
@@ -1439,19 +1480,21 @@ async def test_omitted_max_turns_preserves_deepagents_default(
 
     assert result["failed"] is False
     fake_sdks["agent"].with_config.assert_not_called()
+    assert fake_sdks["astream_agent"] == "original"
+    assert fake_sdks["astream_recursion_limit"] is None
 
 
 async def test_recursion_limit_failure_is_normalized(
     tmp_path, make_payload, fake_sdks
 ):
-    fake_sdks["stream_error"] = GraphRecursionError("recursion limit reached")
+    fake_sdks["stream_error"] = GraphRecursionError("internal limit details")
 
     result = await invoke_once(make_payload(tmp_path))
 
     assert result["failed"] is True
     assert result["error"] == {
-        "code": "deepagents_invocation_failed",
-        "message": "GraphRecursionError: recursion limit reached",
+        "code": "deepagents_recursion_limit_reached",
+        "message": "Deep Agents reached its graph recursion limit.",
         "retryable": False,
     }
 


### PR DESCRIPTION
#### Overview

Deep Agents users could not configure LangGraph's recursion limit through `runtime.max_turns`. This change advertises the normalized field for the Deep Agents adapter and maps configured values directly to LangGraph's `recursion_limit`. Omitting the field preserves the existing Deep Agents default.

This change is backward compatible and introduces no dependency changes.

#### Details

- Add `runtime.max_turns` to the repository and packaged Deep Agents descriptors.
- Apply configured values to the compiled Deep Agents graph with `with_config`.
- Preserve Deep Agents' native behavior when `runtime.max_turns` is omitted.
- Cover configured, omitted, planning, and normalized recursion-failure behavior.
- Document that LangGraph counts graph supersteps and that remote Agent Protocol subagents manage their own recursion limits.

#### Validation

- `just no_uv=true test-all`
- `cargo fmt --all -- --check`
- `just build-rust`
- `just docs`
  - Passed with one non-blocking warning because the published-redirect comparison returned HTTP 403.
- Live Deep Agents smoke test with `runtime.max_turns = 1`
  - Confirmed that the configured value reached LangGraph as `recursion_limit` and produced the expected normalized `GraphRecursionError` result.

#### Where should the reviewer start?

Start with `adapters/deepagents/src/nemo_fabric_adapters/deepagents/adapter.py`, where the configured value is applied to the compiled graph, and `tests/adapters/test_deepagents.py`, which covers configured and omitted behavior.

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- Relates to: [FABRIC-234](https://linear.app/nvidia/issue/FABRIC-234/make-deep-agents-recursion-limit-configurable-through-fabricconfig)

- [x] I confirm this contribution is my own work, or I have the right to submit it under this project's license.
- [x] I searched existing issues and open pull requests, and this does not duplicate existing work.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Deep Agents now supports configuring `runtime.max_turns`.
  * The setting controls graph execution steps while preserving the default when omitted.
  * Local declarative subgraphs retain their own limits, while remote Agent Protocol subagents manage limits independently.

* **Bug Fixes**
  * Graph recursion-limit errors are now reported as non-retryable invocation failures.

* **Documentation**
  * Updated adapter and SDK documentation to describe support and limit behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->