### PR TITLE
feat: add opt-in local shell backend for Deep Agents

### DIFF
--- a/adapters/python/deepagents/README.md
+++ b/adapters/python/deepagents/README.md
@@ -169,6 +169,13 @@ inherit host variables such as `HOME` and receive only the shell's fallback
 when needed. The `execute` tool remains subject to `tools.enabled` and
 `tools.blocked`, like all other Deep Agents built-ins.
 
+File tools and shell commands use different absolute-path namespaces when
+`virtual_mode=True`. For file tools, `/report.txt` resolves to
+`<workspace>/report.txt`; in `execute`, the same path refers to `/report.txt` on
+the adapter host. Shell commands start in `environment.workspace`, so use
+workspace-relative paths, such as `cat report.txt`, for files surfaced by file
+tools. Do not pass a file tool's virtual absolute path directly to `execute`.
+
 Python middleware, `FilesystemPermission` objects, Python tool objects, and
 precompiled `runnable` subagents are not exposed through `harness.settings`.
 When `tools.enabled` or `tools.blocked` is configured, NeMo Fabric applies the

--- a/adapters/python/deepagents/README.md
+++ b/adapters/python/deepagents/README.md
@@ -163,11 +163,13 @@ environment = EnvironmentConfig(
 tools = ToolsConfig(enabled=["execute"])
 ```
 
-`LocalShellBackend` keeps its `inherit_env=False` default. Commands do not
-inherit host variables such as `HOME` and receive only the shell's fallback
-`PATH`; set required variables in the command and use absolute executable paths
-when needed. The `execute` tool remains subject to `tools.enabled` and
-`tools.blocked`, like all other Deep Agents built-ins.
+`LocalShellBackend` keeps `inherit_env=False`, so commands do not inherit
+ambient adapter-host variables such as `HOME`. Values explicitly configured in
+`environment.env` are passed to shell commands and are available to
+agent-generated commands. If `environment.env` does not set `PATH`, the shell
+provides only its fallback path; configure required variables explicitly and
+use absolute executable paths when needed. The `execute` tool remains subject
+to `tools.enabled` and `tools.blocked`, like all other Deep Agents built-ins.
 
 File tools and shell commands use different absolute-path namespaces when
 `virtual_mode=True`. For file tools, `/report.txt` resolves to

--- a/adapters/python/deepagents/README.md
+++ b/adapters/python/deepagents/README.md
@@ -59,10 +59,10 @@ NeMo Fabric maps the following into the harness:
   is a graph-superstep budget, not a promise of ten model responses or tool
   calls. One interaction can consume multiple supersteps. Omit the field
   to preserve the Deep Agents default.
-- `environment.workspace` roots the Deep Agents filesystem backend
+- By default, `environment.workspace` roots the Deep Agents filesystem backend
   (`FilesystemBackend(root_dir=..., virtual_mode=True)`). `virtual_mode`
-  confines the agent to the workspace: absolute paths and `..` cannot escape
-  `root_dir`.
+  confines filesystem tools to the workspace: absolute paths and `..` cannot
+  escape `root_dir`.
 - Routed `skills` (`native.skill_paths`) become the Deep Agents `skills` sources.
 - Configured MCP servers are loaded as Deep Agents tools via
   `langchain-mcp-adapters`. A misconfigured server (non-mapping, empty target,
@@ -70,9 +70,9 @@ NeMo Fabric maps the following into the harness:
 - `tools.enabled` and `tools.blocked` are enforced by middleware across the full
   tool surface: Deep Agents built-ins (including `task`), MCP tools, and
   **delegated subagents** alike. Use Deep Agents-native tool names.
-- `harness.settings.deepagents` accepts the JSON-serializable Deep Agents
-  `interrupt_on` and `subagents` options. The descriptor schema rejects unknown
-  settings and fields before runtime start.
+- `harness.settings.deepagents` accepts the adapter-owned `backend` selector and
+  the JSON-serializable Deep Agents `interrupt_on` and `subagents` options. The
+  descriptor schema rejects unknown settings and fields before runtime start.
 
 ### Harness Settings
 
@@ -106,6 +106,10 @@ harness = HarnessConfig(
 
 The `deepagents` object is closed and supports the following properties:
 
+- `backend` accepts only `{"type": "local_shell"}`. This opt-in constructs
+  `LocalShellBackend` at `environment.workspace`, or at the NeMo Fabric base
+  directory when the workspace is omitted. Omit `backend` to preserve the
+  existing filesystem or Deep Agents default backend behavior.
 - `interrupt_on` maps a Deep Agents tool name to a boolean or an object with
   required `allowed_decisions`. Decisions are `approve`, `edit`, `reject`, or
   `respond`. The object can also contain a static `description` and an
@@ -119,6 +123,48 @@ The `deepagents` object is closed and supports the following properties:
   and a JSON `response_format`. An asynchronous subagent requires `name`,
   `description`, and `graph_id`; it can also contain `url` and string-valued
   `headers`.
+
+### Enable Local Shell Execution for a Supervised Demo
+
+> [!WARNING]
+> `LocalShellBackend` executes commands directly on the adapter host with the
+> host user's permissions. It provides no process isolation, and shell commands
+> can bypass `virtual_mode` filesystem restrictions. Use it only with trusted
+> input in a controlled environment. Do not use it for production or
+> multi-tenant workloads.
+
+The following configuration opts in to local shell execution, limits the tool
+surface to `execute`, and requires a reviewer decision for each command:
+
+```python
+from nemo_fabric import EnvironmentConfig, HarnessConfig, ToolsConfig
+
+harness = HarnessConfig(
+    adapter_id="nvidia.fabric.langchain.deepagents",
+    settings={
+        "deepagents": {
+            "backend": {"type": "local_shell"},
+            "interrupt_on": {
+                "execute": {
+                    "allowed_decisions": ["approve", "reject"],
+                    "description": "Review this local shell command.",
+                }
+            },
+        }
+    },
+)
+environment = EnvironmentConfig(
+    provider="local",
+    workspace="/path/to/supervised-demo",
+)
+tools = ToolsConfig(enabled=["execute"])
+```
+
+If `environment.workspace` is omitted, the adapter uses the NeMo Fabric base
+directory as the backend root. The `execute` tool remains subject to
+`tools.enabled` and `tools.blocked`, like all other Deep Agents built-ins.
+Approval middleware reduces accidental execution but does not isolate the
+process or contain an approved command.
 
 Python middleware, `FilesystemPermission` objects, Python tool objects, and
 precompiled `runnable` subagents are not exposed through `harness.settings`.

--- a/adapters/python/deepagents/README.md
+++ b/adapters/python/deepagents/README.md
@@ -133,6 +133,10 @@ The `deepagents` object is closed and supports the following properties:
 > input in a controlled environment. Do not use it for production or
 > multi-tenant workloads.
 
+The adapter rejects `local_shell` unless `execute` is blocked by
+`tools.blocked`, omitted from a configured `tools.enabled` allowlist, or
+protected by an `interrupt_on.execute` approval rule.
+
 The following configuration opts in to local shell execution, limits the tool
 surface to `execute`, and requires a reviewer decision for each command:
 

--- a/adapters/python/deepagents/README.md
+++ b/adapters/python/deepagents/README.md
@@ -107,9 +107,8 @@ harness = HarnessConfig(
 The `deepagents` object is closed and supports the following properties:
 
 - `backend` accepts only `{"type": "local_shell"}`. This opt-in constructs
-  `LocalShellBackend` at `environment.workspace`, or at the NeMo Fabric base
-  directory when the workspace is omitted. Omit `backend` to preserve the
-  existing filesystem or Deep Agents default backend behavior.
+  `LocalShellBackend` at the required `environment.workspace`. Omit `backend`
+  to preserve the existing filesystem or Deep Agents default backend behavior.
 - `interrupt_on` maps a Deep Agents tool name to a boolean or an object with
   required `allowed_decisions`. Decisions are `approve`, `edit`, `reject`, or
   `respond`. The object can also contain a static `description` and an
@@ -133,12 +132,20 @@ The `deepagents` object is closed and supports the following properties:
 > input in a controlled environment. Do not use it for production or
 > multi-tenant workloads.
 
-The adapter rejects `local_shell` unless `execute` is blocked by
-`tools.blocked`, omitted from a configured `tools.enabled` allowlist, or
-protected by an `interrupt_on.execute` approval rule.
+The adapter requires `environment.workspace` and an explicit Fabric tool policy
+when `local_shell` is selected. The policy is applied to the main agent and all
+declarative subagents, including a subagent that replaces the parent's
+`interrupt_on` map. Include `execute` in `tools.enabled` to permit commands;
+omit it from that allowlist or add it to `tools.blocked` to prevent commands.
 
-The following configuration opts in to local shell execution, limits the tool
-surface to `execute`, and requires a reviewer decision for each command:
+Do not configure `interrupt_on.execute` with `local_shell`. The current adapter
+lifecycle cannot surface and resume a LangGraph approval interrupt, so the
+adapter rejects that combination instead of reporting an interrupted command as
+a completed turn.
+
+The following configuration opts in to local shell execution and limits the
+tool surface to `execute`. It does not provide per-command approval; use it only
+with trusted input under direct operator supervision:
 
 ```python
 from nemo_fabric import EnvironmentConfig, HarnessConfig, ToolsConfig
@@ -146,15 +153,7 @@ from nemo_fabric import EnvironmentConfig, HarnessConfig, ToolsConfig
 harness = HarnessConfig(
     adapter_id="nvidia.fabric.langchain.deepagents",
     settings={
-        "deepagents": {
-            "backend": {"type": "local_shell"},
-            "interrupt_on": {
-                "execute": {
-                    "allowed_decisions": ["approve", "reject"],
-                    "description": "Review this local shell command.",
-                }
-            },
-        }
+        "deepagents": {"backend": {"type": "local_shell"}}
     },
 )
 environment = EnvironmentConfig(
@@ -164,11 +163,11 @@ environment = EnvironmentConfig(
 tools = ToolsConfig(enabled=["execute"])
 ```
 
-If `environment.workspace` is omitted, the adapter uses the NeMo Fabric base
-directory as the backend root. The `execute` tool remains subject to
-`tools.enabled` and `tools.blocked`, like all other Deep Agents built-ins.
-Approval middleware reduces accidental execution but does not isolate the
-process or contain an approved command.
+`LocalShellBackend` keeps its `inherit_env=False` default. Commands do not
+inherit host variables such as `HOME` and receive only the shell's fallback
+`PATH`; set required variables in the command and use absolute executable paths
+when needed. The `execute` tool remains subject to `tools.enabled` and
+`tools.blocked`, like all other Deep Agents built-ins.
 
 Python middleware, `FilesystemPermission` objects, Python tool objects, and
 precompiled `runnable` subagents are not exposed through `harness.settings`.

--- a/adapters/python/deepagents/deepagents.fabric-adapter.json
+++ b/adapters/python/deepagents/deepagents.fabric-adapter.json
@@ -131,6 +131,19 @@
       "deepagents": {
         "type": "object",
         "properties": {
+          "backend": {
+            "type": "object",
+            "properties": {
+              "type": {
+                "type": "string",
+                "const": "local_shell",
+                "description": "Selects the adapter-owned LocalShellBackend."
+              }
+            },
+            "required": ["type"],
+            "additionalProperties": false,
+            "description": "Optional backend selection. Local shell execution runs directly on the adapter host without process isolation."
+          },
           "interrupt_on": {
             "$ref": "#/$defs/interrupt_on",
             "default": {},
@@ -155,7 +168,7 @@
         "required": [],
         "additionalProperties": false,
         "default": {},
-        "description": "JSON-serializable options forwarded to Deep Agents."
+        "description": "JSON-serializable adapter and Deep Agents options."
       }
     },
     "required": [],

--- a/adapters/python/deepagents/src/nemo_fabric_adapters/deepagents/adapter.py
+++ b/adapters/python/deepagents/src/nemo_fabric_adapters/deepagents/adapter.py
@@ -247,7 +247,10 @@ def resolve_backend(
         from deepagents.backends import LocalShellBackend
 
         return LocalShellBackend(
-            root_dir=str(root), virtual_mode=True, inherit_env=False
+            root_dir=str(root),
+            virtual_mode=True,
+            env=dict(runtime_context.environment.env),
+            inherit_env=False,
         )
 
     from deepagents.backends import FilesystemBackend

--- a/adapters/python/deepagents/src/nemo_fabric_adapters/deepagents/adapter.py
+++ b/adapters/python/deepagents/src/nemo_fabric_adapters/deepagents/adapter.py
@@ -231,16 +231,24 @@ def resolve_backend(
     """Resolve the adapter-owned backend selection and root directory."""
 
     workspace = runtime_context.environment.workspace
-    if not workspace and backend_config is None:
+    if backend_config is not None and not workspace:
+        raise AdapterConfigError(
+            "harness.settings.deepagents.backend.type='local_shell' requires "
+            "environment.workspace so host shell execution is never rooted at the "
+            "NeMo Fabric base directory."
+        )
+    if not workspace:
         return None
-    root = Path(str(workspace or base_dir))
+    root = Path(str(workspace))
     if not root.is_absolute():
         root = Path(base_dir) / root
 
     if backend_config is not None:
         from deepagents.backends import LocalShellBackend
 
-        return LocalShellBackend(root_dir=str(root), virtual_mode=True)
+        return LocalShellBackend(
+            root_dir=str(root), virtual_mode=True, inherit_env=False
+        )
 
     from deepagents.backends import FilesystemBackend
 
@@ -280,21 +288,8 @@ def tool_policy_middleware(enabled: set[str] | None, blocked: set[str]) -> Any:
     )
 
 
-def _local_shell_execute_is_guarded(
-    settings: dict[str, Any], enabled: set[str] | None, blocked: set[str]
-) -> bool:
-    if "execute" in blocked or (enabled is not None and "execute" not in enabled):
-        return True
-    interrupt_on = settings.get("interrupt_on")
-    if not isinstance(interrupt_on, dict):
-        return False
-    execute_interrupt = interrupt_on.get("execute")
-    if execute_interrupt is True:
-        return True
-    if not isinstance(execute_interrupt, dict):
-        return False
-    allowed_decisions = execute_interrupt.get("allowed_decisions")
-    return isinstance(allowed_decisions, list) and bool(allowed_decisions)
+def _interrupt_is_enabled(policy: Any) -> bool:
+    return policy is True or isinstance(policy, dict)
 
 
 def resolve_skills(config: AgentConfig) -> list[str] | None:
@@ -413,15 +408,35 @@ async def build_agent_kwargs(
     extra = _validated_deepagents_settings(settings.get("deepagents"))
     enabled = _enabled_tool_names(config)
     blocked = _blocked_tool_names(config)
-    if extra.get("backend") is not None and not _local_shell_execute_is_guarded(
-        extra, enabled, blocked
-    ):
-        raise AdapterConfigError(
-            "harness.settings.deepagents.backend.type='local_shell' requires "
-            "'execute' to be blocked by tools.blocked, omitted from a configured "
-            "tools.enabled allowlist, or protected by "
-            "harness.settings.deepagents.interrupt_on.execute approval."
-        )
+    if extra.get("backend") is not None:
+        if enabled is None and "execute" not in blocked:
+            raise AdapterConfigError(
+                "harness.settings.deepagents.backend.type='local_shell' requires an "
+                "explicit tools.enabled allowlist or 'execute' in tools.blocked so "
+                "the policy is enforced for the main agent and declarative subagents."
+            )
+        interrupt_on = extra.get("interrupt_on")
+        if isinstance(interrupt_on, dict) and _interrupt_is_enabled(
+            interrupt_on.get("execute")
+        ):
+            raise AdapterConfigError(
+                "harness.settings.deepagents.interrupt_on.execute is not supported "
+                "with the local_shell backend because NeMo Fabric cannot resume the "
+                "LangGraph interrupt; use tools.enabled or tools.blocked instead."
+            )
+        for index, subagent in enumerate(extra.get("subagents") or []):
+            if not isinstance(subagent, dict):
+                continue
+            subagent_interrupt_on = subagent.get("interrupt_on")
+            if isinstance(subagent_interrupt_on, dict) and _interrupt_is_enabled(
+                subagent_interrupt_on.get("execute")
+            ):
+                raise AdapterConfigError(
+                    "harness.settings.deepagents.subagents"
+                    f"[{index}].interrupt_on.execute is not supported with the "
+                    "local_shell backend because NeMo Fabric cannot resume the "
+                    "LangGraph interrupt; use tools.enabled or tools.blocked instead."
+                )
     kwargs: dict[str, Any] = {
         "model": model,
         "tools": await resolve_tools(config),

--- a/adapters/python/deepagents/src/nemo_fabric_adapters/deepagents/adapter.py
+++ b/adapters/python/deepagents/src/nemo_fabric_adapters/deepagents/adapter.py
@@ -46,7 +46,8 @@ VALID_MCP_TRANSPORTS = {"stdio", "sse", "streamable_http", "websocket"}
 # create_deep_agent arguments Fabric derives from normalized config; the
 # harness.settings.deepagents passthrough must not override them (doing so would
 # bypass the normalized model config, MCP tool resolution, workspace confinement,
-# or tool gating).
+# or tool gating). The declarative backend selector is validated separately and
+# never forwarded as a create_deep_agent argument.
 FABRIC_OWNED_AGENT_KEYS = frozenset(
     {
         "model",
@@ -62,6 +63,7 @@ FABRIC_OWNED_AGENT_KEYS = frozenset(
 # through harness.settings.deepagents. Executable objects (AgentMiddleware, BaseTool,
 # Python callables) cannot cross the SDK->JSON->payload boundary and are excluded.
 DEEPAGENTS_PASSTHROUGH_KEYS = frozenset({"subagents", "interrupt_on"})
+DEEPAGENTS_ADAPTER_SETTING_KEYS = frozenset({"backend"})
 # Appended to the fault that poisoned Relay's scope stack, and then reported on every
 # later turn of the same runtime so none of them can look telemetry-clean. Deliberately
 # does not claim later turns are untraced: the Relay middleware is attached to the
@@ -221,15 +223,25 @@ def build_chat_model(model_config: AgentModelConfig) -> tuple[Any, str, str | No
     return ChatOpenAI(**_supported_kwargs(ChatOpenAI, kwargs)), model_name, base_url
 
 
-def resolve_backend(runtime_context: RuntimeContext, base_dir: str) -> Any:
-    """Root the Deep Agents filesystem backend at the Fabric workspace, if set."""
+def resolve_backend(
+    runtime_context: RuntimeContext,
+    base_dir: str,
+    backend_config: dict[str, Any] | None = None,
+) -> Any:
+    """Resolve the adapter-owned backend selection and root directory."""
 
     workspace = runtime_context.environment.workspace
-    if not workspace:
+    if not workspace and backend_config is None:
         return None
-    root = Path(str(workspace))
+    root = Path(str(workspace or base_dir))
     if not root.is_absolute():
         root = Path(base_dir) / root
+
+    if backend_config is not None:
+        from deepagents.backends import LocalShellBackend
+
+        return LocalShellBackend(root_dir=str(root), virtual_mode=True)
+
     from deepagents.backends import FilesystemBackend
 
     # virtual_mode=True confines the agent to root_dir; absolute paths and ``..``
@@ -381,19 +393,20 @@ async def build_agent_kwargs(
         adapter="Deep Agents",
         supported_modes={"replace"},
     )
+    extra = _validated_deepagents_settings(settings.get("deepagents"))
     kwargs: dict[str, Any] = {
         "model": model,
         "tools": await resolve_tools(config),
         # deepagents 0.5.x/0.6.x take the system prompt as ``system_prompt``.
         "system_prompt": instruction.content if instruction else None,
         "skills": resolve_skills(config),
-        "backend": resolve_backend(runtime_context, base_dir),
+        "backend": resolve_backend(runtime_context, base_dir, extra.get("backend")),
     }
     # Deep Agents-specific settings (e.g. subagents, interrupt_on) pass through,
     # after validation against the documented JSON-serializable allow-list.
-    extra = settings.get("deepagents")
-    if extra is not None:
-        kwargs.update(_validated_passthrough(extra))
+    kwargs.update(
+        {key: extra[key] for key in DEEPAGENTS_PASSTHROUGH_KEYS if key in extra}
+    )
     enabled = _enabled_tool_names(config)
     blocked = _blocked_tool_names(config)
     if enabled is not None or blocked:
@@ -406,8 +419,8 @@ async def build_agent_kwargs(
     return {key: value for key, value in kwargs.items() if value is not None}
 
 
-def _validated_passthrough(extra: Any) -> dict[str, Any]:
-    """Validate the harness.settings.deepagents passthrough and return the safe subset.
+def _validated_deepagents_settings(extra: Any) -> dict[str, Any]:
+    """Validate adapter-owned and passthrough Deep Agents settings.
 
     Only documented, JSON-serializable create_deep_agent options are forwarded.
     Fabric-owned keys cannot be overridden (that would bypass the normalized model
@@ -415,22 +428,45 @@ def _validated_passthrough(extra: Any) -> dict[str, Any]:
     keys fail clearly instead of being silently dropped.
     """
 
+    if extra is None:
+        return {}
     if not isinstance(extra, dict):
         raise AdapterConfigError(
             f"harness.settings.deepagents must be a mapping of JSON-serializable options, not {type(extra).__name__}."
         )
-    reserved = sorted(FABRIC_OWNED_AGENT_KEYS.intersection(extra))
+    reserved = sorted(
+        FABRIC_OWNED_AGENT_KEYS.intersection(extra) - DEEPAGENTS_ADAPTER_SETTING_KEYS
+    )
     if reserved:
         raise AdapterConfigError(
             f"harness.settings.deepagents cannot override NeMo Fabric-owned keys {reserved}; "
             "they are derived from the normalized NeMo Fabric config."
         )
-    unknown = sorted(set(extra) - DEEPAGENTS_PASSTHROUGH_KEYS)
+    supported = DEEPAGENTS_PASSTHROUGH_KEYS | DEEPAGENTS_ADAPTER_SETTING_KEYS
+    unknown = sorted(set(extra) - supported)
     if unknown:
         raise AdapterConfigError(
             f"harness.settings.deepagents has unsupported option(s) {unknown}; supported "
-            f"passthrough keys are {sorted(DEEPAGENTS_PASSTHROUGH_KEYS)}."
+            f"settings are {sorted(supported)}."
         )
+
+    backend_config = extra.get("backend")
+    if backend_config is not None:
+        if not isinstance(backend_config, dict):
+            raise AdapterConfigError(
+                "harness.settings.deepagents.backend must be a mapping with "
+                "type='local_shell'."
+            )
+        unknown_backend = sorted(set(backend_config) - {"type"})
+        if unknown_backend:
+            raise AdapterConfigError(
+                "harness.settings.deepagents.backend has unsupported field(s) "
+                f"{unknown_backend}; only 'type' is supported."
+            )
+        if backend_config.get("type") != "local_shell":
+            raise AdapterConfigError(
+                "harness.settings.deepagents.backend.type must be 'local_shell'."
+            )
     return dict(extra)
 
 

--- a/adapters/python/deepagents/src/nemo_fabric_adapters/deepagents/adapter.py
+++ b/adapters/python/deepagents/src/nemo_fabric_adapters/deepagents/adapter.py
@@ -280,6 +280,23 @@ def tool_policy_middleware(enabled: set[str] | None, blocked: set[str]) -> Any:
     )
 
 
+def _local_shell_execute_is_guarded(
+    settings: dict[str, Any], enabled: set[str] | None, blocked: set[str]
+) -> bool:
+    if "execute" in blocked or (enabled is not None and "execute" not in enabled):
+        return True
+    interrupt_on = settings.get("interrupt_on")
+    if not isinstance(interrupt_on, dict):
+        return False
+    execute_interrupt = interrupt_on.get("execute")
+    if execute_interrupt is True:
+        return True
+    if not isinstance(execute_interrupt, dict):
+        return False
+    allowed_decisions = execute_interrupt.get("allowed_decisions")
+    return isinstance(allowed_decisions, list) and bool(allowed_decisions)
+
+
 def resolve_skills(config: AgentConfig) -> list[str] | None:
     """Map Fabric skill paths onto the Deep Agents ``skills`` sources."""
 
@@ -394,6 +411,17 @@ async def build_agent_kwargs(
         supported_modes={"replace"},
     )
     extra = _validated_deepagents_settings(settings.get("deepagents"))
+    enabled = _enabled_tool_names(config)
+    blocked = _blocked_tool_names(config)
+    if extra.get("backend") is not None and not _local_shell_execute_is_guarded(
+        extra, enabled, blocked
+    ):
+        raise AdapterConfigError(
+            "harness.settings.deepagents.backend.type='local_shell' requires "
+            "'execute' to be blocked by tools.blocked, omitted from a configured "
+            "tools.enabled allowlist, or protected by "
+            "harness.settings.deepagents.interrupt_on.execute approval."
+        )
     kwargs: dict[str, Any] = {
         "model": model,
         "tools": await resolve_tools(config),
@@ -407,8 +435,6 @@ async def build_agent_kwargs(
     kwargs.update(
         {key: extra[key] for key in DEEPAGENTS_PASSTHROUGH_KEYS if key in extra}
     )
-    enabled = _enabled_tool_names(config)
-    blocked = _blocked_tool_names(config)
     if enabled is not None or blocked:
         middleware = list(kwargs.get("middleware") or [])
         middleware.append(tool_policy_middleware(enabled, blocked))

--- a/crates/fabric-cli/assets/adapters/deepagents/deepagents.fabric-adapter.json
+++ b/crates/fabric-cli/assets/adapters/deepagents/deepagents.fabric-adapter.json
@@ -131,6 +131,19 @@
       "deepagents": {
         "type": "object",
         "properties": {
+          "backend": {
+            "type": "object",
+            "properties": {
+              "type": {
+                "type": "string",
+                "const": "local_shell",
+                "description": "Selects the adapter-owned LocalShellBackend."
+              }
+            },
+            "required": ["type"],
+            "additionalProperties": false,
+            "description": "Optional backend selection. Local shell execution runs directly on the adapter host without process isolation."
+          },
           "interrupt_on": {
             "$ref": "#/$defs/interrupt_on",
             "default": {},
@@ -155,7 +168,7 @@
         "required": [],
         "additionalProperties": false,
         "default": {},
-        "description": "JSON-serializable options forwarded to Deep Agents."
+        "description": "JSON-serializable adapter and Deep Agents options."
       }
     },
     "required": [],

--- a/docs/integrations/harness/deepagents.mdx
+++ b/docs/integrations/harness/deepagents.mdx
@@ -124,12 +124,20 @@ in a controlled environment. Do not use it for production or multi-tenant
 workloads.
 </Warning>
 
-The adapter rejects `local_shell` unless `execute` is blocked by
-`tools.blocked`, omitted from a configured `tools.enabled` allowlist, or
-protected by an `interrupt_on.execute` approval rule.
+The adapter requires `environment.workspace` and an explicit Fabric tool policy
+when `local_shell` is selected. The policy is applied to the main agent and all
+declarative subagents, including a subagent that replaces the parent's
+`interrupt_on` map. Include `execute` in `tools.enabled` to permit commands;
+omit it from that allowlist or add it to `tools.blocked` to prevent commands.
 
-The following configuration opts in to local shell execution, limits the tool
-surface to `execute`, and requires a reviewer decision for each command:
+Do not configure `interrupt_on.execute` with `local_shell`. The current adapter
+lifecycle cannot surface and resume a LangGraph approval interrupt, so the
+adapter rejects that combination instead of reporting an interrupted command as
+a completed turn.
+
+The following configuration opts in to local shell execution and limits the
+tool surface to `execute`. It does not provide per-command approval; use it only
+with trusted input under direct operator supervision:
 
 ```python
 from nemo_fabric import EnvironmentConfig, HarnessConfig, ToolsConfig
@@ -137,15 +145,7 @@ from nemo_fabric import EnvironmentConfig, HarnessConfig, ToolsConfig
 harness = HarnessConfig(
     adapter_id="nvidia.fabric.langchain.deepagents",
     settings={
-        "deepagents": {
-            "backend": {"type": "local_shell"},
-            "interrupt_on": {
-                "execute": {
-                    "allowed_decisions": ["approve", "reject"],
-                    "description": "Review this local shell command.",
-                }
-            },
-        }
+        "deepagents": {"backend": {"type": "local_shell"}}
     },
 )
 environment = EnvironmentConfig(
@@ -155,11 +155,11 @@ environment = EnvironmentConfig(
 tools = ToolsConfig(enabled=["execute"])
 ```
 
-If `environment.workspace` is omitted, the adapter uses the NeMo Fabric base
-directory as the backend root. The `execute` tool remains subject to
-`tools.enabled` and `tools.blocked`, like all other Deep Agents built-ins.
-Approval middleware reduces accidental execution but does not isolate the
-process or contain an approved command.
+`LocalShellBackend` keeps its `inherit_env=False` default. Commands do not
+inherit host variables such as `HOME` and receive only the shell's fallback
+`PATH`; set required variables in the command and use absolute executable paths
+when needed. The `execute` tool remains subject to `tools.enabled` and
+`tools.blocked`, like all other Deep Agents built-ins.
 
 `subagents` accepts declarative synchronous subagents and Agent Protocol
 asynchronous subagents. A declarative subagent requires `name`, `description`,

--- a/docs/integrations/harness/deepagents.mdx
+++ b/docs/integrations/harness/deepagents.mdx
@@ -161,6 +161,13 @@ inherit host variables such as `HOME` and receive only the shell's fallback
 when needed. The `execute` tool remains subject to `tools.enabled` and
 `tools.blocked`, like all other Deep Agents built-ins.
 
+File tools and shell commands use different absolute-path namespaces when
+`virtual_mode=True`. For file tools, `/report.txt` resolves to
+`<workspace>/report.txt`; in `execute`, the same path refers to `/report.txt` on
+the adapter host. Shell commands start in `environment.workspace`, so use
+workspace-relative paths, such as `cat report.txt`, for files surfaced by file
+tools. Do not pass a file tool's virtual absolute path directly to `execute`.
+
 `subagents` accepts declarative synchronous subagents and Agent Protocol
 asynchronous subagents. A declarative subagent requires `name`, `description`,
 and `system_prompt`. An asynchronous subagent requires `name`, `description`,

--- a/docs/integrations/harness/deepagents.mdx
+++ b/docs/integrations/harness/deepagents.mdx
@@ -155,11 +155,13 @@ environment = EnvironmentConfig(
 tools = ToolsConfig(enabled=["execute"])
 ```
 
-`LocalShellBackend` keeps its `inherit_env=False` default. Commands do not
-inherit host variables such as `HOME` and receive only the shell's fallback
-`PATH`; set required variables in the command and use absolute executable paths
-when needed. The `execute` tool remains subject to `tools.enabled` and
-`tools.blocked`, like all other Deep Agents built-ins.
+`LocalShellBackend` keeps `inherit_env=False`, so commands do not inherit
+ambient adapter-host variables such as `HOME`. Values explicitly configured in
+`environment.env` are passed to shell commands and are available to
+agent-generated commands. If `environment.env` does not set `PATH`, the shell
+provides only its fallback path; configure required variables explicitly and
+use absolute executable paths when needed. The `execute` tool remains subject
+to `tools.enabled` and `tools.blocked`, like all other Deep Agents built-ins.
 
 File tools and shell commands use different absolute-path namespaces when
 `virtual_mode=True`. For file tools, `/report.txt` resolves to

--- a/docs/integrations/harness/deepagents.mdx
+++ b/docs/integrations/harness/deepagents.mdx
@@ -103,6 +103,8 @@ harness = HarnessConfig(
 
 The descriptor closes both `harness.settings` and its nested `deepagents`
 object, so planning rejects unknown settings before runtime start.
+The optional `backend` object accepts only `{"type": "local_shell"}`. Omit it
+to preserve the existing filesystem or Deep Agents default backend behavior.
 `runtime.max_turns=10` configures LangGraph with `recursion_limit=10`. This is
 a graph-superstep budget, not a promise of ten model responses or tool calls.
 One interaction can consume multiple supersteps. When `runtime.max_turns` is
@@ -111,6 +113,49 @@ omitted, the adapter keeps the Deep Agents default.
 `allowed_decisions`; supported decisions are `approve`, `edit`, `reject`, and
 `respond`. The object can also contain a static `description` and an
 `args_schema` JSON Schema.
+
+### Enable Local Shell Execution for a Supervised Demo
+
+<Warning>
+`LocalShellBackend` executes commands directly on the adapter host with the host
+user's permissions. It provides no process isolation, and shell commands can
+bypass `virtual_mode` filesystem restrictions. Use it only with trusted input
+in a controlled environment. Do not use it for production or multi-tenant
+workloads.
+</Warning>
+
+The following configuration opts in to local shell execution, limits the tool
+surface to `execute`, and requires a reviewer decision for each command:
+
+```python
+from nemo_fabric import EnvironmentConfig, HarnessConfig, ToolsConfig
+
+harness = HarnessConfig(
+    adapter_id="nvidia.fabric.langchain.deepagents",
+    settings={
+        "deepagents": {
+            "backend": {"type": "local_shell"},
+            "interrupt_on": {
+                "execute": {
+                    "allowed_decisions": ["approve", "reject"],
+                    "description": "Review this local shell command.",
+                }
+            },
+        }
+    },
+)
+environment = EnvironmentConfig(
+    provider="local",
+    workspace="/path/to/supervised-demo",
+)
+tools = ToolsConfig(enabled=["execute"])
+```
+
+If `environment.workspace` is omitted, the adapter uses the NeMo Fabric base
+directory as the backend root. The `execute` tool remains subject to
+`tools.enabled` and `tools.blocked`, like all other Deep Agents built-ins.
+Approval middleware reduces accidental execution but does not isolate the
+process or contain an approved command.
 
 `subagents` accepts declarative synchronous subagents and Agent Protocol
 asynchronous subagents. A declarative subagent requires `name`, `description`,

--- a/docs/integrations/harness/deepagents.mdx
+++ b/docs/integrations/harness/deepagents.mdx
@@ -124,6 +124,10 @@ in a controlled environment. Do not use it for production or multi-tenant
 workloads.
 </Warning>
 
+The adapter rejects `local_shell` unless `execute` is blocked by
+`tools.blocked`, omitted from a configured `tools.enabled` allowlist, or
+protected by an `interrupt_on.execute` approval rule.
+
 The following configuration opts in to local shell execution, limits the tool
 surface to `execute`, and requires a reviewer decision for each command:
 

--- a/tests/adapters/test_deepagents.py
+++ b/tests/adapters/test_deepagents.py
@@ -1481,8 +1481,10 @@ async def test_local_shell_backend_resolves_root_from_workspace_or_base_dir(
     payload = make_payload(tmp_path)
     payload["runtime_context"]["environment"]["workspace"] = workspace
     payload["config"]["harness"]["settings"]["deepagents"] = {
-        "backend": {"type": "local_shell"}
+        "backend": {"type": "local_shell"},
+        "interrupt_on": {"execute": {"allowed_decisions": ["approve", "reject"]}},
     }
+    payload["config"]["tools"] = {"enabled": ["execute"]}
 
     await invoke_once(payload)
 
@@ -1490,6 +1492,40 @@ async def test_local_shell_backend_resolves_root_from_workspace_or_base_dir(
     expected_root = tmp_path if workspace is None else tmp_path / workspace
     assert backend_kwargs == {"root_dir": str(expected_root), "virtual_mode": True}
     fake_sdks["fs_backend"].assert_not_called()
+
+
+@pytest.mark.parametrize("tools", [None, {"enabled": ["execute"]}])
+async def test_local_shell_backend_rejects_unguarded_execute(
+    tmp_path, make_payload, tools
+):
+    payload = make_payload(tmp_path)
+    payload["config"]["harness"]["settings"]["deepagents"] = {
+        "backend": {"type": "local_shell"}
+    }
+    if tools is not None:
+        payload["config"]["tools"] = tools
+
+    with pytest.raises(
+        adapter.AdapterConfigError, match="requires 'execute' to be blocked"
+    ):
+        await adapter.DeepAgentsRuntime().start(lifecycle_start_payload(payload))
+
+
+@pytest.mark.parametrize(
+    "tools", [{"blocked": ["execute"]}, {"enabled": ["read_file"]}]
+)
+async def test_local_shell_backend_accepts_policy_that_blocks_execute(
+    tmp_path, make_payload, fake_sdks, tools
+):
+    payload = make_payload(tmp_path)
+    payload["config"]["harness"]["settings"]["deepagents"] = {
+        "backend": {"type": "local_shell"}
+    }
+    payload["config"]["tools"] = tools
+
+    await invoke_once(payload)
+
+    fake_sdks["local_shell_backend"].assert_called_once()
 
 
 async def test_checkpointer_closed_on_success_and_failure(

--- a/tests/adapters/test_deepagents.py
+++ b/tests/adapters/test_deepagents.py
@@ -1492,6 +1492,7 @@ async def test_local_shell_backend_resolves_root_from_workspace(
 ):
     payload = make_payload(tmp_path)
     payload["runtime_context"]["environment"]["workspace"] = "relative-workspace"
+    payload["runtime_context"]["environment"]["env"] = {"EXPLICIT_VALUE": "configured"}
     payload["config"]["harness"]["settings"]["deepagents"] = {
         "backend": {"type": "local_shell"}
     }
@@ -1503,6 +1504,7 @@ async def test_local_shell_backend_resolves_root_from_workspace(
     assert backend_kwargs == {
         "root_dir": str(tmp_path / "relative-workspace"),
         "virtual_mode": True,
+        "env": {"EXPLICIT_VALUE": "configured"},
         "inherit_env": False,
     }
     fake_sdks["fs_backend"].assert_not_called()
@@ -1539,6 +1541,28 @@ def test_local_shell_backend_keeps_file_and_shell_path_namespaces_distinct(
 
     assert relative.exit_code == 0
     assert host_absolute.exit_code != 0
+
+
+@pytest.mark.usefixtures("use_real_deepagents")
+def test_local_shell_backend_forwards_only_explicit_environment(tmp_path, make_payload):
+    os.environ["AMBIENT_ONLY"] = "ambient"
+    payload = make_payload(tmp_path)
+    payload["runtime_context"]["environment"]["env"] = {"EXPLICIT_VALUE": "configured"}
+    context = RuntimeContext.from_mapping(payload["runtime_context"])
+
+    backend = adapter.resolve_backend(
+        context,
+        str(tmp_path),
+        {"type": "local_shell"},
+    )
+    result = backend.execute(
+        f'"{sys.executable}" -c "import os; '
+        "print(os.environ.get('EXPLICIT_VALUE')); "
+        "print(os.environ.get('AMBIENT_ONLY', '<missing>'))\""
+    )
+
+    assert result.exit_code == 0
+    assert result.output.splitlines() == ["configured", "<missing>"]
 
 
 async def test_local_shell_backend_requires_workspace(tmp_path, make_payload):

--- a/tests/adapters/test_deepagents.py
+++ b/tests/adapters/test_deepagents.py
@@ -49,6 +49,24 @@ def test_descriptor_declares_supported_normalized_config():
 
     assert descriptor["config"]["system_instruction_modes"] == ["replace"]
     assert "runtime.max_turns" in descriptor["config"]["accepts"]
+    assert descriptor["settings_schema"]["properties"]["deepagents"]["properties"][
+        "backend"
+    ] == {
+        "type": "object",
+        "properties": {
+            "type": {
+                "type": "string",
+                "const": "local_shell",
+                "description": "Selects the adapter-owned LocalShellBackend.",
+            }
+        },
+        "required": ["type"],
+        "additionalProperties": False,
+        "description": (
+            "Optional backend selection. Local shell execution runs directly on "
+            "the adapter host without process isolation."
+        ),
+    }
 
 
 def lifecycle_start_payload(payload: dict[str, Any]) -> dict[str, Any]:
@@ -110,16 +128,19 @@ def fake_sdks_fixture(monkeypatch):
     """Stub the deepagents/langchain/langgraph SDKs with mocks.
 
     Returns a recorder capturing the ``create_deep_agent`` kwargs, the streamed
-    ``config``, and the checkpointer close count. ``chat_openai``/``fs_backend``
-    expose the mocked classes so tests can assert their construction kwargs.
+    ``config``, and the checkpointer close count. ``chat_openai``, ``fs_backend``,
+    and ``local_shell_backend`` expose the mocked classes so tests can assert their
+    construction kwargs.
     """
 
     recorder: dict[str, Any] = {"saver_exits": 0}
 
     mock_chat_openai = MagicMock()
     mock_fs_backend = MagicMock()
+    mock_local_shell_backend = MagicMock()
     recorder["chat_openai"] = mock_chat_openai
     recorder["fs_backend"] = mock_fs_backend
+    recorder["local_shell_backend"] = mock_local_shell_backend
 
     def build_agent(**kwargs):
         recorder["create_kwargs"] = kwargs
@@ -189,6 +210,7 @@ def fake_sdks_fixture(monkeypatch):
     deepagents_mod.create_deep_agent = MagicMock(side_effect=build_agent)
     backends_mod = types.ModuleType("deepagents.backends")
     backends_mod.FilesystemBackend = mock_fs_backend
+    backends_mod.LocalShellBackend = mock_local_shell_backend
     middleware_mod = types.ModuleType("deepagents.middleware")
     subagents_mod = types.ModuleType("deepagents.middleware.subagents")
     subagents_mod.GENERAL_PURPOSE_SUBAGENT = {
@@ -1439,6 +1461,37 @@ async def test_workspace_roots_filesystem_backend(tmp_path, make_payload, fake_s
     assert backend_kwargs["virtual_mode"] is True
 
 
+async def test_omitted_workspace_preserves_default_backend(
+    tmp_path, make_payload, fake_sdks
+):
+    payload = make_payload(tmp_path)
+    payload["runtime_context"]["environment"]["workspace"] = None
+
+    await invoke_once(payload)
+
+    assert "backend" not in fake_sdks["create_kwargs"]
+    fake_sdks["fs_backend"].assert_not_called()
+    fake_sdks["local_shell_backend"].assert_not_called()
+
+
+@pytest.mark.parametrize("workspace", [None, "relative-workspace"])
+async def test_local_shell_backend_resolves_root_from_workspace_or_base_dir(
+    tmp_path, make_payload, fake_sdks, workspace
+):
+    payload = make_payload(tmp_path)
+    payload["runtime_context"]["environment"]["workspace"] = workspace
+    payload["config"]["harness"]["settings"]["deepagents"] = {
+        "backend": {"type": "local_shell"}
+    }
+
+    await invoke_once(payload)
+
+    backend_kwargs = fake_sdks["local_shell_backend"].call_args.kwargs
+    expected_root = tmp_path if workspace is None else tmp_path / workspace
+    assert backend_kwargs == {"root_dir": str(expected_root), "virtual_mode": True}
+    fake_sdks["fs_backend"].assert_not_called()
+
+
 async def test_checkpointer_closed_on_success_and_failure(
     tmp_path, make_payload, monkeypatch, fake_sdks
 ):
@@ -1607,6 +1660,32 @@ async def test_tool_policy_middleware_enforces_enabled_and_blocked_tools():
     unselected = await middleware.awrap_tool_call(request("search"), handler)
     assert isinstance(unselected, ToolMessage)
     assert unselected.status == "error"
+
+
+@pytest.mark.parametrize(
+    ("enabled", "blocked"),
+    [({"execute"}, set()), (None, {"execute"})],
+)
+@pytest.mark.usefixtures("use_real_langgraph")
+async def test_tool_policy_applies_to_local_shell_execute(enabled, blocked):
+    pytest.importorskip("langchain.agents.middleware")
+    from langchain_core.messages import ToolMessage
+
+    middleware = adapter.tool_policy_middleware(enabled, blocked)
+    request = types.SimpleNamespace(
+        tool_call={"name": "execute", "id": "call-1", "args": {}}
+    )
+    handler = AsyncMock(return_value="executed")
+
+    result = await middleware.awrap_tool_call(request, handler)
+
+    if blocked:
+        assert isinstance(result, ToolMessage)
+        assert result.status == "error"
+        handler.assert_not_awaited()
+    else:
+        assert result == "executed"
+        handler.assert_awaited_once_with(request)
 
 
 @pytest.mark.usefixtures("use_real_langgraph")
@@ -1995,17 +2074,23 @@ async def test_deepagents_passthrough_forwards_supported_options(
     assert fake_sdks["create_kwargs"]["interrupt_on"] == {"write_file": True}
 
 
-async def test_deepagents_passthrough_cannot_override_fabric_owned_keys(
-    tmp_path, make_payload
-):
-    # Overriding a Fabric-owned key (here backend) would defeat workspace confinement;
-    # it must fail loudly rather than silently replacing the derived value.
+async def test_deepagents_backend_rejects_unknown_fields(tmp_path, make_payload):
     payload = make_payload(tmp_path)
     payload["config"]["harness"]["settings"]["deepagents"] = {
         "backend": {"root_dir": "/etc"}
     }
 
-    with pytest.raises(adapter.AdapterConfigError, match="backend"):
+    with pytest.raises(adapter.AdapterConfigError, match="unsupported field"):
+        await adapter.DeepAgentsRuntime().start(lifecycle_start_payload(payload))
+
+
+async def test_deepagents_backend_rejects_unknown_type(tmp_path, make_payload):
+    payload = make_payload(tmp_path)
+    payload["config"]["harness"]["settings"]["deepagents"] = {
+        "backend": {"type": "sandbox"}
+    }
+
+    with pytest.raises(adapter.AdapterConfigError, match="must be 'local_shell'"):
         await adapter.DeepAgentsRuntime().start(lifecycle_start_payload(payload))
 
 

--- a/tests/adapters/test_deepagents.py
+++ b/tests/adapters/test_deepagents.py
@@ -1474,28 +1474,41 @@ async def test_omitted_workspace_preserves_default_backend(
     fake_sdks["local_shell_backend"].assert_not_called()
 
 
-@pytest.mark.parametrize("workspace", [None, "relative-workspace"])
-async def test_local_shell_backend_resolves_root_from_workspace_or_base_dir(
-    tmp_path, make_payload, fake_sdks, workspace
+async def test_local_shell_backend_resolves_root_from_workspace(
+    tmp_path, make_payload, fake_sdks
 ):
     payload = make_payload(tmp_path)
-    payload["runtime_context"]["environment"]["workspace"] = workspace
+    payload["runtime_context"]["environment"]["workspace"] = "relative-workspace"
     payload["config"]["harness"]["settings"]["deepagents"] = {
-        "backend": {"type": "local_shell"},
-        "interrupt_on": {"execute": {"allowed_decisions": ["approve", "reject"]}},
+        "backend": {"type": "local_shell"}
     }
     payload["config"]["tools"] = {"enabled": ["execute"]}
 
     await invoke_once(payload)
 
     backend_kwargs = fake_sdks["local_shell_backend"].call_args.kwargs
-    expected_root = tmp_path if workspace is None else tmp_path / workspace
-    assert backend_kwargs == {"root_dir": str(expected_root), "virtual_mode": True}
+    assert backend_kwargs == {
+        "root_dir": str(tmp_path / "relative-workspace"),
+        "virtual_mode": True,
+        "inherit_env": False,
+    }
     fake_sdks["fs_backend"].assert_not_called()
 
 
-@pytest.mark.parametrize("tools", [None, {"enabled": ["execute"]}])
-async def test_local_shell_backend_rejects_unguarded_execute(
+async def test_local_shell_backend_requires_workspace(tmp_path, make_payload):
+    payload = make_payload(tmp_path)
+    payload["runtime_context"]["environment"]["workspace"] = None
+    payload["config"]["harness"]["settings"]["deepagents"] = {
+        "backend": {"type": "local_shell"}
+    }
+    payload["config"]["tools"] = {"enabled": ["execute"]}
+
+    with pytest.raises(adapter.AdapterConfigError, match="requires environment.workspace"):
+        await adapter.DeepAgentsRuntime().start(lifecycle_start_payload(payload))
+
+
+@pytest.mark.parametrize("tools", [None, {"blocked": ["write_file"]}])
+async def test_local_shell_backend_requires_explicit_execute_policy(
     tmp_path, make_payload, tools
 ):
     payload = make_payload(tmp_path)
@@ -1505,16 +1518,19 @@ async def test_local_shell_backend_rejects_unguarded_execute(
     if tools is not None:
         payload["config"]["tools"] = tools
 
-    with pytest.raises(
-        adapter.AdapterConfigError, match="requires 'execute' to be blocked"
-    ):
+    with pytest.raises(adapter.AdapterConfigError, match="explicit tools.enabled"):
         await adapter.DeepAgentsRuntime().start(lifecycle_start_payload(payload))
 
 
 @pytest.mark.parametrize(
-    "tools", [{"blocked": ["execute"]}, {"enabled": ["read_file"]}]
+    "tools",
+    [
+        {"enabled": ["execute"]},
+        {"enabled": ["read_file"]},
+        {"blocked": ["execute"]},
+    ],
 )
-async def test_local_shell_backend_accepts_policy_that_blocks_execute(
+async def test_local_shell_backend_accepts_explicit_execute_policy(
     tmp_path, make_payload, fake_sdks, tools
 ):
     payload = make_payload(tmp_path)
@@ -1526,6 +1542,88 @@ async def test_local_shell_backend_accepts_policy_that_blocks_execute(
     await invoke_once(payload)
 
     fake_sdks["local_shell_backend"].assert_called_once()
+
+
+@pytest.mark.parametrize(
+    ("settings", "error_path"),
+    [
+        (
+            {
+                "interrupt_on": {
+                    "execute": {"allowed_decisions": ["approve", "reject"]}
+                }
+            },
+            "interrupt_on.execute",
+        ),
+        (
+            {
+                "subagents": [
+                    {
+                        "name": "runner",
+                        "description": "Runs commands.",
+                        "system_prompt": "Run the requested command.",
+                        "interrupt_on": {"execute": True},
+                    }
+                ]
+            },
+            "subagents[0].interrupt_on.execute",
+        ),
+    ],
+)
+async def test_local_shell_backend_rejects_unresumable_execute_interrupt(
+    tmp_path, make_payload, settings, error_path
+):
+    payload = make_payload(tmp_path)
+    payload["config"]["harness"]["settings"]["deepagents"] = {
+        "backend": {"type": "local_shell"},
+        **settings,
+    }
+    payload["config"]["tools"] = {"enabled": ["execute"]}
+
+    with pytest.raises(adapter.AdapterConfigError) as error:
+        await adapter.DeepAgentsRuntime().start(lifecycle_start_payload(payload))
+
+    assert error_path in str(error.value)
+
+
+async def test_local_shell_backend_gates_subagent_interrupt_override(
+    tmp_path, make_payload, fake_sdks
+):
+    from langchain_core.messages import ToolMessage
+
+    payload = make_payload(tmp_path)
+    payload["config"]["harness"]["settings"]["deepagents"] = {
+        "backend": {"type": "local_shell"},
+        "interrupt_on": {"write_file": True},
+        "subagents": [
+            {
+                "name": "runner",
+                "description": "Runs commands.",
+                "system_prompt": "Run the requested command.",
+                "interrupt_on": {"execute": False},
+            }
+        ],
+    }
+    payload["config"]["tools"] = {"enabled": ["read_file"]}
+
+    await invoke_once(payload)
+
+    subagents = fake_sdks["create_kwargs"]["subagents"]
+    assert [subagent["name"] for subagent in subagents] == [
+        "general-purpose",
+        "runner",
+    ]
+    assert all(subagent["middleware"] for subagent in subagents)
+
+    request = types.SimpleNamespace(
+        tool_call={"name": "execute", "id": "call-1", "args": {}}
+    )
+    handler = AsyncMock(return_value="executed")
+    for subagent in subagents:
+        result = await subagent["middleware"][-1].awrap_tool_call(request, handler)
+        assert isinstance(result, ToolMessage)
+        assert result.status == "error"
+    handler.assert_not_awaited()
 
 
 async def test_checkpointer_closed_on_success_and_failure(
@@ -2139,6 +2237,11 @@ async def test_deepagents_passthrough_rejects_unknown_option(tmp_path, make_payl
 
     with pytest.raises(adapter.AdapterConfigError, match="interupt_on"):
         await adapter.DeepAgentsRuntime().start(lifecycle_start_payload(payload))
+
+
+def test_deepagents_passthrough_rejects_fabric_owned_option():
+    with pytest.raises(adapter.AdapterConfigError, match="Fabric-owned keys.*model"):
+        adapter._validated_deepagents_settings({"model": "untrusted-model"})
 
 
 async def test_subagent_usage_folded_from_subgraph(tmp_path, make_payload, monkeypatch):

--- a/tests/adapters/test_deepagents.py
+++ b/tests/adapters/test_deepagents.py
@@ -441,6 +441,19 @@ def use_real_langgraph_fixture(fake_sdks, monkeypatch):
         monkeypatch.delitem(sys.modules, name, raising=False)
 
 
+@pytest.fixture(name="use_real_deepagents")
+def use_real_deepagents_fixture(fake_sdks, monkeypatch):
+    """Drop the fake Deep Agents stubs so the real backend package resolves."""
+
+    for name in (
+        "deepagents",
+        "deepagents.backends",
+        "deepagents.middleware",
+        "deepagents.middleware.subagents",
+    ):
+        monkeypatch.delitem(sys.modules, name, raising=False)
+
+
 async def test_single_invocation_normalizes_response_usage_and_thread(
     tmp_path, make_payload, fake_sdks
 ):
@@ -1493,6 +1506,39 @@ async def test_local_shell_backend_resolves_root_from_workspace(
         "inherit_env": False,
     }
     fake_sdks["fs_backend"].assert_not_called()
+
+
+@pytest.mark.usefixtures("use_real_deepagents")
+def test_local_shell_backend_keeps_file_and_shell_path_namespaces_distinct(
+    tmp_path, make_payload
+):
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    payload = make_payload(tmp_path)
+    payload["runtime_context"]["environment"]["workspace"] = "workspace"
+    context = RuntimeContext.from_mapping(payload["runtime_context"])
+
+    backend = adapter.resolve_backend(
+        context,
+        str(tmp_path),
+        {"type": "local_shell"},
+    )
+    filename = f"virtual-path-{uuid.uuid4().hex}.txt"
+    backend.write(f"/{filename}", "workspace content")
+
+    assert (workspace / filename).read_text(encoding="utf-8") == "workspace content"
+
+    relative = backend.execute(
+        f'"{sys.executable}" -c "from pathlib import Path; '
+        f"raise SystemExit(not Path('{filename}').is_file())\""
+    )
+    host_absolute = backend.execute(
+        f'"{sys.executable}" -c "from pathlib import Path; '
+        f"raise SystemExit(not Path('/{filename}').is_file())\""
+    )
+
+    assert relative.exit_code == 0
+    assert host_absolute.exit_code != 0
 
 
 async def test_local_shell_backend_requires_workspace(tmp_path, make_payload):

--- a/tests/python/test_harness_settings_validation.py
+++ b/tests/python/test_harness_settings_validation.py
@@ -85,6 +85,7 @@ _config = partial(
             "nvidia.fabric.langchain.deepagents",
             {
                 "deepagents": {
+                    "backend": {"type": "local_shell"},
                     "interrupt_on": {
                         "write_file": True,
                         "delete_file": {
@@ -365,6 +366,18 @@ def test_remote_agent_rejects_nonpositive_timeout(tmp_path: Path, setting: str):
             {"deepagents": {"subagents": [{"name": "researcher"}]}},
             "harness.settings.deepagents.subagents.0",
             id="deepagents-subagent-required-fields",
+        ),
+        pytest.param(
+            "nvidia.fabric.langchain.deepagents",
+            {"deepagents": {"backend": {"type": "sandbox"}}},
+            "harness.settings.deepagents.backend.type",
+            id="deepagents-backend-type",
+        ),
+        pytest.param(
+            "nvidia.fabric.langchain.deepagents",
+            {"deepagents": {"backend": {"type": "local_shell", "root_dir": "/tmp"}}},
+            "harness.settings.deepagents.backend.root_dir",
+            id="deepagents-backend-unknown-field",
         ),
         pytest.param(
             "nvidia.fabric.hermes",


### PR DESCRIPTION
#### Overview

Adds an explicit, declarative opt-in for LangChain Deep Agents' `LocalShellBackend` while preserving the existing filesystem and default backend behavior. This option is intended only for trusted, supervised development or demo environments because commands run directly on the adapter host without process isolation.

#### Details

- Adds a closed `harness.settings.deepagents.backend` schema that supports only `{"type": "local_shell"}`.
- Constructs an adapter-owned local shell backend rooted at the required workspace with host environment inheritance explicitly disabled.
- Requires an explicit Fabric tool policy for local shell execution and applies that gate to the main agent and declarative subagents.
- Rejects `interrupt_on.execute` for local shell because the adapter lifecycle cannot surface and resume LangGraph approval interrupts.
- Rejects unsupported backend types and fields with actionable validation errors.
- Synchronizes the CLI-packaged Deep Agents descriptor with the canonical adapter descriptor.
- Documents the host-execution security boundary, the distinct file-tool and shell absolute-path namespaces, and a supervised configuration example.
- Adds adapter and planning tests covering defaults, backend selection and rooting, path semantics, invalid configuration, and tool-policy enforcement.
- Breaking changes: none.

#### Validation

- `uv run --no-project --with pytest --with pytest-asyncio --with-editable 'adapters/python/deepagents[harness]' --with-editable adapters/python/common --with-editable adapter-contract/python pytest tests/adapters/test_deepagents.py -q` — 96 passed.
- `just --set no_uv true test-python` — passed on the current commit after synchronizing the full test environment.
- GitHub Python test matrix (Python 3.11–3.14 across Linux, macOS, and Windows) — passed on `5bdce6f3`.
- `just test-rust` — passed.
- `just schemas` — passed with no generated diff.
- `just docs` — passed; Fern skipped its authenticated redirect check because no token was available.
- `uv run ruff check adapters/python/deepagents/src/nemo_fabric_adapters/deepagents/adapter.py tests/adapters/test_deepagents.py tests/python/test_harness_settings_validation.py` — passed.
- `uv run --no-project --with pre-commit pre-commit run --files adapters/python/deepagents/src/nemo_fabric_adapters/deepagents/adapter.py tests/adapters/test_deepagents.py adapters/python/deepagents/README.md docs/integrations/harness/deepagents.mdx` — passed.
- `git diff --check upstream/main...HEAD` — passed.

The path-semantics regression test invokes the real `LocalShellBackend` only with deterministic file-existence checks. It does not execute model-generated commands.

#### Where should the reviewer start?

Start with `adapters/python/deepagents/src/nemo_fabric_adapters/deepagents/adapter.py` for the descriptor schema and backend-resolution boundary, then review `tests/adapters/test_deepagents.py` for behavior and policy coverage.

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- Relates to: none

- [x] I confirm this contribution is my own work, or I have the right to submit it under this project's license.
- [x] I searched existing issues and open pull requests, and this does not duplicate existing work.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optional Deep Agents `local_shell` backend configuration for supervised command execution in a selected workspace.
  * Added validation for backend types, fields, workspace requirements, and tool policies.
  * Preserved existing behavior when no backend is configured.

* **Documentation**
  * Added setup guidance and safety considerations, including host execution, environment inheritance, path differences, and approval limitations.

* **Tests**
  * Expanded coverage for backend selection, configuration validation, workspace handling, and execution policies.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
