### PR TITLE
ci: verify npm README from packed artifact

### DIFF
--- a/scripts/ci/publish_typescript_package.py
+++ b/scripts/ci/publish_typescript_package.py
@@ -37,7 +37,6 @@ class PackageArtifact:
     version: str
     integrity: str
     filename: str
-    readme: str
 
 
 @dataclass(frozen=True)
@@ -45,7 +44,6 @@ class PublishedState:
     version: str
     integrity: str
     dist_tag_version: str
-    readme: str
 
 
 RunNpm = Callable[[Sequence[str], Path], subprocess.CompletedProcess[str]]
@@ -120,12 +118,16 @@ def _pack_package(
     try:
         values = json.loads(output)
         value = values[0] if len(values) == 1 else None
+        packed_files = {
+            entry["path"]
+            for entry in value["files"]
+            if isinstance(entry, dict) and isinstance(entry.get("path"), str)
+        }
         artifact = PackageArtifact(
             name=value["name"],
             version=value["version"],
             integrity=value["integrity"],
             filename=value["filename"],
-            readme=readme,
         )
     except (IndexError, KeyError, TypeError, json.JSONDecodeError) as error:
         raise PublicationError("npm pack returned an unexpected result") from error
@@ -144,6 +146,8 @@ def _pack_package(
         )
     if not (package_directory / artifact.filename).is_file():
         raise PublicationError(f"npm pack did not create {artifact.filename}")
+    if "README.md" not in packed_files:
+        raise PublicationError("Packed artifact is missing README.md")
     return artifact
 
 
@@ -221,12 +225,12 @@ def _published_state(
         artifact.name,
         f"dist-tags.{dist_tag}",
     )
-    readme = _view(package_directory, run_npm, package_version, "readme")
+    # npm does not consistently expose version-scoped README metadata. The
+    # packed-file check above and dist.integrity verify the published README.
     return PublishedState(
         version=version,
         integrity=integrity or "",
         dist_tag_version=dist_tag_version or "",
-        readme=readme or "",
     )
 
 
@@ -239,7 +243,6 @@ def _state_matches(
         state.version == artifact.version
         and state.integrity == artifact.integrity
         and state.dist_tag_version == artifact.version
-        and state.readme == artifact.readme
     )
 
 
@@ -269,10 +272,6 @@ def _describe_conflict(
                 f"Published {dist_tag} dist-tag: {state.dist_tag_version or '<unset>'}",
             )
         )
-    if not state.readme:
-        details.append("Published README metadata is missing")
-    elif state.readme != artifact.readme:
-        details.append("Published README metadata does not match README.md")
     return "\n".join(details)
 
 
@@ -313,9 +312,8 @@ def publish_package(
             f"Refusing to move {dist_tag} backward from {current_dist_tag} to {version}"
         )
 
