### PR TITLE
fix(hermes): add top_p to hermes adapter

### DIFF
--- a/adapters/python/hermes/README.md
+++ b/adapters/python/hermes/README.md
@@ -60,9 +60,11 @@ Tool selectors are Hermes toolset names because that is the native policy
 surface Hermes exposes. The descriptor validates the following
 `harness.settings` fields:
 
-The adapter also validates `top_p` (from 0 through 1) and positive
-`max_tokens` values as model extensions. A model-level `max_tokens` overrides
-the harness-level default for the selected model role.
+During run-plan resolution, NeMo Fabric Core validates the `top_p` (from 0
+through 1) and positive `max_tokens` model extensions against the Hermes
+descriptor before runtime startup. Hermes reads these prevalidated values from
+`AgentConfig`. A model-level `max_tokens` overrides the harness-level default
+for the selected model role.
 
 | Setting | Type | Default | Description |
 | --- | --- | --- | --- |

--- a/adapters/python/hermes/README.md
+++ b/adapters/python/hermes/README.md
@@ -45,8 +45,8 @@ includes the NeMo Relay Python package.
 
 The adapter receives a normalized payload from NeMo Fabric and materializes a native Hermes Agent configuration for:
 
-- selected model provider, model name, base URL, and temperature through
-  `models`;
+- selected model provider, model name, base URL, temperature, `top_p`, and
+  per-model `max_tokens` through `models`;
 - replacement `instructions.system` and `runtime.max_turns`;
 - workspace and explicit environment variables through `environment`;
 - invocation timeout through `runtime.timeout_seconds`;
@@ -59,6 +59,10 @@ The adapter receives a normalized payload from NeMo Fabric and materializes a na
 Tool selectors are Hermes toolset names because that is the native policy
 surface Hermes exposes. The descriptor validates the following
 `harness.settings` fields:
+
+The adapter also validates `top_p` (from 0 through 1) and positive
+`max_tokens` values as model extensions. A model-level `max_tokens` overrides
+the harness-level default for the selected model role.
 
 | Setting | Type | Default | Description |
 | --- | --- | --- | --- |

--- a/adapters/python/hermes/README.md
+++ b/adapters/python/hermes/README.md
@@ -57,14 +57,16 @@ The adapter receives a normalized payload from NeMo Fabric and materializes a na
 - optional NeMo Relay telemetry plugin configuration.
 
 Tool selectors are Hermes toolset names because that is the native policy
-surface Hermes exposes. The descriptor validates the following
-`harness.settings` fields:
+surface Hermes exposes.
 
-During run-plan resolution, NeMo Fabric Core validates the `top_p` (from 0
-through 1) and positive `max_tokens` model extensions against the Hermes
-descriptor before runtime startup. Hermes reads these prevalidated values from
-`AgentConfig`. A model-level `max_tokens` overrides the harness-level default
-for the selected model role.
+During run-plan resolution, NeMo Fabric Core validates the
+`models.<role>.top_p` (from 0 through 1) and positive
+`models.<role>.max_tokens` extensions against the Hermes descriptor before
+runtime startup. Hermes reads these prevalidated values from `AgentConfig`. A
+model-level `max_tokens` overrides the harness-level default for the selected
+model role.
+
+The descriptor validates the following `harness.settings` fields:
 
 | Setting | Type | Default | Description |
 | --- | --- | --- | --- |

