### PR TITLE
feat: normalize model sampling settings

### DIFF
--- a/adapter-contract/python/src/nemo_fabric_adapter_contract/models.py
+++ b/adapter-contract/python/src/nemo_fabric_adapter_contract/models.py
@@ -175,6 +175,7 @@ class AgentModelConfig(AgentContractBlock):
                 "must be greater than zero",
                 path=("max_tokens",),
             )
+        _bounded_int(self.max_tokens, "max_tokens", (1 << 64) - 1)
         if self.base_url is not None:
             _nonblank(self.base_url, "base_url")
 

--- a/adapter-contract/python/src/nemo_fabric_adapter_contract/models.py
+++ b/adapter-contract/python/src/nemo_fabric_adapter_contract/models.py
@@ -147,6 +147,8 @@ class AgentModelConfig(AgentContractBlock):
     model: str
     api_key_env: str | None = _optional()
     temperature: float | None = _optional()
+    top_p: float | None = _optional()
+    max_tokens: int | None = _optional()
     base_url: str | None = _optional()
     settings: dict[str, JsonValue] = _json_dict()
 
@@ -163,6 +165,16 @@ class AgentModelConfig(AgentContractBlock):
         _nonblank(self.model, "model")
         if self.api_key_env is not None:
             _nonblank(self.api_key_env, "api_key_env")
+        if self.top_p is not None and not 0 <= self.top_p <= 1:
+            raise ContractValidationError(
+                "must be between zero and one",
+                path=("top_p",),
+            )
+        if self.max_tokens is not None and self.max_tokens < 1:
+            raise ContractValidationError(
+                "must be greater than zero",
+                path=("max_tokens",),
+            )
         if self.base_url is not None:
             _nonblank(self.base_url, "base_url")
 

--- a/adapter-contract/typescript/schemas/adapter-descriptor.schema.json
+++ b/adapter-contract/typescript/schemas/adapter-descriptor.schema.json
@@ -19,6 +19,16 @@
           "type": "string"
         },
         {
+          "const": "models.top_p",
+          "description": "Model nucleus sampling probability.",
+          "type": "string"
+        },
+        {
+          "const": "models.max_tokens",
+          "description": "Maximum model response tokens.",
+          "type": "string"
+        },
+        {
           "const": "instructions.system",
           "description": "Portable system instructions.",
           "type": "string"

--- a/adapter-contract/typescript/schemas/agent-config.schema.json
+++ b/adapter-contract/typescript/schemas/agent-config.schema.json
@@ -185,6 +185,15 @@
           "description": "Adapter-owned model fields.",
           "type": "object"
         },