-    # A directory publish lets npm attach README content to the registry
-    # metadata; publishing the prepacked tarball leaves that field empty. Skip
-    # lifecycle scripts so the upload matches the artifact packed above.
+    # Publish the directory so npm uses the package contents validated above.
+    # Skip lifecycle scripts so the upload matches the artifact packed above.
     publish_result = run_npm(
         [
             "publish",

--- a/tests/scripts/test_publish_typescript_package.py
+++ b/tests/scripts/test_publish_typescript_package.py
@@ -43,6 +43,7 @@ def _pack_result(
     *,
     version: str = VERSION,
     filename: str = TARBALL,
+    files: Sequence[str] = ("README.md",),
 ) -> subprocess.CompletedProcess[str]:
     return _result(
         json.dumps(
@@ -52,6 +53,7 @@ def _pack_result(
                     "version": version,
                     "integrity": INTEGRITY,
                     "filename": filename,
+                    "files": [{"path": path} for path in files],
                 }
             ]
         )
@@ -179,9 +181,7 @@ def test_runtime_dependency_versions_must_be_exact(package_directory: Path):
     (package_directory / "package.json").write_text(
         json.dumps(manifest), encoding="utf-8"
     )
-    runner = NpmRunner(
-        [(["pack", "--json", "--ignore-scripts"], _pack_result())]
-    )
+    runner = NpmRunner([(["pack", "--json", "--ignore-scripts"], _pack_result())])
 
     with pytest.raises(
         publish_typescript_package.PublicationError,
@@ -203,14 +203,12 @@ def _exact_view_responses(
     integrity: str = INTEGRITY,
     dist_tag: str = "latest",
     dist_tag_version: str = VERSION,
-    readme: str = README,
 ) -> list[tuple[list[str], subprocess.CompletedProcess[str]]]:
     package_version = f"{PACKAGE}@{VERSION}"
     return [
         (["view", package_version, "version"], _result(VERSION)),
         (["view", package_version, "dist.integrity"], _result(integrity)),
         (["view", PACKAGE, f"dist-tags.{dist_tag}"], _result(dist_tag_version)),
-        (["view", package_version, "readme"], _result(readme)),
     ]
 
 
@@ -234,7 +232,7 @@ def test_invalid_readme_encoding_fails_closed(package_directory: Path):
 
 
 @pytest.mark.parametrize("dist_tag", ["alpha", "latest", "next"])
-def test_existing_exact_package_is_an_idempotent_success(
+def test_existing_exact_package_without_registry_readme_is_idempotent_success(
     package_directory: Path,
     dist_tag: str,
 ):
@@ -301,28 +299,19 @@ def test_existing_conflicting_package_fails(
     runner.assert_finished()
 
 
-@pytest.mark.parametrize(
-    ("readme", "error"),
-    [
-        ("", "Published README metadata is missing"),
-        ("# Wrong package", "Published README metadata does not match README.md"),
-    ],
-)
-def test_existing_readme_metadata_must_match_package(
-    package_directory: Path,
-    readme: str,
-    error: str,
-):
+def test_packed_artifact_must_include_readme(package_directory: Path):
     runner = NpmRunner(
         [
-            (["pack", "--json", "--ignore-scripts"], _pack_result()),
-            *_exact_view_responses(readme=readme),
+            (
+                ["pack", "--json", "--ignore-scripts"],
+                _pack_result(files=()),
+            ),
         ]
     )
 
     with pytest.raises(
         publish_typescript_package.PublicationError,
-        match=error,
+        match=r"Packed artifact is missing README\.md",
     ):
         publish_typescript_package.publish_package(
             package_directory,


### PR DESCRIPTION
#### Overview

The `v0.3.0-beta.1` TypeScript workflow published `nemo-fabric-adapter-contract@0.3.0-beta.1`, then reported a failure because npm omitted version-scoped `readme` metadata. npm also omits that field for the existing `0.2.0` release, so retries cannot reconcile an otherwise byte-identical artifact.

This change verifies README inclusion from the local packed artifact and continues to use registry integrity plus the expected dist-tag as the publication authority. There are no public API or package-content changes.

#### Details

- Require a nonempty local `README.md` to appear in the `npm pack --json` file list.
- Stop querying npm for unreliable version-scoped README metadata.
- Preserve exact version, `dist.integrity`, and dist-tag conflict checks.
- Add regression coverage for an exact published package with no registry README metadata and for a packed artifact missing `README.md`.

#### Validation

- `pytest tests/scripts -q` — 95 passed.
- `ruff format --check scripts/ci/publish_typescript_package.py tests/scripts/test_publish_typescript_package.py`
- `ruff check scripts/ci/publish_typescript_package.py tests/scripts/test_publish_typescript_package.py`
- `git diff --check`
- `just test-python` could not complete locally because provisioning the pinned Hermes Agent dependency returned HTTP 429 from GitHub. The draft PR CI will run the full matrix.

#### Where should the reviewer start?

1. `scripts/ci/publish_typescript_package.py` — packed README validation and registry reconciliation.
2. `tests/scripts/test_publish_typescript_package.py` — missing-registry-metadata regression coverage.

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- Relates to the failed [v0.3.0-beta.1 TypeScript publication workflow](https://github.com/NVIDIA/NeMo-Fabric/actions/runs/33819118000).
- Relates to: none.

- [x] I confirm this contribution is my own work, or I have the right to submit it under this project's license.
- [x] I searched existing issues and open pull requests, and this does not duplicate existing work.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Package publishing now verifies that the packed artifact contains a `README.md`.
  * Publication verification and conflict reporting rely on package version, integrity, and distribution tag, avoiding dependency on registry README metadata.
  * Packages without registry README metadata can now be handled successfully when the packed artifact is valid.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->