### PR TITLE
feat(nooa): install published packages in Fabric examples

### DIFF
--- a/examples/harbor/nooa_bench/README.md
+++ b/examples/harbor/nooa_bench/README.md
@@ -22,25 +22,26 @@ results, optional Relay telemetry, and cleanup.
 
 ## Prepare the Task Image
 
-Complete the [shared Harbor setup](../README.md#shared-host-setup), clone OO
-Agents beside this repository, and set a valid NVIDIA API key:
+Complete the [shared Harbor setup](../README.md#shared-host-setup) and set a
+valid NVIDIA API key:
 
 ```bash
 export NVIDIA_API_KEY="..."
-test -d ../labs-OO-Agents/.git
 ```
 
 Build source-consistent Fabric wheels, including a manylinux runtime wheel, and
-stage committed Fabric and NOOA source into the ignored Docker build
-context:
+stage committed Fabric adapter source plus the shared NOOA package constraints
+into the ignored Docker build context:
 
 ```bash
-./examples/harbor/nooa_bench/prepare.sh ../labs-OO-Agents
+./examples/harbor/nooa_bench/prepare.sh
 ```
 
-The task image installs `nemo-relay>=0.7.2,<0.8`, NOOA core, `nooa-cli`,
-`nooa-bench`, and the BenchAgent adapter. `prepare.sh` builds every NeMo Fabric wheel
-in a fresh temporary directory and uses Maturin with Zig for manylinux 2.17
+The task image installs `nemo-relay>=0.7.2,<0.8`, `nooa`, `nooa-cli`, and
+`nooa-bench` from PyPI using
+[`external/nooa/constraints.txt`](../../../external/nooa/constraints.txt), plus
+the BenchAgent adapter source. `prepare.sh` builds every NeMo Fabric wheel in a
+fresh temporary directory and uses Maturin with Zig for manylinux 2.17
 compatibility, so the Python 3.12 Debian task image does not depend on the
 glibc version installed in the host.
 
@@ -113,7 +114,7 @@ task instruction and verifier unchanged but adds an isolated Python 3.12
 environment for NeMo Fabric, NOOA, and Relay:
 
 ```bash
-./examples/harbor/nooa_bench/prepare_swebench.sh ../labs-OO-Agents
+./examples/harbor/nooa_bench/prepare_swebench.sh
 ```
 
 The helper also performs the source build from `prepare.sh`. It writes the

--- a/examples/harbor/nooa_bench/prepare.sh
+++ b/examples/harbor/nooa_bench/prepare.sh
@@ -7,7 +7,6 @@ set -euo pipefail
 script_dir="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
 repo_root="$(git -C "$script_dir" rev-parse --show-toplevel)"
 example_dir="$script_dir"
-oo_agents_repo="${1:-$repo_root/../labs-OO-Agents}"
 stage_dir="$(mktemp -d "${TMPDIR:-/tmp}/fabric-nooa-bench.XXXXXX")"
 
 cleanup() {
@@ -15,16 +14,11 @@ cleanup() {
 }
 trap cleanup EXIT
 
-if [[ ! -d "$oo_agents_repo/.git" ]]; then
-    echo "OO Agents repository not found: $oo_agents_repo" >&2
-    exit 1
-fi
-
 wheelhouse="$stage_dir/wheelhouse"
 adapter_source="$stage_dir/nooa-adapter"
-oo_agents_source="$stage_dir/labs-OO-Agents"
+constraints_file="$stage_dir/nooa-constraints.txt"
 bundle="$stage_dir/bundle"
-mkdir -p "$wheelhouse" "$adapter_source" "$oo_agents_source" "$bundle/adapters"
+mkdir -p "$wheelhouse" "$adapter_source" "$bundle/adapters"
 
 uv build --wheel --out-dir "$wheelhouse" "$repo_root/sdk/python/nemo-fabric"
 uv build --wheel --out-dir "$wheelhouse" "$repo_root/adapter-contract/python"
@@ -40,14 +34,14 @@ uv build --wheel --out-dir "$wheelhouse" "$repo_root/adapters/python/common"
 )
 
 git -C "$repo_root" archive HEAD:external/nooa src | tar -x -C "$adapter_source"
-git -C "$oo_agents_repo" archive HEAD | tar -x -C "$oo_agents_source"
+cp "$repo_root/external/nooa/constraints.txt" "$constraints_file"
 cp "$repo_root/external/nooa/nooa-bench.fabric-adapter.json" "$bundle/adapters/"
 
 rm -rf "$example_dir/task/environment/vendor" "$example_dir/.bundle"
 mkdir -p "$example_dir/task/environment/vendor"
 mv "$wheelhouse" "$example_dir/task/environment/vendor/"
 mv "$adapter_source" "$example_dir/task/environment/vendor/"
-mv "$oo_agents_source" "$example_dir/task/environment/vendor/"
+mv "$constraints_file" "$example_dir/task/environment/vendor/"
 mv "$bundle" "$example_dir/.bundle"
 
-echo "Built and prepared the BenchAgent Harbor context from committed source."
+echo "Built and prepared the BenchAgent Harbor context with published NOOA packages."

--- a/examples/harbor/nooa_bench/prepare_swebench.sh
+++ b/examples/harbor/nooa_bench/prepare_swebench.sh
@@ -6,7 +6,6 @@ set -euo pipefail
 
 script_dir="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
 repo_root="$(git -C "$script_dir" rev-parse --show-toplevel)"
-oo_agents_repo="${1:-$repo_root/../labs-OO-Agents}"
 runs_dir="$script_dir/runs"
 task_dir="$runs_dir/prepared-django__django-13741"
 mkdir -p "$runs_dir"
@@ -17,7 +16,7 @@ cleanup() {
 }
 trap cleanup EXIT
 
-"$script_dir/prepare.sh" "$oo_agents_repo"
+"$script_dir/prepare.sh"
 
 uv run --extra harbor harbor download \
     swe-bench/django__django-13741 \

--- a/examples/harbor/nooa_bench/swebench/Dockerfile
+++ b/examples/harbor/nooa_bench/swebench/Dockerfile
@@ -14,10 +14,11 @@ COPY vendor /opt/nemo-fabric-nooa
 
 RUN uv venv --python 3.12 /opt/nemo-fabric-venv \
     && uv pip install --python /opt/nemo-fabric-venv/bin/python \
+        -c /opt/nemo-fabric-nooa/nooa-constraints.txt \
         /opt/nemo-fabric-nooa/wheelhouse/*.whl \
         "nemo-relay>=0.7.2,<0.8" \
-        /opt/nemo-fabric-nooa/labs-OO-Agents \
-        /opt/nemo-fabric-nooa/labs-OO-Agents/packages/nooa-cli \
-        /opt/nemo-fabric-nooa/labs-OO-Agents/packages/nooa-bench
+        nooa \
+        nooa-cli \
+        nooa-bench
 
 ENV PYTHONPATH=/opt/nemo-fabric-nooa/nooa-adapter/src

--- a/examples/harbor/nooa_bench/task/environment/Dockerfile
+++ b/examples/harbor/nooa_bench/task/environment/Dockerfile
@@ -10,14 +10,15 @@ RUN apt-get update \
 
 COPY vendor/wheelhouse /opt/nemo-fabric-wheelhouse
 COPY vendor/nooa-adapter /opt/nemo-fabric-nooa
-COPY vendor/labs-OO-Agents /opt/labs-OO-Agents
+COPY vendor/nooa-constraints.txt /opt/nooa-constraints.txt
 
 RUN pip install --no-cache-dir \
+        -c /opt/nooa-constraints.txt \
         /opt/nemo-fabric-wheelhouse/*.whl \
         "nemo-relay>=0.7.2,<0.8" \
-        -e /opt/labs-OO-Agents \
-        -e /opt/labs-OO-Agents/packages/nooa-cli \
-        -e /opt/labs-OO-Agents/packages/nooa-bench
+        nooa \
+        nooa-cli \
+        nooa-bench
 
 RUN python -c \
     "import importlib.metadata as m; from nooa_bench.bench_agent import BenchAgent; print(BenchAgent.__name__, m.version('nemo-relay'))"

--- a/external/nooa/README.md
+++ b/external/nooa/README.md
@@ -26,7 +26,7 @@ contains the following components:
 
 - NeMo Fabric, `nemo-fabric-adapter-contract`, and
   `nemo-fabric-adapters-common`.
-- NOOA core and the package that provides the selected agent.
+- The published NOOA packages that provide the selected agent.
 - The source adapter in this directory.
 
 NOOA requires Python 3.12 or 3.13. Expose the adapter source from the NVIDIA
@@ -34,6 +34,13 @@ NeMo Fabric repository root:
 
 ```bash
 export PYTHONPATH="$PWD/external/nooa/src${PYTHONPATH:+:$PYTHONPATH}"
+```
+
+Install the compatible published packages from the repository root. The shared
+constraints file is the maintained compatibility boundary for NOOA packages:
+
+```bash
+pip install -c external/nooa/constraints.txt nooa nooa-cli nooa-bench
 ```
 
 During source development, include `external/nooa` and the selected target

--- a/external/nooa/constraints.txt
+++ b/external/nooa/constraints.txt
@@ -1,0 +1,9 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# 0.0.10 introduces nooa_cli.coding.CodingAgent. Keep the three unstable
+# pre-1.0 distributions on this tested patch line until a later release is
+# validated with the Fabric adapter.
+nooa>=0.0.10,<0.0.11
+nooa-cli>=0.0.10,<0.0.11
+nooa-bench>=0.0.10,<0.0.11

--- a/tests/examples/test_nooa_bench_harbor_example.py
+++ b/tests/examples/test_nooa_bench_harbor_example.py
@@ -12,6 +12,9 @@ from typing import Any
 from examples.harbor.nooa_bench.verify_run import verify
 
 
+REPOSITORY_ROOT = Path(__file__).parents[2]
+
+
 def write_json(path: Path, value: Any) -> None:
     path.parent.mkdir(parents=True, exist_ok=True)
     path.write_text(json.dumps(value), encoding="utf-8")
@@ -151,3 +154,49 @@ def test_verify_accepts_zero_reward_swebench_run(tmp_path: Path):
     )
 
     assert summary["reward"] == 0.0
+
+
+def test_harbor_example_uses_published_nooa_packages():
+    constraints = (
+        REPOSITORY_ROOT / "external" / "nooa" / "constraints.txt"
+    ).read_text(encoding="utf-8")
+    package_constraints = {
+        line.split(">=", maxsplit=1)[0]: line
+        for line in constraints.splitlines()
+        if line and not line.startswith("#")
+    }
+    assert package_constraints == {
+        "nooa": "nooa>=0.0.10,<0.0.11",
+        "nooa-cli": "nooa-cli>=0.0.10,<0.0.11",
+        "nooa-bench": "nooa-bench>=0.0.10,<0.0.11",
+    }
+
+    files = (
+        REPOSITORY_ROOT / "examples" / "harbor" / "nooa_bench" / "prepare.sh",
+        REPOSITORY_ROOT
+        / "examples"
+        / "harbor"
+        / "nooa_bench"
+        / "prepare_swebench.sh",
+        REPOSITORY_ROOT
+        / "examples"
+        / "harbor"
+        / "nooa_bench"
+        / "task"
+        / "environment"
+        / "Dockerfile",
+        REPOSITORY_ROOT
+        / "examples"
+        / "harbor"
+        / "nooa_bench"
+        / "swebench"
+        / "Dockerfile",
+    )
+    for path in files:
+        content = path.read_text(encoding="utf-8")
+        assert "labs-OO-Agents" not in content
+
+    calculator_dockerfile = files[2].read_text(encoding="utf-8")
+    swebench_dockerfile = files[3].read_text(encoding="utf-8")
+    assert "-c /opt/nooa-constraints.txt" in calculator_dockerfile
+    assert "-c /opt/nemo-fabric-nooa/nooa-constraints.txt" in swebench_dockerfile

--- a/tests/examples/test_nooa_bench_harbor_example.py
+++ b/tests/examples/test_nooa_bench_harbor_example.py
@@ -200,6 +200,12 @@ def test_harbor_example_uses_published_nooa_packages():
     swebench_dockerfile = files[3].read_text(encoding="utf-8")
     assert "-c /opt/nooa-constraints.txt" in calculator_dockerfile
     assert "-c /opt/nemo-fabric-nooa/nooa-constraints.txt" in swebench_dockerfile
-    for dockerfile in (calculator_dockerfile, swebench_dockerfile):
+    calculator_install_command = calculator_dockerfile.split(
+        "RUN pip install --no-cache-dir", maxsplit=1
+    )[1].split("\n\nRUN ", maxsplit=1)[0]
+    swebench_install_command = swebench_dockerfile.split(
+        "RUN uv venv --python 3.12 /opt/nemo-fabric-venv", maxsplit=1
+    )[1].split("\n\nENV ", maxsplit=1)[0]
+    for install_command in (calculator_install_command, swebench_install_command):
         for package in ("nooa", "nooa-cli", "nooa-bench"):
-            assert f"\n        {package}" in dockerfile
+            assert f"\n        {package}" in install_command

--- a/tests/examples/test_nooa_bench_harbor_example.py
+++ b/tests/examples/test_nooa_bench_harbor_example.py
@@ -200,3 +200,6 @@ def test_harbor_example_uses_published_nooa_packages():
     swebench_dockerfile = files[3].read_text(encoding="utf-8")
     assert "-c /opt/nooa-constraints.txt" in calculator_dockerfile
     assert "-c /opt/nemo-fabric-nooa/nooa-constraints.txt" in swebench_dockerfile
+    for dockerfile in (calculator_dockerfile, swebench_dockerfile):
+        for package in ("nooa", "nooa-cli", "nooa-bench"):
+            assert f"\n        {package}" in dockerfile


### PR DESCRIPTION
#### Overview

Use published NOOA packages in the Harbor examples instead of requiring a local `labs-OO-Agents` checkout.

#### Where should the reviewer start?

Start with:

- `external/nooa/constraints.txt` for the tested package range.
- `examples/harbor/nooa_bench/prepare.sh` and `prepare_swebench.sh` for the updated staging flow.
- The calculator and SWE-bench Dockerfiles for published-package installation.
- `tests/examples/test_nooa_bench_harbor_example.py` for regression coverage.


#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

Resolves FABRIC-239

- [x] I confirm this contribution is my own work, or I have the right to submit it under this project's license.
- [x] I searched existing issues and open pull requests, and this does not duplicate existing work.

#### Changes

- Install `nooa`, `nooa-cli`, and `nooa-bench` from PyPI using a shared, tested `0.0.10` constraint range.
- Remove the `labs-OO-Agents` clone/archive/copy workflow.
- Update Harbor preparation scripts, Dockerfiles, and documentation.
- Add regression coverage for constraints usage, package installation, and removal of obsolete repository references.

#### Validation

- Clean-environment installation verified published `0.0.10` packages and imports for `CodingAgent` and `BenchAgent`.
- Focused NOOA test suite: `73 passed`.
- Harbor Dockerfile regression tests: `3 passed`.
- Calculator workflow: succeeded with reward `1.0`.
- Relay-enabled calculator workflow: succeeded with reward `1.0`; ATIF/ATOF artifacts validated.
- Real SWE-bench task (`django__django-13741`): succeeded with reward `1.0`; Relay artifacts validated.
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Harbor examples now install published NOOA packages using shared compatibility constraints pinned to the tested 0.0.10 patch range.
  * Preparation workflows no longer require a separate OO Agents repository.

* **Documentation**
  * Updated setup instructions and preparation commands to use published packages and the shared constraints file.

* **Tests**
  * Added coverage for package installation, constraints usage, and removal of outdated repository references.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->