+        "max_tokens": {
+          "description": "Optional maximum number of response tokens.",
+          "format": "uint64",
+          "minimum": 1,
+          "type": [
+            "integer",
+            "null"
+          ]
+        },
         "model": {
           "description": "Provider model identifier.",
           "minLength": 1,
@@ -205,6 +214,16 @@
         "temperature": {
           "description": "Optional model temperature.",
           "format": "double",
+          "type": [
+            "number",
+            "null"
+          ]
+        },
+        "top_p": {
+          "description": "Optional nucleus sampling probability.",
+          "format": "double",
+          "maximum": 1.0,
+          "minimum": 0.0,
           "type": [
             "number",
             "null"

--- a/adapter-contract/typescript/schemas/agent-config.schema.json
+++ b/adapter-contract/typescript/schemas/agent-config.schema.json
@@ -188,6 +188,7 @@
         "max_tokens": {
           "description": "Optional maximum number of response tokens.",
           "format": "uint64",
+          "maximum": 18446744073709551615,
           "minimum": 1,
           "type": [
             "integer",

--- a/adapter-contract/typescript/src/generated/adapter-descriptor.ts
+++ b/adapter-contract/typescript/src/generated/adapter-descriptor.ts
@@ -39,6 +39,8 @@ export type AdapterConfigField =
   | "models"
   | "models.base_url"
   | "models.temperature"
+  | "models.top_p"
+  | "models.max_tokens"
   | "instructions.system"
   | "runtime.max_turns"
   | "tools.enabled"

--- a/adapter-contract/typescript/src/generated/agent-config.ts
+++ b/adapter-contract/typescript/src/generated/agent-config.ts
@@ -240,6 +240,10 @@ export interface AgentModelConfig {
    */
   extensions?: JsonObject;
   /**
+   * Optional maximum number of response tokens.
+   */
+  max_tokens?: number | null;
+  /**
    * Provider model identifier.
    */
   model: string;
@@ -255,6 +259,10 @@ export interface AgentModelConfig {
    * Optional model temperature.
    */
   temperature?: number | null;
+  /**
+   * Optional nucleus sampling probability.
+   */
+  top_p?: number | null;
 }
 /**
  * Runtime behavior applied by an adapter target.

--- a/adapters/README.md
+++ b/adapters/README.md
@@ -145,7 +145,7 @@ and additive extension maps because their support does not vary by adapter:
 | `telemetry.providers.<provider>.config` | Declared-provider pass-through | Declared-provider pass-through | Declared-provider pass-through | Declared-provider pass-through | Declared-provider pass-through | Declared-provider pass-through | No | No |
 | `relay.project`, `.output_dir`, `.observability` | Yes | Yes | Yes | Yes | Yes | Yes | No | Uses the named external collector sink when selected; config is not sent to the remote service |
 | `relay.components`, `.policy` | Yes | Yes | Yes | Yes | Yes | Yes | No | Not sent to the remote service |
-| Additive `extensions` on typed config objects | Preserved; no portable adapter semantics | Preserved; no portable adapter semantics | Preserved; no portable adapter semantics | Preserved; no portable adapter semantics | Preserved; no portable adapter semantics | Preserved; no portable adapter semantics | Not accepted unless declared by the Pi descriptor | Preserved; no portable adapter semantics |
+| Other additive `extensions` on typed config objects | Rejected unless declared by the descriptor | Rejected unless declared by the descriptor | Rejected unless declared by the descriptor | Rejected unless declared by the descriptor | Rejected unless declared by the descriptor | Rejected unless declared by the descriptor | Rejected unless declared by the descriptor | Rejected unless declared by the descriptor |
 
 The selected model role is `default`, or the sole configured role when no
 `default` exists. More than one role without `default` fails planning.

--- a/adapters/README.md
+++ b/adapters/README.md
@@ -157,7 +157,10 @@ and `api_key_env`. Deep Agents keeps dynamic LangChain provider selection. Each
 published schema rejects undeclared `ModelConfig.settings` during planning and
 reports each issue through `doctor(...)` before adapter startup. Existing
 configurations that supplied `top_p` and `max_tokens` as flattened model
-extensions retain the same wire shape when loaded as normalized fields.
+extensions retain the same wire shape when loaded as normalized fields. Legacy
+adapter descriptors that accept either name through `extension_schemas.model`
+continue receiving it in `AgentModelConfig.extensions`; adapters that advertise
+the normalized capability receive the typed field instead.
 `runtime.max_turns` is optional; omitting it preserves adapter-native defaults
 without creating a compatibility requirement.
 

--- a/adapters/README.md
+++ b/adapters/README.md
@@ -127,6 +127,7 @@ and additive extension maps because their support does not vary by adapter:
 | `models.<role>.base_url` | Yes | Yes | Yes | Yes | Yes | Yes | Yes; known catalog models only | No; use `harness.settings.base_url` |
 | `models.<role>.temperature` | No | No | Yes | Yes | Yes | Yes | No | Yes |
 | `models.<role>.settings.<key>` | No keys declared | No keys declared | No keys declared | No keys declared | No keys declared | `client_type` | No keys declared | `max_tokens` for Anthropic Messages |
+| `models.<role>.top_p`, `.max_tokens` | No | No | Yes | Yes | Yes; passed through LiteLLM | No | No | Yes; translated to the selected API protocol |
 | `instructions.system` | `replace`, `append` | `replace`; base instructions | `replace` | `replace` | `replace` | `replace` | `replace`; Pi base instructions | `replace` |
 | `runtime.input_schema`, `.output_schema` | Core | Core | Core | Core | Core | Core | Core | Core |
 | `runtime.artifacts`, `.timeout_seconds` | Core | Core | Core | Core | Core | Core | Core | Core |

--- a/adapters/README.md
+++ b/adapters/README.md
@@ -149,12 +149,15 @@ and additive extension maps because their support does not vary by adapter:
 
 The selected model role is `default`, or the sole configured role when no
 `default` exists. More than one role without `default` fails planning.
-Claude and Codex publish a descriptor-owned `model_schema` for every configured
-model role. Their native providers (`anthropic` and `openai`, respectively)
-keep the existing authentication path. Other providers remain valid only with
-an explicit `base_url` and `api_key_env`. The same schema rejects undeclared
-`ModelConfig.settings` during planning and reports each issue through
-`doctor(...)` before adapter startup.
+All bundled adapters except Hermes publish a descriptor-owned `model_schema`
+for every configured model role. The Claude and Codex native providers
+(`anthropic` and `openai`, respectively) keep the existing authentication path.
+Other Claude and Codex providers remain valid only with an explicit `base_url`
+and `api_key_env`. Deep Agents keeps dynamic LangChain provider selection. Each
+published schema rejects undeclared `ModelConfig.settings` during planning and
+reports each issue through `doctor(...)` before adapter startup. Existing
+configurations that supplied `top_p` and `max_tokens` as flattened model
+extensions retain the same wire shape when loaded as normalized fields.
 `runtime.max_turns` is optional; omitting it preserves adapter-native defaults
 without creating a compatibility requirement.
 

--- a/adapters/python/deepagents/README.md
+++ b/adapters/python/deepagents/README.md
@@ -43,6 +43,29 @@ and defaults to `OPENAI_API_KEY` only for the native `openai` provider. Every
 other provider must set `api_key_env` explicitly (a missing one is a normalized
 configuration failure), so a key is never sent to the wrong endpoint.
 
+Set `models.<role>.top_p` from `0` through `1` and a positive
+`models.<role>.max_tokens` to control nucleus sampling and the response token
+limit for that model role. These are normalized model fields, not entries in
+`models.<role>.settings`:
+
+```python
+from nemo_fabric import ModelConfig
+
+model = ModelConfig(
+    provider="nvidia",
+    model="nvidia/nemotron-3-nano-omni-30b-a3b-reasoning",
+    api_key_env="NVIDIA_API_KEY",
+    base_url="https://integrate.api.nvidia.com/v1",
+    top_p=0.8,
+    max_tokens=512,
+)
+```
+
+The adapter passes `top_p` and `max_tokens` to LangChain only when configured,
+so omitted fields preserve the model provider's defaults. Planning rejects
+unknown top-level model fields and every key under
+`models.<role>.settings`.
+
 Because `models.<role>.api_key_env` is provider-specific, the adapter declares no
 static env requirement; a runtime **preflight** verifies that the `deepagents`
 package is importable and the configured credential is set. A failed preflight
@@ -51,7 +74,7 @@ fails runtime start with a stable lifecycle error.
 NeMo Fabric maps the following into the harness:
 
 - The selected `models` role supplies `model`, `provider`, `api_key_env`,
-  `base_url`, and `temperature`.
+  `base_url`, `temperature`, `top_p`, and `max_tokens`.
 - `instructions.system` supports `replace` and becomes the Deep Agents
   `system_prompt`. Deep Agents rejects `append`.
 - `runtime.timeout_seconds` sets the NeMo Fabric invocation deadline.

--- a/adapters/python/deepagents/deepagents.fabric-adapter.json
+++ b/adapters/python/deepagents/deepagents.fabric-adapter.json
@@ -5,6 +5,26 @@
   "runner": {
     "module": "nemo_fabric_adapters.deepagents.adapter"
   },
+  "model_schema": {
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "type": "object",
+    "properties": {
+      "provider": {"type": "string", "minLength": 1},
+      "model": {"type": "string", "minLength": 1},
+      "temperature": {"type": "number"},
+      "top_p": {"type": "number", "minimum": 0, "maximum": 1},
+      "max_tokens": {"type": "integer", "minimum": 1},
+      "api_key_env": {"type": "string", "minLength": 1},
+      "base_url": {"type": "string", "minLength": 1},
+      "settings": {
+        "type": "object",
+        "properties": {},
+        "additionalProperties": false
+      }
+    },
+    "required": ["provider", "model"],
+    "additionalProperties": false
+  },
   "settings_schema": {
     "$schema": "https://json-schema.org/draft/2020-12/schema",
     "$defs": {
@@ -167,6 +187,8 @@
       "models",
       "models.base_url",
       "models.temperature",
+      "models.top_p",
+      "models.max_tokens",
       "instructions.system",
       "runtime.max_turns",
       "tools.enabled",

--- a/adapters/python/deepagents/src/nemo_fabric_adapters/deepagents/adapter.py
+++ b/adapters/python/deepagents/src/nemo_fabric_adapters/deepagents/adapter.py
@@ -190,6 +190,8 @@ def build_chat_model(model_config: AgentModelConfig) -> tuple[Any, str, str | No
     provider = model_config.provider
     base_url = model_config.base_url
     temperature = model_config.temperature
+    top_p = model_config.top_p
+    max_tokens = model_config.max_tokens
 
     if provider in OPENAI_COMPATIBLE_PROVIDERS - {"openai"} and not base_url:
         raise AdapterConfigError(
@@ -203,6 +205,10 @@ def build_chat_model(model_config: AgentModelConfig) -> tuple[Any, str, str | No
         kwargs = {"model": model_name, "model_provider": provider, "api_key": api_key}
         if temperature is not None:
             kwargs["temperature"] = temperature
+        if top_p is not None:
+            kwargs["top_p"] = top_p
+        if max_tokens is not None:
+            kwargs["max_tokens"] = max_tokens
         if base_url:
             kwargs["base_url"] = base_url
         return (
@@ -218,6 +224,10 @@ def build_chat_model(model_config: AgentModelConfig) -> tuple[Any, str, str | No
         kwargs["base_url"] = base_url
     if temperature is not None:
         kwargs["temperature"] = temperature
+    if top_p is not None:
+        kwargs["top_p"] = top_p
+    if max_tokens is not None:
+        kwargs["max_completion_tokens"] = max_tokens
     return ChatOpenAI(**_supported_kwargs(ChatOpenAI, kwargs)), model_name, base_url
 
 

--- a/adapters/python/hermes/README.md
+++ b/adapters/python/hermes/README.md
@@ -61,7 +61,7 @@ surface Hermes exposes.
 
 During run-plan resolution, NeMo Fabric Core validates the
 `models.<role>.top_p` (from 0 through 1) and positive
-`models.<role>.max_tokens` extensions against the Hermes descriptor before
+`models.<role>.max_tokens` fields against the Hermes descriptor before
 runtime startup. Hermes reads these prevalidated values from `AgentConfig`. A
 model-level `max_tokens` overrides the harness-level default for the selected
 model role.

--- a/adapters/python/hermes/hermes.fabric-adapter.json
+++ b/adapters/python/hermes/hermes.fabric-adapter.json
@@ -61,24 +61,6 @@
     "additionalProperties": false
   },
   "extension_schemas": {
-    "model": {
-      "$schema": "https://json-schema.org/draft/2020-12/schema",
-      "type": "object",
-      "properties": {
-        "top_p": {
-          "type": "number",
-          "minimum": 0,
-          "maximum": 1,
-          "description": "Nucleus sampling probability passed to the model provider."
-        },
-        "max_tokens": {
-          "type": "integer",
-          "minimum": 1,
-          "description": "Maximum number of tokens for responses from this model role."
-        }
-      },
-      "additionalProperties": false
-    },
     "run_error": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "type": "object",
@@ -93,6 +75,8 @@
       "models",
       "models.base_url",
       "models.temperature",
+      "models.top_p",
+      "models.max_tokens",
       "instructions.system",
       "runtime.max_turns",
       "tools.enabled",

--- a/adapters/python/hermes/src/nemo_fabric_adapters/hermes/adapter.py
+++ b/adapters/python/hermes/src/nemo_fabric_adapters/hermes/adapter.py
@@ -173,7 +173,7 @@ class HermesRuntime:
                 if max_iterations is None:
                     max_iterations = DEFAULT_MAX_ITERATIONS
                 temperature = model_config.temperature
-                top_p = model_config.extensions.get("top_p")
+                top_p = model_config.top_p
                 request_overrides = {
                     name: value
                     for name, value in (
@@ -199,10 +199,8 @@ class HermesRuntime:
                         save_trajectories=bool(
                             self._settings.get("save_trajectories", False)
                         ),
-                        max_tokens=model_config.extensions.get(
-                            "max_tokens",
-                            self._settings.get("max_tokens", 512),
-                        ),
+                        max_tokens=model_config.max_tokens
+                        or self._settings.get("max_tokens", 512),
                         request_overrides=request_overrides or None,
                         reasoning_config=self._settings.get(
                             "reasoning_config", {"effort": "none"}

--- a/adapters/python/mini-swe-agent/README.md
+++ b/adapters/python/mini-swe-agent/README.md
@@ -28,8 +28,10 @@ The `harness` and `full` extras install the latest compatible mini-SWE-agent
 ## Configuration
 
 The adapter supports `models`, `models.base_url`, `models.temperature`,
-replacement `instructions.system`, `runtime.max_turns`, and
-`environment.workspace`. It rejects `append` system instructions.
+`models.top_p`, `models.max_tokens`, replacement `instructions.system`,
+`runtime.max_turns`, and `environment.workspace`. It passes the normalized
+sampling fields through mini-SWE-agent's LiteLLM model arguments and rejects
+`append` system instructions.
 `runtime.timeout_seconds` sets the NVIDIA NeMo Fabric invocation deadline. Use
 `harness.settings.timeout` to set the maximum duration of one command; the
 default is `30` seconds.

--- a/adapters/python/mini-swe-agent/mini-swe-agent.fabric-adapter.json
+++ b/adapters/python/mini-swe-agent/mini-swe-agent.fabric-adapter.json
@@ -12,6 +12,8 @@
       "provider": {"type": "string", "minLength": 1},
       "model": {"type": "string", "minLength": 1},
       "temperature": {"type": "number"},
+      "top_p": {"type": "number", "minimum": 0, "maximum": 1},
+      "max_tokens": {"type": "integer", "minimum": 1},
       "api_key_env": {"type": "string", "minLength": 1},
       "base_url": {"type": "string", "minLength": 1},
       "settings": {
@@ -42,6 +44,8 @@
       "models",
       "models.base_url",
       "models.temperature",
+      "models.top_p",
+      "models.max_tokens",
       "instructions.system",
       "runtime.max_turns"
     ],

--- a/adapters/python/mini-swe-agent/src/nemo_fabric_adapters/mini_swe_agent/adapter.py
+++ b/adapters/python/mini-swe-agent/src/nemo_fabric_adapters/mini_swe_agent/adapter.py
@@ -96,6 +96,10 @@ class MiniSweAgentRuntime:
             model_kwargs["api_base"] = model.base_url
         if model.temperature is not None:
             model_kwargs["temperature"] = model.temperature
+        if model.top_p is not None:
+            model_kwargs["top_p"] = model.top_p
+        if model.max_tokens is not None:
+            model_kwargs["max_tokens"] = model.max_tokens
         self._model = LitellmModel(
             model_name=(
                 model.model if "/" in model.model else f"{model.provider}/{model.model}"

--- a/adapters/python/remote-agent/README.md
+++ b/adapters/python/remote-agent/README.md
@@ -32,11 +32,15 @@ includes `/v1`; `api_type` defaults to `openai-responses`.
 | `read_timeout_seconds` | Timeout between response bytes; defaults to `600` |
 | `relay_streaming` | Opt in to request-ID correlation with a Relay-instrumented remote service. Supported only by `openai-responses` and `openai-completions`; defaults to `false`. |
 
-The adapter accepts `models`, `models.temperature`, and replacement
-`instructions.system` values.
+The adapter accepts `models`, `models.temperature`, `models.top_p`,
+`models.max_tokens`, and replacement `instructions.system` values. It maps the
+token limit to `max_output_tokens` for OpenAI Responses,
+`max_completion_tokens` for OpenAI Chat Completions, and `max_tokens` for
+Anthropic Messages.
 Set `models.default.api_key_env` when the service requires a credential. For
-Anthropic Messages, optionally set `models.default.settings.max_tokens`; it
-otherwise uses `4096`.
+Anthropic Messages, the legacy `models.default.settings.max_tokens` key remains
+accepted; `models.default.max_tokens` takes precedence. The adapter otherwise
+uses `4096`.
 
 ## Relay-Backed Streaming
 

--- a/adapters/python/remote-agent/README.md
+++ b/adapters/python/remote-agent/README.md
@@ -332,7 +332,7 @@ invocations in one runtime.
 
 The remote agent is configured and started independently of Fabric, so Fabric
 cannot normalize or apply configuration that controls how the agent is
-constructed. The adapter only normalizes `models`, `models.temperature`, and
-replacement `instructions.system` settings. MCP, skills, tool policy, and
-subagents can be configured by the remote deployment, but the adapter does not
-expose them through `FabricConfig`.
+constructed. The adapter only normalizes `models`, `models.temperature`,
+`models.top_p`, `models.max_tokens`, and replacement `instructions.system`
+settings. MCP, skills, tool policy, and subagents can be configured by the
+remote deployment, but the adapter does not expose them through `FabricConfig`.

--- a/adapters/python/remote-agent/remote-agent.fabric-adapter.json
+++ b/adapters/python/remote-agent/remote-agent.fabric-adapter.json
@@ -55,6 +55,8 @@
       "model": {"type": "string", "minLength": 1},
       "api_key_env": {"type": "string", "minLength": 1},
       "temperature": {"type": "number"},
+      "top_p": {"type": "number", "minimum": 0, "maximum": 1},
+      "max_tokens": {"type": "integer", "minimum": 1},
       "settings": {
         "type": "object",
         "properties": {
@@ -71,6 +73,8 @@
     "accepts": [
       "models",
       "models.temperature",
+      "models.top_p",
+      "models.max_tokens",
       "instructions.system"
     ],
     "system_instruction_modes": ["replace"]

--- a/adapters/python/remote-agent/src/nemo_fabric_adapters/remote_agent/adapter.py
+++ b/adapters/python/remote-agent/src/nemo_fabric_adapters/remote_agent/adapter.py
@@ -292,6 +292,10 @@ class RemoteAgentRuntime:
             payload["instructions"] = config.instructions.system.content
         if model.temperature is not None:
             payload["temperature"] = model.temperature
+        if model.top_p is not None:
+            payload["top_p"] = model.top_p
+        if model.max_tokens is not None:
+            payload["max_output_tokens"] = model.max_tokens
         if metadata is not None:
             payload["metadata"] = metadata
         async with self._client.stream("POST", self._endpoint, json=payload) as response:
@@ -325,6 +329,10 @@ class RemoteAgentRuntime:
         payload: dict[str, Any] = {"model": model.model, "messages": messages}
         if model.temperature is not None:
             payload["temperature"] = model.temperature
+        if model.top_p is not None:
+            payload["top_p"] = model.top_p
+        if model.max_tokens is not None:
+            payload["max_completion_tokens"] = model.max_tokens
         if metadata is not None:
             payload["metadata"] = metadata
         response = await self._client.post(self._endpoint, json=payload)
@@ -349,15 +357,16 @@ class RemoteAgentRuntime:
         payload: dict[str, Any] = {
             "model": model.model,
             "messages": [*self._messages, {"role": "user", "content": user_text}],
-            "max_tokens": model.settings.get(
-                "max_tokens", DEFAULT_ANTHROPIC_MAX_TOKENS
-            ),
+            "max_tokens": model.max_tokens
+            or model.settings.get("max_tokens", DEFAULT_ANTHROPIC_MAX_TOKENS),
             "stream": True,
         }
         if config.instructions and config.instructions.system:
             payload["system"] = config.instructions.system.content
         if model.temperature is not None:
             payload["temperature"] = model.temperature
+        if model.top_p is not None:
+            payload["top_p"] = model.top_p
         if metadata is not None:
             payload["metadata"] = metadata
         text = ""

--- a/crates/fabric-cli/assets/adapters/deepagents/deepagents.fabric-adapter.json
+++ b/crates/fabric-cli/assets/adapters/deepagents/deepagents.fabric-adapter.json
@@ -5,6 +5,26 @@
   "runner": {
     "module": "nemo_fabric_adapters.deepagents.adapter"
   },
+  "model_schema": {
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "type": "object",
+    "properties": {
+      "provider": {"type": "string", "minLength": 1},
+      "model": {"type": "string", "minLength": 1},
+      "temperature": {"type": "number"},
+      "top_p": {"type": "number", "minimum": 0, "maximum": 1},
+      "max_tokens": {"type": "integer", "minimum": 1},
+      "api_key_env": {"type": "string", "minLength": 1},
+      "base_url": {"type": "string", "minLength": 1},
+      "settings": {
+        "type": "object",
+        "properties": {},
+        "additionalProperties": false
+      }
+    },
+    "required": ["provider", "model"],
+    "additionalProperties": false
+  },
   "settings_schema": {
     "$schema": "https://json-schema.org/draft/2020-12/schema",
     "$defs": {
@@ -167,6 +187,8 @@
       "models",
       "models.base_url",
       "models.temperature",
+      "models.top_p",
+      "models.max_tokens",
       "instructions.system",
       "runtime.max_turns",
       "tools.enabled",

--- a/crates/fabric-cli/assets/adapters/hermes/hermes.fabric-adapter.json
+++ b/crates/fabric-cli/assets/adapters/hermes/hermes.fabric-adapter.json
@@ -61,24 +61,6 @@
     "additionalProperties": false
   },
   "extension_schemas": {
-    "model": {
-      "$schema": "https://json-schema.org/draft/2020-12/schema",
-      "type": "object",
-      "properties": {
-        "top_p": {
-          "type": "number",
-          "minimum": 0,
-          "maximum": 1,
-          "description": "Nucleus sampling probability passed to the model provider."
-        },
-        "max_tokens": {
-          "type": "integer",
-          "minimum": 1,
-          "description": "Maximum number of tokens for responses from this model role."
-        }
-      },
-      "additionalProperties": false
-    },
     "run_error": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "type": "object",
@@ -93,6 +75,8 @@
       "models",
       "models.base_url",
       "models.temperature",
+      "models.top_p",
+      "models.max_tokens",
       "instructions.system",
       "runtime.max_turns",
       "tools.enabled",

--- a/crates/fabric-cli/src/presets.rs
+++ b/crates/fabric-cli/src/presets.rs
@@ -320,6 +320,8 @@ fn model(
         provider: provider.to_string(),
         model: name.to_string(),
         temperature: None,
+        top_p: None,
+        max_tokens: None,
         api_key_env: api_key_env.map(str::to_string),
         base_url: base_url.map(str::to_string),
         settings: Map::new(),

--- a/crates/fabric-cli/src/scaffold.rs
+++ b/crates/fabric-cli/src/scaffold.rs
@@ -222,13 +222,21 @@ fn python_models(model: Option<&ModelConfig>) -> String {
         .temperature
         .map(|value| value.to_string())
         .unwrap_or_else(|| "None".to_string());
+    let top_p = model
+        .top_p
+        .map(|value| value.to_string())
+        .unwrap_or_else(|| "None".to_string());
+    let max_tokens = model
+        .max_tokens
+        .map(|value| value.to_string())
+        .unwrap_or_else(|| "None".to_string());
     let base_url = model
         .base_url
         .as_deref()
         .map(python_string)
         .unwrap_or_else(|| "None".to_string());
     format!(
-        "{{\"default\": ModelConfig(provider={}, model={}, temperature={temperature}, api_key_env={}, base_url={base_url}, settings={})}}",
+        "{{\"default\": ModelConfig(provider={}, model={}, temperature={temperature}, top_p={top_p}, max_tokens={max_tokens}, api_key_env={}, base_url={base_url}, settings={})}}",
         python_string(&model.provider),
         python_string(&model.model),
         model
@@ -375,13 +383,21 @@ fn rust_models(model: Option<&ModelConfig>) -> String {
         .temperature
         .map(|value| format!("Some({value})"))
         .unwrap_or_else(|| "None".to_string());
+    let top_p = model
+        .top_p
+        .map(|value| format!("Some({value})"))
+        .unwrap_or_else(|| "None".to_string());
+    let max_tokens = model
+        .max_tokens
+        .map(|value| format!("Some({value})"))
+        .unwrap_or_else(|| "None".to_string());
     let base_url = model
         .base_url
         .as_deref()
         .map(|value| format!("Some({}.to_string())", rust_string(value)))
         .unwrap_or_else(|| "None".to_string());
     format!(
-        "BTreeMap::from_iter([(\"default\".to_string(), nemo_fabric_core::ModelConfig {{ provider: {}.to_string(), model: {}.to_string(), temperature: {temperature}, api_key_env: {api_key}, base_url: {base_url}, settings: {}, extensions: BTreeMap::new() }})])",
+        "BTreeMap::from_iter([(\"default\".to_string(), nemo_fabric_core::ModelConfig {{ provider: {}.to_string(), model: {}.to_string(), temperature: {temperature}, top_p: {top_p}, max_tokens: {max_tokens}, api_key_env: {api_key}, base_url: {base_url}, settings: {}, extensions: BTreeMap::new() }})])",
         rust_string(&model.provider),
         rust_string(&model.model),
         rust_settings(&model.settings),
@@ -507,23 +523,26 @@ mod tests {
     }
 
     #[test]
-    fn renderers_preserve_model_settings_and_temperature() {
+    fn renderers_preserve_normalized_model_settings() {
         let mut config = presets::find("hermes")
             .expect("hermes preset")
             .config()
             .expect("construct Hermes config");
-        config
-            .models
-            .get_mut("default")
-            .expect("default model")
-            .temperature = Some(0.2);
+        let model = config.models.get_mut("default").expect("default model");
+        model.temperature = Some(0.2);
+        model.top_p = Some(0.8);
+        model.max_tokens = Some(512);
 
         let python = render_python(&config);
         assert!(python.contains("temperature=0.2"));
+        assert!(python.contains("top_p=0.8"));
+        assert!(python.contains("max_tokens=512"));
         assert!(python.contains("base_url=\"https://integrate.api.nvidia.com/v1\""));
 
         let rust = render_rust(&config);
         assert!(rust.contains("temperature: Some(0.2)"));
+        assert!(rust.contains("top_p: Some(0.8)"));
+        assert!(rust.contains("max_tokens: Some(512)"));
         assert!(
             rust.contains("base_url: Some(\"https://integrate.api.nvidia.com/v1\".to_string())")
         );

--- a/crates/fabric-cli/src/scaffold.rs
+++ b/crates/fabric-cli/src/scaffold.rs
@@ -381,11 +381,11 @@ fn rust_models(model: Option<&ModelConfig>) -> String {
         .unwrap_or_else(|| "None".to_string());
     let temperature = model
         .temperature
-        .map(|value| format!("Some({value})"))
+        .map(|value| format!("Some({value:?})"))
         .unwrap_or_else(|| "None".to_string());
     let top_p = model
         .top_p
-        .map(|value| format!("Some({value})"))
+        .map(|value| format!("Some({value:?})"))
         .unwrap_or_else(|| "None".to_string());
     let max_tokens = model
         .max_tokens
@@ -529,19 +529,19 @@ mod tests {
             .config()
             .expect("construct Hermes config");
         let model = config.models.get_mut("default").expect("default model");
-        model.temperature = Some(0.2);
-        model.top_p = Some(0.8);
+        model.temperature = Some(1.0);
+        model.top_p = Some(1.0);
         model.max_tokens = Some(512);
 
         let python = render_python(&config);
-        assert!(python.contains("temperature=0.2"));
-        assert!(python.contains("top_p=0.8"));
+        assert!(python.contains("temperature=1"));
+        assert!(python.contains("top_p=1"));
         assert!(python.contains("max_tokens=512"));
         assert!(python.contains("base_url=\"https://integrate.api.nvidia.com/v1\""));
 
         let rust = render_rust(&config);
-        assert!(rust.contains("temperature: Some(0.2)"));
-        assert!(rust.contains("top_p: Some(0.8)"));
+        assert!(rust.contains("temperature: Some(1.0)"));
+        assert!(rust.contains("top_p: Some(1.0)"));
         assert!(rust.contains("max_tokens: Some(512)"));
         assert!(
             rust.contains("base_url: Some(\"https://integrate.api.nvidia.com/v1\".to_string())")

--- a/crates/fabric-core/src/agent_config.rs
+++ b/crates/fabric-core/src/agent_config.rs
@@ -12,7 +12,7 @@ use serde_json::Value;
 
 use crate::config::{
     AdapterConfigField, AdapterDescriptor, CapabilityPlan, FabricConfig, InstructionMode,
-    McpAuthenticationConfig, ResolvedAdapterTargetDescriptor,
+    McpAuthenticationConfig, ResolvedAdapterTargetDescriptor, legacy_model_sampling_extensions,
 };
 use crate::error::{FabricError, Result};
 
@@ -348,6 +348,11 @@ pub(crate) fn project_agent_config(
             .models
             .iter()
             .map(|(name, model)| {
+                let legacy_extensions = descriptor
+                    .map(|descriptor| legacy_model_sampling_extensions(model, descriptor))
+                    .unwrap_or_default();
+                let mut extensions = model.extensions.clone();
+                extensions.extend(legacy_extensions.clone());
                 (
                     name.clone(),
                     AgentModelConfig {
@@ -355,11 +360,15 @@ pub(crate) fn project_agent_config(
                         model: model.model.clone(),
                         api_key_env: model.api_key_env.clone(),
                         temperature: model.temperature,
-                        top_p: model.top_p,
-                        max_tokens: model.max_tokens,
+                        top_p: (!legacy_extensions.contains_key("top_p"))
+                            .then_some(model.top_p)
+                            .flatten(),
+                        max_tokens: (!legacy_extensions.contains_key("max_tokens"))
+                            .then_some(model.max_tokens)
+                            .flatten(),
                         base_url: model.base_url.clone(),
                         settings: model.settings.clone(),
-                        extensions: model.extensions.clone(),
+                        extensions,
                     },
                 )
             })

--- a/crates/fabric-core/src/agent_config.rs
+++ b/crates/fabric-core/src/agent_config.rs
@@ -77,6 +77,14 @@ pub struct AgentModelConfig {
     /// Optional model temperature.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub temperature: Option<f64>,
+    /// Optional nucleus sampling probability.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    #[schemars(range(min = 0.0, max = 1.0))]
+    pub top_p: Option<f64>,
+    /// Optional maximum number of response tokens.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    #[schemars(range(min = 1))]
+    pub max_tokens: Option<u64>,
     /// Optional provider API base URL.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub base_url: Option<String>,
@@ -347,6 +355,8 @@ pub(crate) fn project_agent_config(
                         model: model.model.clone(),
                         api_key_env: model.api_key_env.clone(),
                         temperature: model.temperature,
+                        top_p: model.top_p,
+                        max_tokens: model.max_tokens,
                         base_url: model.base_url.clone(),
                         settings: model.settings.clone(),
                         extensions: model.extensions.clone(),

--- a/crates/fabric-core/src/agent_config.rs
+++ b/crates/fabric-core/src/agent_config.rs
@@ -83,7 +83,7 @@ pub struct AgentModelConfig {
     pub top_p: Option<f64>,
     /// Optional maximum number of response tokens.
     #[serde(default, skip_serializing_if = "Option::is_none")]
-    #[schemars(range(min = 1))]
+    #[schemars(range(min = 1, max = u64::MAX))]
     pub max_tokens: Option<u64>,
     /// Optional provider API base URL.
     #[serde(default, skip_serializing_if = "Option::is_none")]

--- a/crates/fabric-core/src/config.rs
+++ b/crates/fabric-core/src/config.rs
@@ -976,7 +976,11 @@ pub struct ModelConfig {
     #[schemars(range(min = 0.0, max = 1.0))]
     pub top_p: Option<f64>,
     /// Optional maximum number of response tokens.
-    #[serde(default, skip_serializing_if = "Option::is_none")]
+    #[serde(
+        default,
+        deserialize_with = "deserialize_optional_max_tokens",
+        skip_serializing_if = "Option::is_none"
+    )]
     #[schemars(range(min = 1, max = u64::MAX))]
     pub max_tokens: Option<u64>,
     /// Optional environment variable containing an API key.
@@ -991,6 +995,46 @@ pub struct ModelConfig {
     /// Additive normalized model fields.
     #[serde(default, flatten)]
     pub extensions: BTreeMap<String, Value>,
+}
+
+fn deserialize_optional_max_tokens<'de, D>(
+    deserializer: D,
+) -> std::result::Result<Option<u64>, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    let Some(value) = Option::<Value>::deserialize(deserializer)? else {
+        return Ok(None);
+    };
+    let Value::Number(number) = value else {
+        return Err(D::Error::custom("max_tokens must be an integer"));
+    };
+
+    if let Some(value) = number.as_u64() {
+        return Ok(Some(value));
+    }
+    if number.as_i64().is_some_and(|value| value < 0) {
+        // Keep invalid negative values representable until validation so callers
+        // receive the canonical `models.<role>.max_tokens` field path.
+        return Ok(Some(0));
+    }
+    if let Some(value) = number.as_f64()
+        && value.is_finite()
+        && value.fract() == 0.0
+    {
+        if value < 0.0 {
+            return Ok(Some(0));
+        }
+        // u64::MAX rounds to 2^64 as f64, so the strict comparison also rejects
+        // floating-point values outside the u64 domain.
+        if value < u64::MAX as f64 {
+            return Ok(Some(value as u64));
+        }
+    }
+
+    Err(D::Error::custom(
+        "max_tokens must be an integer between 0 and 18446744073709551615",
+    ))
 }
 
 /// Invocation runtime contract.
@@ -4799,7 +4843,7 @@ mod tests {
             "provider": "nvidia",
             "model": "test-model",
             "top_p": 0.8,
-            "max_tokens": 512
+            "max_tokens": 512.0
         }))
         .expect("existing flattened sampling config");
 
@@ -4812,6 +4856,23 @@ mod tests {
         assert_eq!(encoded["top_p"], serde_json::json!(0.8));
         assert_eq!(encoded["max_tokens"], serde_json::json!(512));
         assert!(encoded.get("extensions").is_none());
+    }
+
+    #[test]
+    fn negative_wire_max_tokens_reports_the_canonical_field() {
+        let mut value = serde_json::to_value(config_with_model("nvidia.fabric.hermes", "nvidia"))
+            .expect("serialize config");
+        value["models"]["default"]["max_tokens"] = serde_json::json!(-5);
+
+        let config: FabricConfig =
+            serde_json::from_value(value).expect("preserve invalid value for validation");
+        let error = resolve_run_plan_from_config(config, ResolveContext::new(repository_root()))
+            .expect_err("negative max_tokens");
+
+        assert!(matches!(
+            error,
+            FabricError::InvalidConfig { field, .. } if field == "models.default.max_tokens"
+        ));
     }
 
     #[test]

--- a/crates/fabric-core/src/config.rs
+++ b/crates/fabric-core/src/config.rs
@@ -855,6 +855,12 @@ pub enum AdapterConfigField {
     /// Model temperature.
     #[serde(rename = "models.temperature")]
     ModelTemperature,
+    /// Model nucleus sampling probability.
+    #[serde(rename = "models.top_p")]
+    ModelTopP,
+    /// Maximum model response tokens.
+    #[serde(rename = "models.max_tokens")]
+    ModelMaxTokens,
     /// Portable system instructions.
     #[serde(rename = "instructions.system")]
     SystemInstructions,
@@ -965,6 +971,14 @@ pub struct ModelConfig {
     /// Optional temperature.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub temperature: Option<f64>,
+    /// Optional nucleus sampling probability.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    #[schemars(range(min = 0.0, max = 1.0))]
+    pub top_p: Option<f64>,
+    /// Optional maximum number of response tokens.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    #[schemars(range(min = 1))]
+    pub max_tokens: Option<u64>,
     /// Optional environment variable containing an API key.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub api_key_env: Option<String>,
@@ -1880,6 +1894,20 @@ pub(crate) fn validate_config(config: &FabricConfig) -> Result<()> {
                 "must be a non-empty string",
             );
         }
+        if let Some(top_p) = model.top_p
+            && (!top_p.is_finite() || !(0.0..=1.0).contains(&top_p))
+        {
+            return invalid_config(
+                format!("models.{role}.top_p"),
+                "must be a finite number between zero and one",
+            );
+        }
+        if model.max_tokens == Some(0) {
+            return invalid_config(
+                format!("models.{role}.max_tokens"),
+                "must be greater than zero",
+            );
+        }
     }
     if let Some(environment) = &config.environment {
         for name in environment.env.keys() {
@@ -2542,6 +2570,18 @@ pub(crate) fn adapter_config_compatibility_issues(
         if model.temperature.is_some() && !accepts(AdapterConfigField::ModelTemperature) {
             issues.push(incompatible(
                 format!("models.{role}.temperature"),
+                "the adapter does not declare an equivalent native mapping".to_string(),
+            ));
+        }
+        if model.top_p.is_some() && !accepts(AdapterConfigField::ModelTopP) {
+            issues.push(incompatible(
+                format!("models.{role}.top_p"),
+                "the adapter does not declare an equivalent native mapping".to_string(),
+            ));
+        }
+        if model.max_tokens.is_some() && !accepts(AdapterConfigField::ModelMaxTokens) {
+            issues.push(incompatible(
+                format!("models.{role}.max_tokens"),
                 "the adapter does not declare an equivalent native mapping".to_string(),
             ));
         }
@@ -3986,6 +4026,8 @@ mod tests {
                 provider: provider.to_string(),
                 model: "test-model".to_string(),
                 temperature: None,
+                top_p: None,
+                max_tokens: None,
                 api_key_env: None,
                 base_url: None,
                 settings: serde_json::Map::new(),
@@ -4700,57 +4742,76 @@ mod tests {
     }
 
     #[test]
-    fn hermes_model_extensions_are_validated_and_projected() {
+    fn hermes_normalized_model_sampling_is_validated_and_projected() {
         let mut config = config_with_model("nvidia.fabric.hermes", "nvidia");
         let model = config.models.get_mut("default").expect("default model");
-        model
-            .extensions
-            .insert("top_p".to_string(), serde_json::json!(0.85));
-        model
-            .extensions
-            .insert("max_tokens".to_string(), serde_json::json!(768));
+        model.top_p = Some(0.85);
+        model.max_tokens = Some(768);
 
         let plan = resolve_run_plan_from_config(config, ResolveContext::new(repository_root()))
-            .expect("Hermes model extensions");
+            .expect("Hermes normalized model sampling");
         let model = plan
             .agent_config
             .models
             .get("default")
             .expect("projected default model");
 
-        assert_eq!(
-            model.extensions.get("top_p"),
-            Some(&serde_json::json!(0.85))
-        );
-        assert_eq!(
-            model.extensions.get("max_tokens"),
-            Some(&serde_json::json!(768))
-        );
+        assert_eq!(model.top_p, Some(0.85));
+        assert_eq!(model.max_tokens, Some(768));
     }
 
     #[test]
-    fn hermes_model_extensions_reject_invalid_sampling_values() {
+    fn normalized_model_sampling_rejects_invalid_values() {
         let mut config = config_with_model("nvidia.fabric.hermes", "nvidia");
         config
             .models
             .get_mut("default")
             .expect("default model")
-            .extensions
-            .insert("top_p".to_string(), serde_json::json!(1.1));
+            .top_p = Some(1.1);
 
         let error = resolve_run_plan_from_config(config, ResolveContext::new(repository_root()))
             .expect_err("top_p above one");
 
-        assert!(
-            matches!(
-                error,
-                FabricError::InvalidAdapterExtension {
-                    ref extension_path,
-                    ..
-                } if extension_path == "models.default.top_p"
-            ),
-            "{error:?}"
-        );
+        assert!(matches!(
+            error,
+            FabricError::InvalidConfig { field, .. } if field == "models.default.top_p"
+        ));
+
+        let mut config = config_with_model("nvidia.fabric.hermes", "nvidia");
+        config
+            .models
+            .get_mut("default")
+            .expect("default model")
+            .max_tokens = Some(0);
+
+        let error = resolve_run_plan_from_config(config, ResolveContext::new(repository_root()))
+            .expect_err("zero max_tokens");
+
+        assert!(matches!(
+            error,
+            FabricError::InvalidConfig { field, .. } if field == "models.default.max_tokens"
+        ));
+    }
+
+    #[test]
+    fn flattened_sampling_extensions_keep_their_wire_shape_when_normalized() {
+        let model: ModelConfig = serde_json::from_value(serde_json::json!({
+            "provider": "nvidia",
+            "model": "test-model",
+            "top_p": 0.8,
+            "max_tokens": 512
+        }))
+        .expect("existing flattened sampling config");
+
+        assert_eq!(model.top_p, Some(0.8));
+        assert_eq!(model.max_tokens, Some(512));
+        assert!(!model.extensions.contains_key("top_p"));
+        assert!(!model.extensions.contains_key("max_tokens"));
+
+        let encoded = serde_json::to_value(model).expect("normalized model JSON");
+        assert_eq!(encoded["top_p"], serde_json::json!(0.8));
+        assert_eq!(encoded["max_tokens"], serde_json::json!(512));
+        assert!(encoded.get("extensions").is_none());
     }
 
     #[test]
@@ -5029,6 +5090,8 @@ mod tests {
                 provider: "nvidia".to_string(),
                 model: "nvidia/test".to_string(),
                 temperature: Some(0.2),
+                top_p: Some(0.8),
+                max_tokens: Some(512),
                 api_key_env: Some("NVIDIA_API_KEY".to_string()),
                 base_url: Some("https://models.example/v1".to_string()),
                 settings: serde_json::Map::new(),
@@ -5244,6 +5307,8 @@ mod tests {
                     provider: provider.to_string(),
                     model: "default-model".to_string(),
                     temperature: None,
+                    top_p: None,
+                    max_tokens: None,
                     api_key_env: None,
                     base_url: None,
                     settings: serde_json::Map::new(),
@@ -5256,6 +5321,8 @@ mod tests {
                     provider: provider.to_string(),
                     model: "test-model".to_string(),
                     temperature: Some(0.2),
+                    top_p: None,
+                    max_tokens: None,
                     api_key_env: None,
                     base_url: None,
                     settings: serde_json::Map::new(),
@@ -5289,6 +5356,8 @@ mod tests {
                 provider: "anthropic".to_string(),
                 model: "default-model".to_string(),
                 temperature: None,
+                top_p: None,
+                max_tokens: None,
                 api_key_env: None,
                 base_url: None,
                 settings: serde_json::Map::new(),
@@ -5301,6 +5370,8 @@ mod tests {
                 provider: "anthropic".to_string(),
                 model: "review-model".to_string(),
                 temperature: None,
+                top_p: None,
+                max_tokens: None,
                 api_key_env: None,
                 base_url: Some("https://example.test/v1".to_string()),
                 settings: serde_json::Map::new(),
@@ -5364,6 +5435,8 @@ mod tests {
                     provider: "acme".to_string(),
                     model: "review-model".to_string(),
                     temperature: None,
+                    top_p: None,
+                    max_tokens: None,
                     api_key_env: None,
                     base_url: None,
                     settings: serde_json::Map::new(),
@@ -5413,6 +5486,96 @@ mod tests {
     }
 
     #[test]
+    fn supporting_adapters_project_normalized_model_sampling() {
+        for adapter_id in [
+            "nvidia.fabric.langchain.deepagents",
+            "nvidia.fabric.hermes",
+            "nvidia.fabric.mini-swe-agent",
+            "nvidia.fabric.remote-agent",
+        ] {
+            let mut config = config_with_model(adapter_id, "nvidia");
+            config.skills = None;
+            let model = config.models.get_mut("default").expect("default model");
+            model.top_p = Some(0.8);
+            model.max_tokens = Some(256);
+
+            if adapter_id == "nvidia.fabric.remote-agent" {
+                config.harness.as_mut().expect("harness").settings.insert(
+                    "base_url".to_string(),
+                    serde_json::json!("https://agent.example/v1"),
+                );
+            }
+
+            let plan = resolve_run_plan_from_config(
+                config,
+                ResolveContext::new("/tmp/fabric-model-sampling"),
+            )
+            .unwrap_or_else(|error| panic!("valid {adapter_id} model sampling: {error}"));
+            let model = plan
+                .agent_config
+                .models
+                .get("default")
+                .expect("projected default model");
+
+            assert_eq!(model.top_p, Some(0.8), "{adapter_id}");
+            assert_eq!(model.max_tokens, Some(256), "{adapter_id}");
+        }
+    }
+
+    #[test]
+    fn adapters_without_normalized_model_sampling_reject_it() {
+        let mut config = config_with_model("nvidia.fabric.claude", "anthropic");
+        let model = config.models.get_mut("default").expect("default model");
+        model.top_p = Some(0.8);
+        model.max_tokens = Some(256);
+
+        let issues = adapter_config_compatibility_issues(
+            &config,
+            Some(
+                &load_adapter_descriptor(
+                    repository_root().join("adapters/python/claude/claude.fabric-adapter.json"),
+                )
+                .expect("Claude descriptor"),
+            ),
+        )
+        .into_iter()
+        .map(|issue| issue.field)
+        .collect::<BTreeSet<_>>();
+
+        assert!(issues.contains("models.default.top_p"));
+        assert!(issues.contains("models.default.max_tokens"));
+    }
+
+    #[test]
+    fn deepagents_model_schema_accepts_omitted_options_and_rejects_settings() {
+        resolve_run_plan_from_config(
+            config_with_model("nvidia.fabric.langchain.deepagents", "nvidia"),
+            ResolveContext::new("/tmp/fabric-deepagents-omitted-model-options"),
+        )
+        .expect("omitted Deep Agents model options");
+
+        let mut config = config_with_model("nvidia.fabric.langchain.deepagents", "nvidia");
+        config
+            .models
+            .get_mut("default")
+            .expect("default model")
+            .settings
+            .insert("top_p".to_string(), serde_json::json!(0.8));
+
+        let error = resolve_run_plan_from_config(
+            config,
+            ResolveContext::new("/tmp/fabric-deepagents-model-settings"),
+        )
+        .expect_err("undeclared Deep Agents model setting");
+
+        assert!(matches!(
+            error,
+            FabricError::AdapterCompatibility { field, .. }
+                if field == "models.default.settings.top_p"
+        ));
+    }
+
+    #[test]
     fn unsupported_enabled_tools_report_canonical_field() {
         let adapter_id = "nvidia.fabric.codex";
         let mut config = typed_config(adapter_id);
@@ -5446,6 +5609,8 @@ mod tests {
                 provider: "anthropic".to_string(),
                 model: "claude-test".to_string(),
                 temperature: None,
+                top_p: None,
+                max_tokens: None,
                 api_key_env: None,
                 base_url: None,
                 settings: serde_json::Map::new(),
@@ -5467,6 +5632,8 @@ mod tests {
                     provider: "anthropic".to_string(),
                     model: format!("claude-{role}"),
                     temperature: None,
+                    top_p: None,
+                    max_tokens: None,
                     api_key_env: None,
                     base_url: None,
                     settings: serde_json::Map::new(),

--- a/crates/fabric-core/src/config.rs
+++ b/crates/fabric-core/src/config.rs
@@ -2503,6 +2503,65 @@ pub(crate) struct AdapterCompatibilityIssue {
     pub(crate) reason: String,
 }
 
+/// Return normalized sampling fields that a legacy adapter still accepts through
+/// its model extension schema.
+pub(crate) fn legacy_model_sampling_extensions(
+    model: &ModelConfig,
+    descriptor: &AdapterDescriptor,
+) -> BTreeMap<String, Value> {
+    let Some(schema) = descriptor
+        .extension_schemas
+        .get(&AdapterExtensionPoint::Model)
+    else {
+        return BTreeMap::new();
+    };
+    let mut candidates = BTreeMap::new();
+    if model.top_p.is_some()
+        && !descriptor
+            .config
+            .accepts
+            .contains(&AdapterConfigField::ModelTopP)
+    {
+        candidates.insert("top_p".to_string(), serde_json::json!(model.top_p));
+    }
+    if model.max_tokens.is_some()
+        && !descriptor
+            .config
+            .accepts
+            .contains(&AdapterConfigField::ModelMaxTokens)
+    {
+        candidates.insert(
+            "max_tokens".to_string(),
+            serde_json::json!(model.max_tokens),
+        );
+    }
+    if candidates.is_empty() {
+        return candidates;
+    }
+
+    let validator = jsonschema::validator_for(&Value::Object(schema.clone()))
+        .expect("adapter extension schema was validated during descriptor resolution");
+    let accepts = |legacy: &BTreeMap<String, Value>| {
+        let mut extensions = model.extensions.clone();
+        extensions.extend(legacy.clone());
+        validator.is_valid(
+            &serde_json::to_value(extensions)
+                .expect("typed model extensions are always JSON serializable"),
+        )
+    };
+
+    if accepts(&candidates) {
+        return candidates;
+    }
+    for (name, value) in &candidates {
+        let candidate = BTreeMap::from([(name.clone(), value.clone())]);
+        if accepts(&candidate) {
+            return candidate;
+        }
+    }
+    BTreeMap::new()
+}
+
 pub(crate) fn adapter_config_compatibility_issues(
     config: &FabricConfig,
     descriptor: Option<&AdapterDescriptor>,
@@ -2588,10 +2647,14 @@ pub(crate) fn adapter_config_compatibility_issues(
         let validator = jsonschema::validator_for(&schema)
             .expect("adapter model schema was validated during descriptor resolution");
         for (role, model) in &config.models {
+            let legacy_extensions = legacy_model_sampling_extensions(model, descriptor);
             let mut value = serde_json::to_value(model)
                 .expect("typed model configuration is always JSON serializable");
             if let Some(object) = value.as_object_mut() {
                 for extension in model.extensions.keys() {
+                    object.remove(extension);
+                }
+                for extension in legacy_extensions.keys() {
                     object.remove(extension);
                 }
             }
@@ -2605,6 +2668,7 @@ pub(crate) fn adapter_config_compatibility_issues(
     }
 
     for (role, model) in &config.models {
+        let legacy_extensions = legacy_model_sampling_extensions(model, descriptor);
         if model.base_url.is_some() && !accepts(AdapterConfigField::ModelBaseUrl) {
             issues.push(incompatible(
                 format!("models.{role}.base_url"),
@@ -2617,13 +2681,19 @@ pub(crate) fn adapter_config_compatibility_issues(
                 "the adapter does not declare an equivalent native mapping".to_string(),
             ));
         }
-        if model.top_p.is_some() && !accepts(AdapterConfigField::ModelTopP) {
+        if model.top_p.is_some()
+            && !accepts(AdapterConfigField::ModelTopP)
+            && !legacy_extensions.contains_key("top_p")
+        {
             issues.push(incompatible(
                 format!("models.{role}.top_p"),
                 "the adapter does not declare an equivalent native mapping".to_string(),
             ));
         }
-        if model.max_tokens.is_some() && !accepts(AdapterConfigField::ModelMaxTokens) {
+        if model.max_tokens.is_some()
+            && !accepts(AdapterConfigField::ModelMaxTokens)
+            && !legacy_extensions.contains_key("max_tokens")
+        {
             issues.push(incompatible(
                 format!("models.{role}.max_tokens"),
                 "the adapter does not declare an equivalent native mapping".to_string(),
@@ -3055,11 +3125,16 @@ pub(crate) fn validate_agent_config_extensions(
         )?;
     }
     for (name, model) in &config.models {
+        let mut extensions = model.extensions.clone();
+        extensions.extend(legacy_model_sampling_extensions(
+            model,
+            &resolved.descriptor,
+        ));
         validate_extension_block(
             resolved,
             AdapterExtensionPoint::Model,
             &format!("models.{name}"),
-            &model.extensions,
+            &extensions,
             &mut validators,
         )?;
     }
@@ -5580,7 +5655,89 @@ mod tests {
 
             assert_eq!(model.top_p, Some(0.8), "{adapter_id}");
             assert_eq!(model.max_tokens, Some(256), "{adapter_id}");
+            assert!(!model.extensions.contains_key("top_p"), "{adapter_id}");
+            assert!(!model.extensions.contains_key("max_tokens"), "{adapter_id}");
         }
+    }
+
+    #[test]
+    fn legacy_model_sampling_extensions_are_validated_and_projected() {
+        let path = repository_root().join("adapters/python/claude/claude.fabric-adapter.json");
+        let mut descriptor = load_adapter_descriptor(&path).expect("Claude descriptor");
+        descriptor.extension_schemas.insert(
+            AdapterExtensionPoint::Model,
+            serde_json::json!({
+                "type": "object",
+                "properties": {
+                    "top_p": {"type": "number", "minimum": 0, "maximum": 1},
+                    "max_tokens": {"type": "integer", "minimum": 1}
+                },
+                "required": ["top_p", "max_tokens"],
+                "additionalProperties": false
+            })
+            .as_object()
+            .expect("model extension schema")
+            .clone(),
+        );
+        let resolved = resolved_adapter(path, descriptor);
+        let mut config = config_with_model("nvidia.fabric.claude", "anthropic");
+        let model = config.models.get_mut("default").expect("default model");
+        model.top_p = Some(0.8);
+        model.max_tokens = Some(256);
+
+        assert!(
+            adapter_config_compatibility_issues(&config, Some(&resolved.descriptor)).is_empty()
+        );
+        validate_agent_config_extensions(&config, Some(&resolved), None)
+            .expect("legacy sampling extensions");
+        let capability_plan = resolve_capability_plan(
+            &config,
+            Path::new("/tmp/fabric-legacy-sampling"),
+            Some(&resolved),
+        );
+        let agent_config =
+            project_agent_config(&config, &capability_plan, Some(&resolved.descriptor), None);
+        let model = agent_config
+            .models
+            .get("default")
+            .expect("projected default model");
+
+        assert_eq!(model.top_p, None);
+        assert_eq!(model.max_tokens, None);
+        assert_eq!(model.extensions["top_p"], serde_json::json!(0.8));
+        assert_eq!(model.extensions["max_tokens"], serde_json::json!(256));
+    }
+
+    #[test]
+    fn unrelated_model_extension_schema_does_not_accept_normalized_sampling() {
+        let path = repository_root().join("adapters/python/claude/claude.fabric-adapter.json");
+        let mut descriptor = load_adapter_descriptor(&path).expect("Claude descriptor");
+        descriptor.extension_schemas.insert(
+            AdapterExtensionPoint::Model,
+            serde_json::json!({
+                "type": "object",
+                "properties": {"profile": {"type": "string"}},
+                "additionalProperties": false
+            })
+            .as_object()
+            .expect("model extension schema")
+            .clone(),
+        );
+        let mut config = config_with_model("nvidia.fabric.claude", "anthropic");
+        config
+            .models
+            .get_mut("default")
+            .expect("default model")
+            .top_p = Some(0.8);
+
+        let issues = adapter_config_compatibility_issues(&config, Some(&descriptor));
+
+        assert!(
+            !issues.is_empty()
+                && issues
+                    .iter()
+                    .all(|issue| issue.field == "models.default.top_p")
+        );
     }
 
     #[test]

--- a/crates/fabric-core/src/config.rs
+++ b/crates/fabric-core/src/config.rs
@@ -977,7 +977,7 @@ pub struct ModelConfig {
     pub top_p: Option<f64>,
     /// Optional maximum number of response tokens.
     #[serde(default, skip_serializing_if = "Option::is_none")]
-    #[schemars(range(min = 1))]
+    #[schemars(range(min = 1, max = u64::MAX))]
     pub max_tokens: Option<u64>,
     /// Optional environment variable containing an API key.
     #[serde(default, skip_serializing_if = "Option::is_none")]

--- a/crates/fabric-core/src/schema.rs
+++ b/crates/fabric-core/src/schema.rs
@@ -351,6 +351,10 @@ mod tests {
             u32::MAX
         );
         assert_eq!(
+            schema["$defs"]["ModelConfig"]["properties"]["max_tokens"]["maximum"],
+            u64::MAX
+        );
+        assert_eq!(
             schema["$defs"]["RuntimeConfig"]["properties"]["timeout_seconds"]["exclusiveMinimum"],
             0.0
         );
@@ -530,6 +534,10 @@ mod tests {
         assert_eq!(
             config["$defs"]["AgentRuntimeConfig"]["properties"]["max_turns"]["maximum"],
             u32::MAX
+        );
+        assert_eq!(
+            config["$defs"]["AgentModelConfig"]["properties"]["max_tokens"]["maximum"],
+            u64::MAX
         );
 
         let result = generate_schema(SchemaName::AgentRunResult).expect("schema generation");

--- a/docs/integrations/harness/deepagents.mdx
+++ b/docs/integrations/harness/deepagents.mdx
@@ -70,6 +70,27 @@ from nemo_fabric import HarnessConfig
 harness = HarnessConfig(adapter_id="nvidia.fabric.langchain.deepagents")
 ```
 
+Configure nucleus sampling and the response token limit with the normalized
+`models.<role>.top_p` and `models.<role>.max_tokens` fields. `top_p` must be
+from `0` through `1`, and `max_tokens` must be a positive integer:
+
+```python
+from nemo_fabric import ModelConfig
+
+model = ModelConfig(
+    provider="nvidia",
+    model="nvidia/nemotron-3-nano-omni-30b-a3b-reasoning",
+    api_key_env="NVIDIA_API_KEY",
+    base_url="https://integrate.api.nvidia.com/v1",
+    top_p=0.8,
+    max_tokens=512,
+)
+```
+
+The adapter passes these fields to LangChain only when configured, so omitted
+fields preserve the model provider's defaults. Planning rejects unknown
+top-level model fields and every key under `models.<role>.settings`.
+
 Use normalized `FabricConfig` fields to configure the model, workspace, skills,
 MCP servers, replacement system instructions, blocked tools, and telemetry.
 The adapter rejects `append` system instructions. Use

--- a/docs/integrations/harness/hermes.mdx
+++ b/docs/integrations/harness/hermes.mdx
@@ -62,7 +62,7 @@ selectors, and telemetry. The adapter rejects `append` system instructions.
 
 During run-plan resolution, NeMo Fabric Core validates the
 `models.<role>.top_p` (from 0 through 1) and positive
-`models.<role>.max_tokens` extensions against the Hermes descriptor before
+`models.<role>.max_tokens` fields against the Hermes descriptor before
 runtime startup. Hermes reads these prevalidated values from `AgentConfig`. A
 model-level `max_tokens` overrides the harness-level default for the selected
 model role.

--- a/docs/integrations/harness/remote-agent.mdx
+++ b/docs/integrations/harness/remote-agent.mdx
@@ -150,10 +150,10 @@ invocations within a runtime.
 
 The remote agent is configured and started independently of Fabric, so Fabric
 cannot normalize or apply configuration that controls how the agent is
-constructed. The adapter normalizes only `models`, `models.temperature`, and
-replacement `instructions.system` settings. MCP, skills, tool policy, and
-subagents can be configured by the remote deployment, but the adapter does not
-expose them through `FabricConfig`.
+constructed. The adapter normalizes only `models`, `models.temperature`,
+`models.top_p`, `models.max_tokens`, and replacement `instructions.system`
+settings. MCP, skills, tool policy, and subagents can be configured by the
+remote deployment, but the adapter does not expose them through `FabricConfig`.
 
 `capabilities.streaming` remains false because that descriptor flag represents
 adapter-native OpenAI Chat Completions chunks. The adapter still reduces native

--- a/docs/integrations/harness/remote-agent.mdx
+++ b/docs/integrations/harness/remote-agent.mdx
@@ -56,11 +56,16 @@ Supported `api_type` values are `openai-responses`, `openai-completions`, and
 `anthropic-messages`. Planning rejects unknown settings and values outside this
 set.
 
-The adapter supports `models`, `models.temperature`, and replacement
-`instructions.system` values. Set `models.default.api_key_env` when the service
+The adapter supports `models`, `models.temperature`, `models.top_p`,
+`models.max_tokens`, and replacement `instructions.system` values. It maps the
+token limit to `max_output_tokens` for OpenAI Responses,
+`max_completion_tokens` for OpenAI Chat Completions, and `max_tokens` for
+Anthropic Messages. Set `models.default.api_key_env` when the service
 requires a credential. The adapter sends it as a Bearer token for OpenAI APIs
-and as `x-api-key` for Anthropic Messages. For Anthropic Messages, you can set
-`models.default.settings.max_tokens`; when omitted, the adapter sends `4096`.
+and as `x-api-key` for Anthropic Messages. The legacy
+`models.default.settings.max_tokens` key remains accepted for Anthropic
+Messages; normalized `models.default.max_tokens` takes precedence. When both
+are omitted, the adapter sends `4096`.
 The connect timeout defaults to 10 seconds, and the timeout between response
 bytes defaults to 600 seconds.
 

--- a/docs/reference/api/python-library-reference/nemo_fabric.models.md
+++ b/docs/reference/api/python-library-reference/nemo_fabric.models.md
@@ -673,6 +673,8 @@ The model defines the following fields:
 | `model` | `str` | Yes | — | `MinLen(min_length=1)` | — |
 | `api_key_env` | `str \| None` | No | `None` | — | — |
 | `temperature` | `float \| None` | No | `None` | — | — |
+| `top_p` | `float \| None` | No | `None` | `Ge(ge=0), Le(le=1)` | — |
+| `max_tokens` | `int \| None` | No | `None` | `Strict(strict=True), Gt(gt=0)` | — |
 | `base_url` | `str \| None` | No | `None` | `MinLen(min_length=1)` | — |
 | `settings` | `dict[str, Any]` | No | `dict()` | — | — |
 

--- a/docs/reference/api/python-library-reference/nemo_fabric.models.md
+++ b/docs/reference/api/python-library-reference/nemo_fabric.models.md
@@ -674,7 +674,7 @@ The model defines the following fields:
 | `api_key_env` | `str \| None` | No | `None` | — | — |
 | `temperature` | `float \| None` | No | `None` | — | — |
 | `top_p` | `float \| None` | No | `None` | `Ge(ge=0), Le(le=1)` | — |
-| `max_tokens` | `int \| None` | No | `None` | `Strict(strict=True), Gt(gt=0)` | — |
+| `max_tokens` | `int \| None` | No | `None` | `Strict(strict=True), Gt(gt=0), Le(le=18446744073709551615)` | — |
 | `base_url` | `str \| None` | No | `None` | `MinLen(min_length=1)` | — |
 | `settings` | `dict[str, Any]` | No | `dict()` | — | — |
 

--- a/docs/reference/api/python-library-reference/nemo_fabric.models.md
+++ b/docs/reference/api/python-library-reference/nemo_fabric.models.md
@@ -673,7 +673,7 @@ The model defines the following fields:
 | `model` | `str` | Yes | — | `MinLen(min_length=1)` | — |
 | `api_key_env` | `str \| None` | No | `None` | — | — |
 | `temperature` | `float \| None` | No | `None` | — | — |
-| `top_p` | `float \| None` | No | `None` | `Ge(ge=0), Le(le=1)` | — |
+| `top_p` | `float \| None` | No | `None` | `Strict(strict=True), Ge(ge=0), Le(le=1)` | — |
 | `max_tokens` | `int \| None` | No | `None` | `Strict(strict=True), Gt(gt=0), Le(le=18446744073709551615)` | — |
 | `base_url` | `str \| None` | No | `None` | `MinLen(min_length=1)` | — |
 | `settings` | `dict[str, Any]` | No | `dict()` | — | — |

--- a/docs/reference/api/rust-library-reference/nemo-fabric-core/agent-config/struct-agentmodelconfig.mdx
+++ b/docs/reference/api/rust-library-reference/nemo-fabric-core/agent-config/struct-agentmodelconfig.mdx
@@ -10,7 +10,7 @@ SPDX-License-Identifier: Apache-2.0 */}
 
 Generated from `cargo doc --no-deps -p nemo-fabric-core`.
 
-<pre className="rust-signature"><code dangerouslySetInnerHTML={{"__html": "pub struct AgentModelConfig &#123;\n    pub provider: <a href=\"https://doc.rust-lang.org/1.94.0/alloc/string/struct.String.html\">String</a>,\n    pub model: <a href=\"https://doc.rust-lang.org/1.94.0/alloc/string/struct.String.html\">String</a>,\n    pub api_key_env: <a href=\"https://doc.rust-lang.org/1.94.0/core/option/enum.Option.html\">Option</a>&lt;<a href=\"https://doc.rust-lang.org/1.94.0/alloc/string/struct.String.html\">String</a>&gt;,\n    pub temperature: <a href=\"https://doc.rust-lang.org/1.94.0/core/option/enum.Option.html\">Option</a>&lt;<a href=\"https://doc.rust-lang.org/1.94.0/std/primitive.f64.html\">f64</a>&gt;,\n    pub base_url: <a href=\"https://doc.rust-lang.org/1.94.0/core/option/enum.Option.html\">Option</a>&lt;<a href=\"https://doc.rust-lang.org/1.94.0/alloc/string/struct.String.html\">String</a>&gt;,\n    pub settings: <a href=\"https://docs.rs/serde_json/1.0.150/serde_json/map/struct.Map.html\">Map</a>&lt;<a href=\"https://doc.rust-lang.org/1.94.0/alloc/string/struct.String.html\">String</a>, <a href=\"https://docs.rs/serde_json/1.0.150/serde_json/value/enum.Value.html\">Value</a>&gt;,\n    pub extensions: <a href=\"https://doc.rust-lang.org/1.94.0/alloc/collections/btree/map/struct.BTreeMap.html\">BTreeMap</a>&lt;<a href=\"https://doc.rust-lang.org/1.94.0/alloc/string/struct.String.html\">String</a>, <a href=\"https://docs.rs/serde_json/1.0.150/serde_json/value/enum.Value.html\">Value</a>&gt;,\n&#125;"}} /></pre>
+<pre className="rust-signature"><code dangerouslySetInnerHTML={{"__html": "pub struct AgentModelConfig &#123;\n    pub provider: <a href=\"https://doc.rust-lang.org/1.94.0/alloc/string/struct.String.html\">String</a>,\n    pub model: <a href=\"https://doc.rust-lang.org/1.94.0/alloc/string/struct.String.html\">String</a>,\n    pub api_key_env: <a href=\"https://doc.rust-lang.org/1.94.0/core/option/enum.Option.html\">Option</a>&lt;<a href=\"https://doc.rust-lang.org/1.94.0/alloc/string/struct.String.html\">String</a>&gt;,\n    pub temperature: <a href=\"https://doc.rust-lang.org/1.94.0/core/option/enum.Option.html\">Option</a>&lt;<a href=\"https://doc.rust-lang.org/1.94.0/std/primitive.f64.html\">f64</a>&gt;,\n    pub top_p: <a href=\"https://doc.rust-lang.org/1.94.0/core/option/enum.Option.html\">Option</a>&lt;<a href=\"https://doc.rust-lang.org/1.94.0/std/primitive.f64.html\">f64</a>&gt;,\n    pub max_tokens: <a href=\"https://doc.rust-lang.org/1.94.0/core/option/enum.Option.html\">Option</a>&lt;<a href=\"https://doc.rust-lang.org/1.94.0/std/primitive.u64.html\">u64</a>&gt;,\n    pub base_url: <a href=\"https://doc.rust-lang.org/1.94.0/core/option/enum.Option.html\">Option</a>&lt;<a href=\"https://doc.rust-lang.org/1.94.0/alloc/string/struct.String.html\">String</a>&gt;,\n    pub settings: <a href=\"https://docs.rs/serde_json/1.0.150/serde_json/map/struct.Map.html\">Map</a>&lt;<a href=\"https://doc.rust-lang.org/1.94.0/alloc/string/struct.String.html\">String</a>, <a href=\"https://docs.rs/serde_json/1.0.150/serde_json/value/enum.Value.html\">Value</a>&gt;,\n    pub extensions: <a href=\"https://doc.rust-lang.org/1.94.0/alloc/collections/btree/map/struct.BTreeMap.html\">BTreeMap</a>&lt;<a href=\"https://doc.rust-lang.org/1.94.0/alloc/string/struct.String.html\">String</a>, <a href=\"https://docs.rs/serde_json/1.0.150/serde_json/value/enum.Value.html\">Value</a>&gt;,\n&#125;"}} /></pre>
 
 Configuration for one named model role projected to an adapter target.
 
@@ -31,6 +31,14 @@ Environment variable containing the provider credential.
 ### `temperature: Option<f64>`
 
 Optional model temperature.
+
+### `top_p: Option<f64>`
+
+Optional nucleus sampling probability.
+
+### `max_tokens: Option<u64>`
+
+Optional maximum number of response tokens.
 
 ### `base_url: Option<String>`
 

--- a/docs/reference/api/rust-library-reference/nemo-fabric-core/config/enum-adapterconfigfield.mdx
+++ b/docs/reference/api/rust-library-reference/nemo-fabric-core/config/enum-adapterconfigfield.mdx
@@ -14,6 +14,8 @@ pub enum AdapterConfigField {
     Models,
     ModelBaseUrl,
     ModelTemperature,
+    ModelTopP,
+    ModelMaxTokens,
     SystemInstructions,
     MaxTurns,
     EnabledTools,
@@ -48,6 +50,18 @@ Custom model endpoint.
 <pre className="rust-signature"><code dangerouslySetInnerHTML={{"__html": "ModelTemperature"}} /></pre>
 
 Model temperature.
+
+### `ModelTopP`
+
+<pre className="rust-signature"><code dangerouslySetInnerHTML={{"__html": "ModelTopP"}} /></pre>
+
+Model nucleus sampling probability.
+
+### `ModelMaxTokens`
+
+<pre className="rust-signature"><code dangerouslySetInnerHTML={{"__html": "ModelMaxTokens"}} /></pre>
+
+Maximum model response tokens.
 
 ### `SystemInstructions`
 

--- a/docs/reference/api/rust-library-reference/nemo-fabric-core/config/struct-modelconfig.mdx
+++ b/docs/reference/api/rust-library-reference/nemo-fabric-core/config/struct-modelconfig.mdx
@@ -9,7 +9,7 @@ SPDX-License-Identifier: Apache-2.0 */}
 
 Generated from `cargo doc --no-deps -p nemo-fabric-core`.
 
-<pre className="rust-signature"><code dangerouslySetInnerHTML={{"__html": "pub struct ModelConfig &#123;\n    pub provider: <a href=\"https://doc.rust-lang.org/1.94.0/alloc/string/struct.String.html\">String</a>,\n    pub model: <a href=\"https://doc.rust-lang.org/1.94.0/alloc/string/struct.String.html\">String</a>,\n    pub temperature: <a href=\"https://doc.rust-lang.org/1.94.0/core/option/enum.Option.html\">Option</a>&lt;<a href=\"https://doc.rust-lang.org/1.94.0/std/primitive.f64.html\">f64</a>&gt;,\n    pub api_key_env: <a href=\"https://doc.rust-lang.org/1.94.0/core/option/enum.Option.html\">Option</a>&lt;<a href=\"https://doc.rust-lang.org/1.94.0/alloc/string/struct.String.html\">String</a>&gt;,\n    pub base_url: <a href=\"https://doc.rust-lang.org/1.94.0/core/option/enum.Option.html\">Option</a>&lt;<a href=\"https://doc.rust-lang.org/1.94.0/alloc/string/struct.String.html\">String</a>&gt;,\n    pub settings: <a href=\"https://docs.rs/serde_json/1.0.150/serde_json/map/struct.Map.html\">Map</a>&lt;<a href=\"https://doc.rust-lang.org/1.94.0/alloc/string/struct.String.html\">String</a>, <a href=\"https://docs.rs/serde_json/1.0.150/serde_json/value/enum.Value.html\">Value</a>&gt;,\n    pub extensions: <a href=\"https://doc.rust-lang.org/1.94.0/alloc/collections/btree/map/struct.BTreeMap.html\">BTreeMap</a>&lt;<a href=\"https://doc.rust-lang.org/1.94.0/alloc/string/struct.String.html\">String</a>, <a href=\"https://docs.rs/serde_json/1.0.150/serde_json/value/enum.Value.html\">Value</a>&gt;,\n&#125;"}} /></pre>
+<pre className="rust-signature"><code dangerouslySetInnerHTML={{"__html": "pub struct ModelConfig &#123;\n    pub provider: <a href=\"https://doc.rust-lang.org/1.94.0/alloc/string/struct.String.html\">String</a>,\n    pub model: <a href=\"https://doc.rust-lang.org/1.94.0/alloc/string/struct.String.html\">String</a>,\n    pub temperature: <a href=\"https://doc.rust-lang.org/1.94.0/core/option/enum.Option.html\">Option</a>&lt;<a href=\"https://doc.rust-lang.org/1.94.0/std/primitive.f64.html\">f64</a>&gt;,\n    pub top_p: <a href=\"https://doc.rust-lang.org/1.94.0/core/option/enum.Option.html\">Option</a>&lt;<a href=\"https://doc.rust-lang.org/1.94.0/std/primitive.f64.html\">f64</a>&gt;,\n    pub max_tokens: <a href=\"https://doc.rust-lang.org/1.94.0/core/option/enum.Option.html\">Option</a>&lt;<a href=\"https://doc.rust-lang.org/1.94.0/std/primitive.u64.html\">u64</a>&gt;,\n    pub api_key_env: <a href=\"https://doc.rust-lang.org/1.94.0/core/option/enum.Option.html\">Option</a>&lt;<a href=\"https://doc.rust-lang.org/1.94.0/alloc/string/struct.String.html\">String</a>&gt;,\n    pub base_url: <a href=\"https://doc.rust-lang.org/1.94.0/core/option/enum.Option.html\">Option</a>&lt;<a href=\"https://doc.rust-lang.org/1.94.0/alloc/string/struct.String.html\">String</a>&gt;,\n    pub settings: <a href=\"https://docs.rs/serde_json/1.0.150/serde_json/map/struct.Map.html\">Map</a>&lt;<a href=\"https://doc.rust-lang.org/1.94.0/alloc/string/struct.String.html\">String</a>, <a href=\"https://docs.rs/serde_json/1.0.150/serde_json/value/enum.Value.html\">Value</a>&gt;,\n    pub extensions: <a href=\"https://doc.rust-lang.org/1.94.0/alloc/collections/btree/map/struct.BTreeMap.html\">BTreeMap</a>&lt;<a href=\"https://doc.rust-lang.org/1.94.0/alloc/string/struct.String.html\">String</a>, <a href=\"https://docs.rs/serde_json/1.0.150/serde_json/value/enum.Value.html\">Value</a>&gt;,\n&#125;"}} /></pre>
 
 Model configuration.
 
@@ -26,6 +26,14 @@ Provider model identifier.
 ### `temperature: Option<f64>`
 
 Optional temperature.
+
+### `top_p: Option<f64>`
+
+Optional nucleus sampling probability.
+
+### `max_tokens: Option<u64>`
+
+Optional maximum number of response tokens.
 
 ### `api_key_env: Option<String>`
 

--- a/docs/sdk/python.mdx
+++ b/docs/sdk/python.mdx
@@ -216,7 +216,10 @@ and `api_key_env`. Deep Agents keeps dynamic LangChain provider selection. Each
 published schema rejects undeclared `ModelConfig.settings` during planning and
 reports each issue through `doctor(...)` before adapter startup. Existing
 configurations that supplied `top_p` and `max_tokens` as flattened model
-extensions retain the same wire shape when loaded as normalized fields.
+extensions retain the same wire shape when loaded as normalized fields. Legacy
+adapter descriptors that accept either name through `extension_schemas.model`
+continue receiving it in `AgentModelConfig.extensions`; adapters that advertise
+the normalized capability receive the typed field instead.
 
 If a normalized field has no complete mapping, `plan(...)` and runtime start
 fail with a configuration compatibility error naming the adapter and field.

--- a/docs/sdk/python.mdx
+++ b/docs/sdk/python.mdx
@@ -170,8 +170,7 @@ validated against the selected adapter descriptor during planning.
 around adapter execution. `Yes` means the adapter translates the normalized
 field into its harness. `No` means an explicitly configured value fails
 planning instead of being ignored. The following table groups provider-specific
-Relay subfields and additive extension maps because their support does not vary
-by adapter:
+Relay subfields:
 
 | `FabricConfig` Field | Claude | Codex | Deep Agents | Hermes Agent | mini-SWE-agent |
 | --- | --- | --- | --- | --- | --- |
@@ -186,6 +185,7 @@ by adapter:
 | `models.<role>.base_url` | Yes | Yes | Yes | Yes | Yes |
 | `models.<role>.temperature` | No | No | Yes | Yes | Yes |
 | `models.<role>.settings.<key>` | No keys declared | No keys declared | No keys declared | No keys declared | No keys declared |
+| `models.<role>.top_p`, `.max_tokens` | No | No | Yes | Yes | Yes; passed through LiteLLM |
 | `instructions.system` | `replace`, `append` | `replace`; maps to Codex base instructions | `replace` | `replace` | `replace` |
 | `runtime.input_schema`, `.output_schema` | Core | Core | Core | Core | Core |
 | `runtime.artifacts`, `.timeout_seconds` | Core | Core | Core | Core | Core |
@@ -204,16 +204,19 @@ by adapter:
 | `telemetry.providers.<provider>.config` | Declared-provider pass-through | Declared-provider pass-through | Declared-provider pass-through | Declared-provider pass-through | Declared-provider pass-through |
 | `relay.project`, `.output_dir`, `.observability` | Yes | Yes | Yes | Yes | Yes |
 | `relay.components`, `.policy` | Yes | Yes | Yes | Yes | Yes |
-| Additive `extensions` on typed config objects | Preserved; no portable adapter semantics | Preserved; no portable adapter semantics | Preserved; no portable adapter semantics | Preserved; no portable adapter semantics | Preserved; no portable adapter semantics |
+| Other additive `extensions` on typed config objects | Rejected unless declared by the descriptor | Rejected unless declared by the descriptor | Rejected unless declared by the descriptor | Rejected unless declared by the descriptor | Rejected unless declared by the descriptor |
 
 Model selection is deterministic: the `default` role wins; otherwise a single
 named role is selected. More than one role without `default` fails planning.
-Claude and Codex publish a descriptor-owned `model_schema` for every configured
-model role. Their native providers (`anthropic` and `openai`, respectively)
-keep the existing authentication path. Other providers remain valid only with
-an explicit `base_url` and `api_key_env`. The same schema rejects undeclared
-`ModelConfig.settings` during planning and reports each issue through
-`doctor(...)` before adapter startup.
+Claude, Codex, and Deep Agents publish a descriptor-owned `model_schema` for
+every configured model role. The Claude and Codex native providers (`anthropic`
+and `openai`, respectively) keep the existing authentication path. Other Claude
+and Codex providers remain valid only with an explicit `base_url` and
+`api_key_env`. Deep Agents keeps dynamic LangChain provider selection. Each
+schema rejects undeclared `ModelConfig.settings` during planning and reports
+each issue through `doctor(...)` before adapter startup. Existing configurations
+that supplied `top_p` and `max_tokens` as flattened model extensions retain the
+same wire shape when loaded as normalized fields.
 
 If a normalized field has no complete mapping, `plan(...)` and runtime start
 fail with a configuration compatibility error naming the adapter and field.

--- a/docs/sdk/python.mdx
+++ b/docs/sdk/python.mdx
@@ -208,15 +208,15 @@ Relay subfields:
 
 Model selection is deterministic: the `default` role wins; otherwise a single
 named role is selected. More than one role without `default` fails planning.
-Claude, Codex, and Deep Agents publish a descriptor-owned `model_schema` for
-every configured model role. The Claude and Codex native providers (`anthropic`
-and `openai`, respectively) keep the existing authentication path. Other Claude
-and Codex providers remain valid only with an explicit `base_url` and
-`api_key_env`. Deep Agents keeps dynamic LangChain provider selection. Each
-schema rejects undeclared `ModelConfig.settings` during planning and reports
-each issue through `doctor(...)` before adapter startup. Existing configurations
-that supplied `top_p` and `max_tokens` as flattened model extensions retain the
-same wire shape when loaded as normalized fields.
+All bundled adapters except Hermes publish a descriptor-owned `model_schema`
+for every configured model role. The Claude and Codex native providers
+(`anthropic` and `openai`, respectively) keep the existing authentication path.
+Other Claude and Codex providers remain valid only with an explicit `base_url`
+and `api_key_env`. Deep Agents keeps dynamic LangChain provider selection. Each
+published schema rejects undeclared `ModelConfig.settings` during planning and
+reports each issue through `doctor(...)` before adapter startup. Existing
+configurations that supplied `top_p` and `max_tokens` as flattened model
+extensions retain the same wire shape when loaded as normalized fields.
 
 If a normalized field has no complete mapping, `plan(...)` and runtime start
 fail with a configuration compatibility error naming the adapter and field.

--- a/examples/harbor/swebench/adapters/hermes/hermes.fabric-adapter.json
+++ b/examples/harbor/swebench/adapters/hermes/hermes.fabric-adapter.json
@@ -61,24 +61,6 @@
     "additionalProperties": false
   },
   "extension_schemas": {
-    "model": {
-      "$schema": "https://json-schema.org/draft/2020-12/schema",
-      "type": "object",
-      "properties": {
-        "top_p": {
-          "type": "number",
-          "minimum": 0,
-          "maximum": 1,
-          "description": "Nucleus sampling probability passed to the model provider."
-        },
-        "max_tokens": {
-          "type": "integer",
-          "minimum": 1,
-          "description": "Maximum number of tokens for responses from this model role."
-        }
-      },
-      "additionalProperties": false
-    },
     "run_error": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "type": "object",
@@ -93,6 +75,8 @@
       "models",
       "models.base_url",
       "models.temperature",
+      "models.top_p",
+      "models.max_tokens",
       "instructions.system",
       "runtime.max_turns",
       "tools.enabled",

--- a/schemas/adapter-contract/adapter-descriptor.schema.json
+++ b/schemas/adapter-contract/adapter-descriptor.schema.json
@@ -19,6 +19,16 @@
           "type": "string"
         },
         {
+          "const": "models.top_p",
+          "description": "Model nucleus sampling probability.",
+          "type": "string"
+        },
+        {
+          "const": "models.max_tokens",
+          "description": "Maximum model response tokens.",
+          "type": "string"
+        },
+        {
           "const": "instructions.system",
           "description": "Portable system instructions.",
           "type": "string"

--- a/schemas/adapter-contract/agent-config.schema.json
+++ b/schemas/adapter-contract/agent-config.schema.json
@@ -185,6 +185,15 @@
           "description": "Adapter-owned model fields.",
           "type": "object"
         },
+        "max_tokens": {
+          "description": "Optional maximum number of response tokens.",
+          "format": "uint64",
+          "minimum": 1,
+          "type": [
+            "integer",
+            "null"
+          ]
+        },
         "model": {
           "description": "Provider model identifier.",
           "minLength": 1,
@@ -205,6 +214,16 @@
         "temperature": {
           "description": "Optional model temperature.",
           "format": "double",
+          "type": [
+            "number",
+            "null"
+          ]
+        },
+        "top_p": {
+          "description": "Optional nucleus sampling probability.",
+          "format": "double",
+          "maximum": 1.0,
+          "minimum": 0.0,
           "type": [
             "number",
             "null"

--- a/schemas/adapter-contract/agent-config.schema.json
+++ b/schemas/adapter-contract/agent-config.schema.json
@@ -188,6 +188,7 @@
         "max_tokens": {
           "description": "Optional maximum number of response tokens.",
           "format": "uint64",
+          "maximum": 18446744073709551615,
           "minimum": 1,
           "type": [
             "integer",

--- a/schemas/sdk/agent.schema.json
+++ b/schemas/sdk/agent.schema.json
@@ -485,6 +485,7 @@
         "max_tokens": {
           "description": "Optional maximum number of response tokens.",
           "format": "uint64",
+          "maximum": 18446744073709551615,
           "minimum": 1,
           "type": [
             "integer",

--- a/schemas/sdk/agent.schema.json
+++ b/schemas/sdk/agent.schema.json
@@ -482,6 +482,15 @@
             "null"
           ]
         },
+        "max_tokens": {
+          "description": "Optional maximum number of response tokens.",
+          "format": "uint64",
+          "minimum": 1,
+          "type": [
+            "integer",
+            "null"
+          ]
+        },
         "model": {
           "description": "Provider model identifier.",
           "type": "string"
@@ -498,6 +507,16 @@
         "temperature": {
           "description": "Optional temperature.",
           "format": "double",
+          "type": [
+            "number",
+            "null"
+          ]
+        },
+        "top_p": {
+          "description": "Optional nucleus sampling probability.",
+          "format": "double",
+          "maximum": 1.0,
+          "minimum": 0.0,
           "type": [
             "number",
             "null"

--- a/schemas/sdk/run-plan.schema.json
+++ b/schemas/sdk/run-plan.schema.json
@@ -683,6 +683,7 @@
         "max_tokens": {
           "description": "Optional maximum number of response tokens.",
           "format": "uint64",
+          "maximum": 18446744073709551615,
           "minimum": 1,
           "type": [
             "integer",
@@ -1845,6 +1846,7 @@
         "max_tokens": {
           "description": "Optional maximum number of response tokens.",
           "format": "uint64",
+          "maximum": 18446744073709551615,
           "minimum": 1,
           "type": [
             "integer",

--- a/schemas/sdk/run-plan.schema.json
+++ b/schemas/sdk/run-plan.schema.json
@@ -19,6 +19,16 @@
           "type": "string"
         },
         {
+          "const": "models.top_p",
+          "description": "Model nucleus sampling probability.",
+          "type": "string"
+        },
+        {
+          "const": "models.max_tokens",
+          "description": "Maximum model response tokens.",
+          "type": "string"
+        },
+        {
           "const": "instructions.system",
           "description": "Portable system instructions.",
           "type": "string"
@@ -670,6 +680,15 @@
           "description": "Adapter-owned model fields.",
           "type": "object"
         },
+        "max_tokens": {
+          "description": "Optional maximum number of response tokens.",
+          "format": "uint64",
+          "minimum": 1,
+          "type": [
+            "integer",
+            "null"
+          ]
+        },
         "model": {
           "description": "Provider model identifier.",
           "minLength": 1,
@@ -690,6 +709,16 @@
         "temperature": {
           "description": "Optional model temperature.",
           "format": "double",
+          "type": [
+            "number",
+            "null"
+          ]
+        },
+        "top_p": {
+          "description": "Optional nucleus sampling probability.",
+          "format": "double",
+          "maximum": 1.0,
+          "minimum": 0.0,
           "type": [
             "number",
             "null"
@@ -1813,6 +1842,15 @@
             "null"
           ]
         },
+        "max_tokens": {
+          "description": "Optional maximum number of response tokens.",
+          "format": "uint64",
+          "minimum": 1,
+          "type": [
+            "integer",
+            "null"
+          ]
+        },
         "model": {
           "description": "Provider model identifier.",
           "type": "string"
@@ -1829,6 +1867,16 @@
         "temperature": {
           "description": "Optional temperature.",
           "format": "double",
+          "type": [
+            "number",
+            "null"
+          ]
+        },
+        "top_p": {
+          "description": "Optional nucleus sampling probability.",
+          "format": "double",
+          "maximum": 1.0,
+          "minimum": 0.0,
           "type": [
             "number",
             "null"

--- a/sdk/python/nemo-fabric-runtime/src/nemo_fabric/models.py
+++ b/sdk/python/nemo-fabric-runtime/src/nemo_fabric/models.py
@@ -272,6 +272,8 @@ class ModelConfig(FabricBaseModel):
     model: str = Field(min_length=1)
     api_key_env: str | None = None
     temperature: float | None = None
+    top_p: float | None = Field(default=None, ge=0, le=1)
+    max_tokens: int | None = Field(default=None, strict=True, gt=0)
     base_url: str | None = Field(default=None, min_length=1)
     settings: dict[str, Any] = Field(default_factory=dict)
 

--- a/sdk/python/nemo-fabric-runtime/src/nemo_fabric/models.py
+++ b/sdk/python/nemo-fabric-runtime/src/nemo_fabric/models.py
@@ -272,7 +272,7 @@ class ModelConfig(FabricBaseModel):
     model: str = Field(min_length=1)
     api_key_env: str | None = None
     temperature: float | None = None
-    top_p: float | None = Field(default=None, ge=0, le=1)
+    top_p: float | None = Field(default=None, strict=True, ge=0, le=1)
     max_tokens: int | None = Field(
         default=None,
         strict=True,
@@ -287,6 +287,13 @@ class ModelConfig(FabricBaseModel):
     def _validate_provider(cls, value: str) -> str:
         if not value.strip() or value != value.strip() or value != value.lower():
             raise ValueError("provider must be a non-empty lowercase identifier")
+        return value
+
+    @field_validator("max_tokens", mode="before")
+    @classmethod
+    def _normalize_integral_max_tokens(cls, value: Any) -> Any:
+        if isinstance(value, float) and value.is_integer():
+            return int(value)
         return value
 
     @field_validator("model", "api_key_env")

--- a/sdk/python/nemo-fabric-runtime/src/nemo_fabric/models.py
+++ b/sdk/python/nemo-fabric-runtime/src/nemo_fabric/models.py
@@ -273,7 +273,12 @@ class ModelConfig(FabricBaseModel):
     api_key_env: str | None = None
     temperature: float | None = None
     top_p: float | None = Field(default=None, ge=0, le=1)
-    max_tokens: int | None = Field(default=None, strict=True, gt=0)
+    max_tokens: int | None = Field(
+        default=None,
+        strict=True,
+        gt=0,
+        le=(1 << 64) - 1,
+    )
     base_url: str | None = Field(default=None, min_length=1)
     settings: dict[str, Any] = Field(default_factory=dict)
 

--- a/skills/nemo-fabric-build-adapter/SKILL.md
+++ b/skills/nemo-fabric-build-adapter/SKILL.md
@@ -63,6 +63,10 @@ translation:
   and `extension_schemas` where applicable. Use
   `model_schema` only for static model/provider compatibility and model settings;
   keep credential validity and provider availability in startup validation.
+- New adapters that consume `models.<role>.top_p` or `.max_tokens` should declare
+  the corresponding normalized `config.accepts` field. Existing descriptors
+  that declare either name through `extension_schemas.model` remain compatible
+  and receive it in `AgentModelConfig.extensions`.
 - Declare runtime requirements and telemetry outputs without secret values.
 - Leave optional capability flags false unless the installed NeMo Fabric runtime
   exposes and tests that adapter operation. Set `capabilities.streaming` only

--- a/skills/nemo-fabric-integrate/references/config-mapping.md
+++ b/skills/nemo-fabric-integrate/references/config-mapping.md
@@ -35,10 +35,14 @@ indexes the public config models. The generated pages omit constructor fields an
 defaults, so read the installed `nemo_fabric` models (they ship `py.typed`) for
 exact field names and defaults.
 
-Claude and Codex validate every model role against their descriptor-owned
-`model_schema`. Provider identifiers outside their native `anthropic` and
-`openai` paths require both `ModelConfig.base_url` and
-`ModelConfig.api_key_env`; undeclared `ModelConfig.settings` also fail planning.
+Claude, Codex, and Deep Agents validate every model role against their
+descriptor-owned `model_schema`. Provider identifiers outside the native Claude
+and Codex `anthropic` and `openai` paths require both `ModelConfig.base_url` and
+`ModelConfig.api_key_env`. Deep Agents keeps dynamic LangChain provider
+selection. Undeclared `ModelConfig.settings` fail planning for all three
+adapters. `models.<role>.top_p` and `models.<role>.max_tokens` are normalized
+fields. Deep Agents, Hermes, mini-SWE-agent, and Remote Agent declare native
+mappings; other adapters fail planning when either field is configured.
 
 Omit `instructions.system` to preserve the harness's native system instruction.
 When present, `InstructionConfig.mode` defaults to `replace`; set it to

--- a/skills/nemo-fabric-integrate/references/config-mapping.md
+++ b/skills/nemo-fabric-integrate/references/config-mapping.md
@@ -35,11 +35,11 @@ indexes the public config models. The generated pages omit constructor fields an
 defaults, so read the installed `nemo_fabric` models (they ship `py.typed`) for
 exact field names and defaults.
 
-Claude, Codex, and Deep Agents validate every model role against their
+All bundled adapters except Hermes validate every model role against their
 descriptor-owned `model_schema`. Provider identifiers outside the native Claude
 and Codex `anthropic` and `openai` paths require both `ModelConfig.base_url` and
 `ModelConfig.api_key_env`. Deep Agents keeps dynamic LangChain provider
-selection. Undeclared `ModelConfig.settings` fail planning for all three
+selection. Undeclared `ModelConfig.settings` fail planning for each of these
 adapters. `models.<role>.top_p` and `models.<role>.max_tokens` are normalized
 fields. Deep Agents, Hermes, mini-SWE-agent, and Remote Agent declare native
 mappings; other adapters fail planning when either field is configured.

--- a/skills/nemo-fabric-integrate/references/config-mapping.md
+++ b/skills/nemo-fabric-integrate/references/config-mapping.md
@@ -43,6 +43,10 @@ selection. Undeclared `ModelConfig.settings` fail planning for each of these
 adapters. `models.<role>.top_p` and `models.<role>.max_tokens` are normalized
 fields. Deep Agents, Hermes, mini-SWE-agent, and Remote Agent declare native
 mappings; other adapters fail planning when either field is configured.
+Legacy adapter descriptors that instead accept either name through
+`extension_schemas.model` receive it in `AgentModelConfig.extensions`. A
+descriptor-advertised normalized mapping takes precedence over this compatibility
+route.
 
 Omit `instructions.system` to preserve the harness's native system instruction.
 When present, `InstructionConfig.mode` defaults to `replace`; set it to

--- a/tests/adapter_contract/test_agent_config.py
+++ b/tests/adapter_contract/test_agent_config.py
@@ -209,12 +209,27 @@ def test_agent_model_config_round_trips_normalized_sampling_fields():
     assert model.to_mapping()["max_tokens"] == 512
 
 
+def test_agent_model_config_accepts_u64_max_tokens():
+    maximum = (1 << 64) - 1
+
+    model = AgentModelConfig.from_mapping(
+        {"provider": "nvidia", "model": "test-model", "max_tokens": maximum}
+    )
+
+    assert model.max_tokens == maximum
+
+
 @pytest.mark.parametrize(
     ("field", "value", "message"),
     [
         ("top_p", -0.1, "top_p: must be between zero and one"),
         ("top_p", 1.1, "top_p: must be between zero and one"),
         ("max_tokens", 0, "max_tokens: must be greater than zero"),
+        (
+            "max_tokens",
+            1 << 64,
+            "max_tokens: must be between 0 and 18446744073709551615",
+        ),
         ("max_tokens", True, "max_tokens: must be an integer"),
     ],
 )

--- a/tests/adapter_contract/test_agent_config.py
+++ b/tests/adapter_contract/test_agent_config.py
@@ -193,6 +193,38 @@ def test_agent_model_config_rejects_float_overflow():
         )
 
 
+def test_agent_model_config_round_trips_normalized_sampling_fields():
+    model = AgentModelConfig.from_mapping(
+        {
+            "provider": "nvidia",
+            "model": "test-model",
+            "top_p": 0.8,
+            "max_tokens": 512,
+        }
+    )
+
+    assert model.top_p == 0.8
+    assert model.max_tokens == 512
+    assert model.to_mapping()["top_p"] == 0.8
+    assert model.to_mapping()["max_tokens"] == 512
+
+
+@pytest.mark.parametrize(
+    ("field", "value", "message"),
+    [
+        ("top_p", -0.1, "top_p: must be between zero and one"),
+        ("top_p", 1.1, "top_p: must be between zero and one"),
+        ("max_tokens", 0, "max_tokens: must be greater than zero"),
+        ("max_tokens", True, "max_tokens: must be an integer"),
+    ],
+)
+def test_agent_model_config_rejects_invalid_sampling_fields(field, value, message):
+    with pytest.raises(ContractValidationError, match=message):
+        AgentModelConfig.from_mapping(
+            {"provider": "nvidia", "model": "test-model", field: value}
+        )
+
+
 def test_agent_mcp_server_config_preserves_http_authentication():
     server = AgentMcpServerConfig.from_mapping(
         {

--- a/tests/adapters/test_deepagents.py
+++ b/tests/adapters/test_deepagents.py
@@ -49,6 +49,27 @@ def test_descriptor_declares_supported_normalized_config():
 
     assert descriptor["config"]["system_instruction_modes"] == ["replace"]
     assert "runtime.max_turns" in descriptor["config"]["accepts"]
+    assert descriptor["model_schema"]["properties"]["settings"] == {
+        "type": "object",
+        "properties": {},
+        "additionalProperties": False,
+    }
+    assert {
+        name: descriptor["model_schema"]["properties"][name]
+        for name in ("top_p", "max_tokens")
+    } == {
+        "top_p": {
+            "type": "number",
+            "minimum": 0,
+            "maximum": 1,
+        },
+        "max_tokens": {
+            "type": "integer",
+            "minimum": 1,
+        },
+    }
+    assert "models.top_p" in descriptor["config"]["accepts"]
+    assert "models.max_tokens" in descriptor["config"]["accepts"]
 
 
 def lifecycle_start_payload(payload: dict[str, Any]) -> dict[str, Any]:
@@ -110,15 +131,18 @@ def fake_sdks_fixture(monkeypatch):
     """Stub the deepagents/langchain/langgraph SDKs with mocks.
 
     Returns a recorder capturing the ``create_deep_agent`` kwargs, the streamed
-    ``config``, and the checkpointer close count. ``chat_openai``/``fs_backend``
-    expose the mocked classes so tests can assert their construction kwargs.
+    ``config``, and the checkpointer close count. ``chat_openai``,
+    ``init_chat_model``, and ``fs_backend`` expose the mocked callables so tests
+    can assert their construction kwargs.
     """
 
     recorder: dict[str, Any] = {"saver_exits": 0}
 
     mock_chat_openai = MagicMock()
+    mock_init_chat_model = MagicMock()
     mock_fs_backend = MagicMock()
     recorder["chat_openai"] = mock_chat_openai
+    recorder["init_chat_model"] = mock_init_chat_model
     recorder["fs_backend"] = mock_fs_backend
 
     def build_agent(**kwargs):
@@ -207,6 +231,10 @@ def fake_sdks_fixture(monkeypatch):
     langchain_openai_mod = types.ModuleType("langchain_openai")
     langchain_openai_mod.ChatOpenAI = mock_chat_openai
     monkeypatch.setitem(sys.modules, "langchain_openai", langchain_openai_mod)
+
+    langchain_chat_models_mod = types.ModuleType("langchain.chat_models")
+    langchain_chat_models_mod.init_chat_model = mock_init_chat_model
+    monkeypatch.setitem(sys.modules, "langchain.chat_models", langchain_chat_models_mod)
 
     def open_saver(_conn):
         async def aexit(*_exc):
@@ -2118,6 +2146,71 @@ async def test_openai_provider_defaults_to_openai_key(
     assert output["failed"] is False, output["error"]
     assert output["base_url"] is None
     assert "base_url" not in fake_sdks["chat_openai"].call_args.kwargs
+
+
+async def test_openai_compatible_model_receives_normalized_sampling(
+    tmp_path, make_payload, fake_sdks
+):
+    payload = make_payload(tmp_path)
+    payload["config"]["models"]["default"].update(
+        {
+            "temperature": 0.2,
+            "top_p": 0.8,
+            "max_tokens": 256,
+        }
+    )
+
+    output = await invoke_once(payload)
+
+    assert output["failed"] is False, output["error"]
+    fake_sdks["chat_openai"].assert_called_once_with(
+        model="nvidia/nemotron-3-nano-omni-30b-a3b-reasoning",
+        api_key="test123",
+        base_url="https://integrate.api.nvidia.com/v1",
+        temperature=0.2,
+        top_p=0.8,
+        max_completion_tokens=256,
+    )
+
+
+async def test_generic_model_receives_normalized_sampling(
+    tmp_path, make_payload, fake_sdks
+):
+    os.environ["ANTHROPIC_API_KEY"] = "sk-test"
+    payload = make_payload(tmp_path)
+    payload["config"]["models"]["default"] = {
+        "provider": "anthropic",
+        "model": "claude-test",
+        "api_key_env": "ANTHROPIC_API_KEY",
+        "temperature": 0.3,
+        "top_p": 0.7,
+        "max_tokens": 512,
+    }
+
+    output = await invoke_once(payload)
+
+    assert output["failed"] is False, output["error"]
+    fake_sdks["init_chat_model"].assert_called_once_with(
+        model="claude-test",
+        model_provider="anthropic",
+        api_key="sk-test",
+        temperature=0.3,
+        top_p=0.7,
+        max_tokens=512,
+    )
+
+
+async def test_unset_sampling_preserves_chat_model_defaults(
+    tmp_path, make_payload, fake_sdks
+):
+    output = await invoke_once(make_payload(tmp_path))
+
+    assert output["failed"] is False, output["error"]
+    fake_sdks["chat_openai"].assert_called_once_with(
+        model="nvidia/nemotron-3-nano-omni-30b-a3b-reasoning",
+        api_key="test123",
+        base_url="https://integrate.api.nvidia.com/v1",
+    )
 
 
 async def test_openai_compatible_provider_requires_api_key_env(tmp_path, make_payload):

--- a/tests/adapters/test_deepagents.py
+++ b/tests/adapters/test_deepagents.py
@@ -25,6 +25,7 @@ from unittest.mock import AsyncMock
 from unittest.mock import MagicMock
 
 import pytest
+from langchain_openai import ChatOpenAI as InstalledChatOpenAI
 from langgraph.errors import GraphRecursionError
 from nemo_fabric_adapter_contract.codec import ContractValidationError
 from nemo_fabric_adapter_contract.models import AgentConfig
@@ -2171,6 +2172,16 @@ async def test_openai_compatible_model_receives_normalized_sampling(
         top_p=0.8,
         max_completion_tokens=256,
     )
+
+
+def test_openai_max_tokens_keyword_matches_installed_chat_openai_signature():
+    kwargs = adapter._supported_kwargs(
+        InstalledChatOpenAI,
+        {"max_completion_tokens": 256, "max_tokens": 128},
+    )
+
+    assert kwargs["max_completion_tokens"] == 256
+    assert "max_tokens" not in kwargs
 
 
 async def test_generic_model_receives_normalized_sampling(

--- a/tests/adapters/test_hermes_adapter.py
+++ b/tests/adapters/test_hermes_adapter.py
@@ -116,7 +116,7 @@ def test_validate_hermes_telemetry_provider_rejects_mixed_native_and_relay():
 
 
 def test_descriptor_uses_the_typed_agent_config_contract():
-    """The Hermes descriptor declares its typed config and model extensions."""
+    """The Hermes descriptor declares its typed normalized config."""
     descriptor_path = (
         Path(__file__).parents[2]
         / "adapters"
@@ -131,6 +131,8 @@ def test_descriptor_uses_the_typed_agent_config_contract():
         "models",
         "models.base_url",
         "models.temperature",
+        "models.top_p",
+        "models.max_tokens",
         "instructions.system",
         "runtime.max_turns",
         "tools.enabled",
@@ -139,19 +141,7 @@ def test_descriptor_uses_the_typed_agent_config_contract():
         "mcp.auth.oauth2",
         "skills",
     ]
-    assert descriptor["extension_schemas"]["model"]["properties"] == {
-        "top_p": {
-            "type": "number",
-            "minimum": 0,
-            "maximum": 1,
-            "description": "Nucleus sampling probability passed to the model provider.",
-        },
-        "max_tokens": {
-            "type": "integer",
-            "minimum": 1,
-            "description": "Maximum number of tokens for responses from this model role.",
-        },
-    }
+    assert "model" not in descriptor["extension_schemas"]
     assert descriptor["config"]["system_instruction_modes"] == ["replace"]
 
 
@@ -1362,10 +1352,8 @@ async def test_persistent_runtime_reuses_hermes_agent_session_and_history(
                     "model": "test-model",
                     "api_key_env": "TEST_API_KEY",
                     "temperature": 0.2,
-                    "extensions": {
-                        "top_p": 0.85,
-                        "max_tokens": 768,
-                    },
+                    "top_p": 0.85,
+                    "max_tokens": 768,
                 }
             },
         }

--- a/tests/adapters/test_mini_swe_agent.py
+++ b/tests/adapters/test_mini_swe_agent.py
@@ -126,6 +126,8 @@ def mini_payload_fixture(tmp_path: Path) -> dict:
                     "api_key_env": "TEST_MINI_API_KEY",
                     "base_url": "https://example.test/v1",
                     "temperature": 0.2,
+                    "top_p": 0.8,
+                    "max_tokens": 256,
                 }
             },
             "runtime": {"max_turns": 3},
@@ -263,6 +265,8 @@ def test_mini_swe_agent_descriptor_is_narrow_and_versioned():
             "models",
             "models.base_url",
             "models.temperature",
+            "models.top_p",
+            "models.max_tokens",
             "instructions.system",
             "runtime.max_turns",
         ],
@@ -309,6 +313,8 @@ async def test_mini_swe_agent_maps_config_and_returns_normalized_output(
             "api_key": "test-key",
             "api_base": "https://example.test/v1",
             "temperature": 0.2,
+            "top_p": 0.8,
+            "max_tokens": 256,
         },
     )
     mock_mini["environment_factory"].assert_called_once_with(timeout=45)

--- a/tests/adapters/test_remote_agent.py
+++ b/tests/adapters/test_remote_agent.py
@@ -77,7 +77,8 @@ async def test_remote_agent_invokes_supported_protocol(
                     "provider": "test",
                     "model": "fabric-echo",
                     "temperature": 0.2,
-                    "settings": {"max_tokens": 64},
+                    "top_p": 0.8,
+                    "max_tokens": 64,
                 }
             },
         }
@@ -111,6 +112,13 @@ async def test_remote_agent_invokes_supported_protocol(
     assert result.usage.input_tokens == 0
     assert captured[-1]["model"] == "fabric-echo"
     assert captured[-1]["temperature"] == 0.2
+    assert captured[-1]["top_p"] == 0.8
+    max_tokens_field = {
+        "openai-responses": "max_output_tokens",
+        "openai-completions": "max_completion_tokens",
+        "anthropic-messages": "max_tokens",
+    }[api_type]
+    assert captured[-1][max_tokens_field] == 64
     assert captured[-1].get("stream", False) is (api_type != "openai-completions")
     assert captured[-1]["messages" if api_type != "openai-responses" else "input"]
 

--- a/tests/adapters/test_remote_agent.py
+++ b/tests/adapters/test_remote_agent.py
@@ -123,6 +123,58 @@ async def test_remote_agent_invokes_supported_protocol(
     assert captured[-1]["messages" if api_type != "openai-responses" else "input"]
 
 
+@pytest.mark.parametrize(
+    ("normalized_max_tokens", "expected_max_tokens"),
+    [
+        pytest.param(None, 32, id="legacy-settings-fallback"),
+        pytest.param(64, 64, id="normalized-field-precedence"),
+    ],
+)
+async def test_anthropic_max_tokens_fallback_and_precedence(
+    api_server: str,
+    repo_root: Path,
+    normalized_max_tokens: int | None,
+    expected_max_tokens: int,
+):
+    model: dict[str, object] = {
+        "provider": "test",
+        "model": "fabric-echo",
+        "settings": {"max_tokens": 32},
+    }
+    if normalized_max_tokens is not None:
+        model["max_tokens"] = normalized_max_tokens
+    config = AgentConfig.from_mapping(
+        {
+            "harness": {
+                "settings": {
+                    "base_url": f"{api_server}/v1",
+                    "api_type": "anthropic-messages",
+                }
+            },
+            "models": {"default": model},
+        }
+    )
+    context = _context()
+    runtime = adapter.RemoteAgentRuntime()
+    await runtime.start(
+        {
+            "config": config,
+            "runtime_context": context.to_mapping(),
+            "base_dir": str(repo_root),
+        }
+    )
+
+    try:
+        result = await runtime.invoke(AgentRunRequest(input="Hello."), context)
+    finally:
+        await runtime.stop()
+
+    async with httpx.AsyncClient() as control_client:
+        captured = (await control_client.get(f"{api_server}/_requests")).json()
+    assert result.status == "succeeded"
+    assert captured[-1]["max_tokens"] == expected_max_tokens
+
+
 async def test_remote_agent_retains_transcript_and_reports_http_failure(
     api_server: str,
     repo_root: Path,

--- a/tests/python/test_typed_config.py
+++ b/tests/python/test_typed_config.py
@@ -23,8 +23,10 @@ import pytest
 from nemo_fabric import Fabric
 from nemo_fabric import FabricConfig
 from nemo_fabric import FabricConfigError
+from nemo_fabric import ModelConfig
 from nemo_fabric import RunRequest
 from nemo_fabric import RunResult
+from pydantic import ValidationError
 
 ROOT = Path(__file__).resolve().parents[2]
 SHIM_ADAPTERS = ROOT / "tests" / "fixtures" / "hermes-shim-agent" / "adapters"
@@ -94,6 +96,16 @@ def test_existing_flat_sampling_extensions_load_as_normalized_fields():
     assert model.model_extra is None or "top_p" not in model.model_extra
     assert config.to_mapping()["models"]["default"]["top_p"] == 0.8
     assert config.to_mapping()["models"]["default"]["max_tokens"] == 512
+
+
+def test_model_config_bounds_max_tokens_to_u64():
+    maximum = (1 << 64) - 1
+
+    model = ModelConfig(provider="nvidia", model="test-model", max_tokens=maximum)
+    assert model.max_tokens == maximum
+
+    with pytest.raises(ValidationError, match="less than or equal"):
+        ModelConfig(provider="nvidia", model="test-model", max_tokens=1 << 64)
 
 
 async def resolves_and_diagnoses_typed_config(client: Fabric) -> None:

--- a/tests/python/test_typed_config.py
+++ b/tests/python/test_typed_config.py
@@ -82,6 +82,20 @@ def _shim_adapter_config() -> FabricConfig:
     return FabricConfig.from_mapping(config)
 
 
+def test_existing_flat_sampling_extensions_load_as_normalized_fields():
+    raw = _repository_adapter_config().to_mapping()
+    raw["models"]["default"].update({"top_p": 0.8, "max_tokens": 512})
+
+    config = FabricConfig.from_mapping(raw)
+    model = config.models["default"]
+
+    assert model.top_p == 0.8
+    assert model.max_tokens == 512
+    assert model.model_extra is None or "top_p" not in model.model_extra
+    assert config.to_mapping()["models"]["default"]["top_p"] == 0.8
+    assert config.to_mapping()["models"]["default"]["max_tokens"] == 512
+
+
 async def resolves_and_diagnoses_typed_config(client: Fabric) -> None:
     """Plan and doctor resolve a complete typed config."""
 

--- a/tests/python/test_typed_config.py
+++ b/tests/python/test_typed_config.py
@@ -108,6 +108,17 @@ def test_model_config_bounds_max_tokens_to_u64():
         ModelConfig(provider="nvidia", model="test-model", max_tokens=1 << 64)
 
 
+def test_model_config_preserves_json_integer_compatibility():
+    model = ModelConfig(provider="nvidia", model="test-model", max_tokens=512.0)
+
+    assert model.max_tokens == 512
+
+
+def test_model_config_rejects_boolean_top_p():
+    with pytest.raises(ValidationError, match="valid number"):
+        ModelConfig(provider="nvidia", model="test-model", top_p=True)
+
+
 async def resolves_and_diagnoses_typed_config(client: Fabric) -> None:
     """Plan and doctor resolve a complete typed config."""
 


### PR DESCRIPTION
#### Overview

Normalize `top_p` and `max_tokens` as typed model configuration fields and make them available to adapters that can honor equivalent runtime controls.

Existing flattened JSON and YAML remain wire-compatible: `models.<role>.top_p` and `models.<role>.max_tokens` keep the same serialized shape. Adapter-facing compatibility is also preserved for legacy descriptors that accept either name through `extension_schemas.model`: those values remain in `AgentModelConfig.extensions`, while descriptors that advertise the normalized capability receive typed fields. Python consumers retain attribute access. Direct Rust consumers constructing `ModelConfig` with struct literals must add `top_p: None` and `max_tokens: None` when they do not configure these fields.

#### Details

- Add validated normalized fields to the Rust, Python, TypeScript, and generated schema contracts.
- Advertise and project the fields for Deep Agents, Hermes, mini-SWE-agent, and Remote Agent.
- Preserve legacy adapter projections through descriptor-validated model extensions.
- Map `max_tokens` to each remote protocol's native request field while retaining the legacy Anthropic settings fallback.
- Reject normalized sampling controls when an adapter declares neither normalized support nor a compatible model extension schema.
- Add compatibility, validation, projection, adapter-runtime, and scaffold coverage.
- Update adapter, SDK, integration, generated API, and integration-skill documentation.

#### Validation

- `cargo fmt --all -- --check`
- `just test-rust`
- `cargo clippy -p nemo-fabric-core --lib --locked -- -D warnings`
- `just test-python` (`1366 passed, 18 skipped`)
- `just test-typescript`
- `just docs`
- `uv run pre-commit run --all-files`
- `git diff --check`

#### Where should the reviewer start?

Start with `legacy_model_sampling_extensions` and the compatibility checks in `crates/fabric-core/src/config.rs`, then review the southbound projection in `crates/fabric-core/src/agent_config.rs`. The adapter-specific mappings are in the four Python adapter implementations.

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- Relates to: none

- [x] I confirm this contribution is my own work, or I have the right to submit it under this project's license.
- [x] I searched existing issues and open pull requests, and this does not duplicate existing work.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added optional `top_p` sampling and `max_tokens` response-length settings to model configurations.
  * Added validation for `top_p` values from 0–1 and positive `max_tokens` values.
  * Forwarded these settings across Deep Agents, Hermes, mini-SWE-agent, and Remote Agent integrations with provider-specific request mappings.
  * Added compatibility checks that reject unsupported model settings.

* **Documentation**
  * Updated configuration guides, schemas, API references, and integration examples to cover the new settings, validation rules, and provider-specific behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