--- a/adapters/python/hermes/hermes.fabric-adapter.json
+++ b/adapters/python/hermes/hermes.fabric-adapter.json
@@ -61,6 +61,24 @@
     "additionalProperties": false
   },
   "extension_schemas": {
+    "model": {
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "type": "object",
+      "properties": {
+        "top_p": {
+          "type": "number",
+          "minimum": 0,
+          "maximum": 1,
+          "description": "Nucleus sampling probability passed to the model provider."
+        },
+        "max_tokens": {
+          "type": "integer",
+          "minimum": 1,
+          "description": "Maximum number of tokens for responses from this model role."
+        }
+      },
+      "additionalProperties": false
+    },
     "run_error": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "type": "object",

--- a/adapters/python/hermes/src/nemo_fabric_adapters/hermes/adapter.py
+++ b/adapters/python/hermes/src/nemo_fabric_adapters/hermes/adapter.py
@@ -175,6 +175,15 @@ class HermesRuntime:
                 if max_iterations is None:
                     max_iterations = DEFAULT_MAX_ITERATIONS
                 temperature = model_config.temperature
+                top_p = model_config.extensions.get("top_p")
+                request_overrides = {
+                    name: value
+                    for name, value in (
+                        ("temperature", temperature),
+                        ("top_p", top_p),
+                    )
+                    if value is not None
+                }
                 self._agent = AIAgent(
                     **filter_supported_kwargs(
                         AIAgent,
@@ -192,12 +201,11 @@ class HermesRuntime:
                         save_trajectories=bool(
                             self._settings.get("save_trajectories", False)
                         ),
-                        max_tokens=self._settings.get("max_tokens", 512),
-                        request_overrides=(
-                            {"temperature": temperature}
-                            if temperature is not None
-                            else None
+                        max_tokens=model_config.extensions.get(
+                            "max_tokens",
+                            self._settings.get("max_tokens", 512),
                         ),
+                        request_overrides=request_overrides or None,
                         reasoning_config=self._settings.get(
                             "reasoning_config", {"effort": "none"}
                         ),

--- a/crates/fabric-cli/assets/adapters/hermes/hermes.fabric-adapter.json
+++ b/crates/fabric-cli/assets/adapters/hermes/hermes.fabric-adapter.json
@@ -61,6 +61,24 @@
     "additionalProperties": false
   },
   "extension_schemas": {
+    "model": {
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "type": "object",
+      "properties": {
+        "top_p": {
+          "type": "number",
+          "minimum": 0,
+          "maximum": 1,
+          "description": "Nucleus sampling probability passed to the model provider."
+        },
+        "max_tokens": {
+          "type": "integer",
+          "minimum": 1,
+          "description": "Maximum number of tokens for responses from this model role."
+        }
+      },
+      "additionalProperties": false
+    },
     "run_error": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "type": "object",

--- a/crates/fabric-core/src/config.rs
+++ b/crates/fabric-core/src/config.rs
@@ -4700,6 +4700,60 @@ mod tests {
     }
 
     #[test]
+    fn hermes_model_extensions_are_validated_and_projected() {
+        let mut config = config_with_model("nvidia.fabric.hermes", "nvidia");
+        let model = config.models.get_mut("default").expect("default model");
+        model
+            .extensions
+            .insert("top_p".to_string(), serde_json::json!(0.85));
+        model
+            .extensions
+            .insert("max_tokens".to_string(), serde_json::json!(768));
+
+        let plan = resolve_run_plan_from_config(config, ResolveContext::new(repository_root()))
+            .expect("Hermes model extensions");
+        let model = plan
+            .agent_config
+            .models
+            .get("default")
+            .expect("projected default model");
+
+        assert_eq!(
+            model.extensions.get("top_p"),
+            Some(&serde_json::json!(0.85))
+        );
+        assert_eq!(
+            model.extensions.get("max_tokens"),
+            Some(&serde_json::json!(768))
+        );
+    }
+
+    #[test]
+    fn hermes_model_extensions_reject_invalid_sampling_values() {
+        let mut config = config_with_model("nvidia.fabric.hermes", "nvidia");
+        config
+            .models
+            .get_mut("default")
+            .expect("default model")
+            .extensions
+            .insert("top_p".to_string(), serde_json::json!(1.1));
+
+        let error = resolve_run_plan_from_config(config, ResolveContext::new(repository_root()))
+            .expect_err("top_p above one");
+
+        assert!(
+            matches!(
+                error,
+                FabricError::InvalidAdapterExtension {
+                    ref extension_path,
+                    ..
+                } if extension_path == "models.default.top_p"
+            ),
+            "{error:?}"
+        );
+    }
+
+    #[test]
     fn mcp_service_account_authentication_requires_adapter_support() {
         let mut config = typed_config("nvidia.fabric.langchain.deepagents");
         config.skills = None;

--- a/docs/integrations/harness/hermes.mdx
+++ b/docs/integrations/harness/hermes.mdx
@@ -60,6 +60,13 @@ Use normalized `FabricConfig` fields to configure the model, workspace, skills,
 MCP servers, replacement system instructions, turn limit, native tool
 selectors, and telemetry. The adapter rejects `append` system instructions.
 
+During run-plan resolution, NeMo Fabric Core validates the
+`models.<role>.top_p` (from 0 through 1) and positive
+`models.<role>.max_tokens` extensions against the Hermes descriptor before
+runtime startup. Hermes reads these prevalidated values from `AgentConfig`. A
+model-level `max_tokens` overrides the harness-level default for the selected
+model role.
+
 The Hermes descriptor validates the following `harness.settings` fields:
 
 | Setting | Type | Default | Description |

--- a/examples/harbor/swebench/adapters/hermes/hermes.fabric-adapter.json
+++ b/examples/harbor/swebench/adapters/hermes/hermes.fabric-adapter.json
@@ -61,6 +61,24 @@
     "additionalProperties": false
   },
   "extension_schemas": {
+    "model": {
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "type": "object",
+      "properties": {
+        "top_p": {
+          "type": "number",
+          "minimum": 0,
+          "maximum": 1,
+          "description": "Nucleus sampling probability passed to the model provider."
+        },
+        "max_tokens": {
+          "type": "integer",
+          "minimum": 1,
+          "description": "Maximum number of tokens for responses from this model role."
+        }
+      },
+      "additionalProperties": false
+    },
     "run_error": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "type": "object",

--- a/tests/adapters/test_hermes_adapter.py
+++ b/tests/adapters/test_hermes_adapter.py
@@ -116,6 +116,7 @@ def test_validate_hermes_telemetry_provider_rejects_mixed_native_and_relay():
 
 
 def test_descriptor_uses_the_typed_agent_config_contract():
+    """The Hermes descriptor declares its typed config and model extensions."""
     descriptor_path = (
         Path(__file__).parents[2]
         / "adapters"
@@ -1290,6 +1291,7 @@ async def test_persistent_runtime_reuses_hermes_agent_session_and_history(
     monkeypatch,
     tmp_path: Path,
 ):
+    """A persistent Hermes runtime applies model extensions and reuses state."""
     mock_session_db = MagicMock(spec=SessionDB)
     mock_session_db_type = MagicMock(spec=SessionDB, return_value=mock_session_db)
 

--- a/tests/adapters/test_hermes_adapter.py
+++ b/tests/adapters/test_hermes_adapter.py
@@ -138,6 +138,19 @@ def test_descriptor_uses_the_typed_agent_config_contract():
         "mcp.auth.oauth2",
         "skills",
     ]
+    assert descriptor["extension_schemas"]["model"]["properties"] == {
+        "top_p": {
+            "type": "number",
+            "minimum": 0,
+            "maximum": 1,
+            "description": "Nucleus sampling probability passed to the model provider.",
+        },
+        "max_tokens": {
+            "type": "integer",
+            "minimum": 1,
+            "description": "Maximum number of tokens for responses from this model role.",
+        },
+    }
     assert descriptor["config"]["system_instruction_modes"] == ["replace"]
 
 
@@ -1359,6 +1372,10 @@ async def test_persistent_runtime_reuses_hermes_agent_session_and_history(
                     "model": "test-model",
                     "api_key_env": "TEST_API_KEY",
                     "temperature": 0.2,
+                    "extensions": {
+                        "top_p": 0.85,
+                        "max_tokens": 768,
+                    },
                 }
             },
         }
@@ -1403,8 +1420,8 @@ async def test_persistent_runtime_reuses_hermes_agent_session_and_history(
         skip_context_files=True,
         skip_memory=True,
         save_trajectories=False,
-        max_tokens=512,
-        request_overrides={"temperature": 0.2},
+        max_tokens=768,
+        request_overrides={"temperature": 0.2, "top_p": 0.85},
         reasoning_config={"effort": "none"},
         platform="fabric",
         session_id="runtime-fabric-123",

--- a/tests/adapters/test_hermes_adapter.py
+++ b/tests/adapters/test_hermes_adapter.py
@@ -1364,7 +1364,7 @@ async def test_persistent_runtime_reuses_hermes_agent_session_and_history(
     }
     payload["config"] = _agent_config(
         {
-            "harness": {"settings": {}},
+            "harness": {"settings": {"max_tokens": 1024}},
             "instructions": {"system": {"content": "system", "mode": "replace"}},
             "runtime": {"max_turns": None},
             "tools": {"enabled": []},


### PR DESCRIPTION
#### Overview

Declare and apply Hermes model sampling that callers already put on `models.<role>`. After [PR #186](https://github.com/NVIDIA/NeMo-Fabric/pull/186), planning is fail-closed: extra model keys need `extension_schemas.model`. Hermes never declared that schema and only forwarded `temperature` in `request_overrides`, so `top_p` (and model-level `max_tokens`) failed planning instead of reaching `AIAgent`.

Although `temperature`, `top_p`, and `max_tokens` appear at the same level under `models.<role>`, only `temperature` is currently a normalized `ModelConfig` field. `ModelConfig` flattens unknown fields into its extension map, so Fabric treats `top_p` and `max_tokens` as model extensions and requires Hermes to declare support for them. If another adapter needs the same fields, they can be promoted to the normalized model contract later.

This PR:

- Adds `extension_schemas.model` for `top_p` (`0..1`) and `max_tokens` (integer ≥ 1) on the Hermes descriptor (package + CLI asset).
- Builds `request_overrides` from `temperature` and `model_config.extensions["top_p"]`.
- Prefers model-level `max_tokens` over `harness.settings.max_tokens`.
- Adds projection / invalid-value tests in `nemo-fabric-core` and constructor-kwargs coverage in the Hermes adapter tests.

Unknown keys (for example `allow_empty_api_key`) stay rejected.

#### Where should the reviewer start?

1. `adapters/python/hermes/hermes.fabric-adapter.json` — the `model` extension schema.
2. `adapters/python/hermes/src/nemo_fabric_adapters/hermes/adapter.py` — `request_overrides` / `max_tokens`.
3. `crates/fabric-core/src/config.rs` — `hermes_model_extensions_*` tests.
4. `tests/adapters/test_hermes_adapter.py` — descriptor + `AIAgent` kwargs.

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- Relates to [FABRIC-236](https://linear.app/nvidia/issue/FABRIC-236/allow-top-p-and-per-model-max-tokens-on-the-hermes-adapter)
- Relates to NVBug [6704646](https://nvbugspro.nvidia.com/bug/6704646) (platform optimize examples hit this on the 0.2.0 pin)

- [x] I confirm this contribution is my own work, or I have the right to submit it under this project's license.
- [x] I searched existing issues and open pull requests, and this does not duplicate existing work.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added per-model configuration for `top_p` and `max_tokens`.
  * Model-specific `max_tokens` values take precedence over runtime and default settings.
  * Hermes requests now apply configured temperature and `top_p` overrides, while omitting unset values.

* **Bug Fixes**
  * Added validation for `top_p` ranges and positive `max_tokens` values before startup.

* **Documentation**
  * Documented model-level settings, validation rules, and precedence behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
