### PR TITLE
chore: bump development version to 0.4.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -167,7 +167,7 @@ checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
 
 [[package]]
 name = "fabric-python"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "nemo-fabric-core",
  "pyo3",
@@ -456,7 +456,7 @@ checksum = "c2a86d3146ed3995b5913c414f6664344b9617457320782e64f0bb44afd49d74"
 
 [[package]]
 name = "nemo-fabric-cli"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "clap",
  "nemo-fabric-core",
@@ -465,7 +465,7 @@ dependencies = [
 
 [[package]]
 name = "nemo-fabric-core"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "jsonschema",
  "schemars",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,13 +14,13 @@ default-members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.3.0"
+version = "0.4.0"
 edition = "2024"
 license = "Apache-2.0"
 repository = "https://github.com/NVIDIA/nemo-fabric"
 
 [workspace.dependencies]
-nemo-fabric-core = { path = "crates/fabric-core", version = "0.3.0" }
+nemo-fabric-core = { path = "crates/fabric-core", version = "0.4.0" }
 
 clap = { version = "4", default-features = false, features = ["derive", "std", "help", "usage", "error-context", "suggestions"] }
 # Validate adapter-owned JSON Schema in Rust while preserving precise instance paths.

--- a/README.md
+++ b/README.md
@@ -214,7 +214,7 @@ selected adapter, and the harness inside an isolated task environment such as a
 Docker container or Daytona sandbox. Adapter discovery and task-path resolution
 occur inside that sandbox.
 
-Install `nemo-fabric[harbor]==0.3.0` in the host environment. For a Hermes
+Install `nemo-fabric[harbor]==0.4.0` in the host environment. For a Hermes
 Agent task, use a task image that installs Hermes Agent according to its
 installation guide, then install `nemo-fabric`, `nemo-fabric-adapters-hermes`,
 and optionally `nemo-fabric[relay]` in that environment. For Claude or Codex

--- a/adapter-contract/python/pyproject.toml
+++ b/adapter-contract/python/pyproject.toml
@@ -9,7 +9,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "nemo-fabric-adapter-contract"
-version = "0.3.0"
+version = "0.4.0"
 description = "Typed Python contract for NeMo Fabric adapters"
 authors = [
   { name = "NVIDIA Corporation" },

--- a/adapter-contract/python/uv.lock
+++ b/adapter-contract/python/uv.lock
@@ -13,7 +13,7 @@ wheels = [
 
 [[package]]
 name = "nemo-fabric-adapter-contract"
-version = "0.3.0"
+version = "0.4.0"
 source = { editable = "." }
 
 [package.optional-dependencies]

--- a/adapter-contract/typescript/package-lock.json
+++ b/adapter-contract/typescript/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "nemo-fabric-adapter-contract",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "nemo-fabric-adapter-contract",
-      "version": "0.3.0",
+      "version": "0.4.0",
       "license": "Apache-2.0",
       "devDependencies": {
         "json-schema-to-typescript": "15.0.4",

--- a/adapter-contract/typescript/package.json
+++ b/adapter-contract/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nemo-fabric-adapter-contract",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "description": "Dependency-free TypeScript types for the NVIDIA NeMo Fabric adapter contract.",
   "license": "Apache-2.0",
   "type": "module",

--- a/adapters/python/claude/pyproject.toml
+++ b/adapters/python/claude/pyproject.toml
@@ -9,7 +9,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "nemo-fabric-adapters-claude"
-version = "0.3.0"
+version = "0.4.0"
 description = "Claude adapter for NeMo Fabric"
 authors = [
   { name = "NVIDIA Corporation" },
@@ -25,8 +25,8 @@ license-files = ["LICENSE"]
 readme = "pypi.md"
 requires-python = ">=3.11"
 dependencies = [
-  "nemo-fabric-adapter-contract == 0.3.0",
-  "nemo-fabric-adapters-common == 0.3.0",
+  "nemo-fabric-adapter-contract == 0.4.0",
+  "nemo-fabric-adapters-common == 0.4.0",
   "tomli-w~=1.2",
 ]
 

--- a/adapters/python/claude/uv.lock
+++ b/adapters/python/claude/uv.lock
@@ -350,7 +350,7 @@ wheels = [
 
 [[package]]
 name = "nemo-fabric-adapter-contract"
-version = "0.3.0"
+version = "0.4.0"
 source = { editable = "../../../adapter-contract/python" }
 
 [package.metadata]
@@ -359,7 +359,7 @@ provides-extras = ["pydantic"]
 
 [[package]]
 name = "nemo-fabric-adapters-claude"
-version = "0.3.0"
+version = "0.4.0"
 source = { editable = "." }
 dependencies = [
     { name = "nemo-fabric-adapter-contract" },
@@ -391,7 +391,7 @@ provides-extras = ["harness", "full"]
 
 [[package]]
 name = "nemo-fabric-adapters-common"
-version = "0.3.0"
+version = "0.4.0"
 source = { editable = "../common" }
 dependencies = [
     { name = "nemo-fabric-adapter-contract" },

--- a/adapters/python/codex/pyproject.toml
+++ b/adapters/python/codex/pyproject.toml
@@ -9,7 +9,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "nemo-fabric-adapters-codex"
-version = "0.3.0"
+version = "0.4.0"
 description = "Codex adapter for NeMo Fabric"
 authors = [
   { name = "NVIDIA Corporation" },
@@ -25,8 +25,8 @@ license-files = ["LICENSE"]
 readme = "pypi.md"
 requires-python = ">=3.11"
 dependencies = [
-  "nemo-fabric-adapter-contract == 0.3.0",
-  "nemo-fabric-adapters-common == 0.3.0",
+  "nemo-fabric-adapter-contract == 0.4.0",
+  "nemo-fabric-adapters-common == 0.4.0",
   "tomli-w~=1.2",
 ]
 

--- a/adapters/python/codex/uv.lock
+++ b/adapters/python/codex/uv.lock
@@ -13,7 +13,7 @@ wheels = [
 
 [[package]]
 name = "nemo-fabric-adapter-contract"
-version = "0.3.0"
+version = "0.4.0"
 source = { editable = "../../../adapter-contract/python" }
 
 [package.metadata]
@@ -22,7 +22,7 @@ provides-extras = ["pydantic"]
 
 [[package]]
 name = "nemo-fabric-adapters-codex"
-version = "0.3.0"
+version = "0.4.0"
 source = { editable = "." }
 dependencies = [
     { name = "nemo-fabric-adapter-contract" },
@@ -54,7 +54,7 @@ provides-extras = ["harness", "full"]
 
 [[package]]
 name = "nemo-fabric-adapters-common"
-version = "0.3.0"
+version = "0.4.0"
 source = { editable = "../common" }
 dependencies = [
     { name = "nemo-fabric-adapter-contract" },

--- a/adapters/python/common/pyproject.toml
+++ b/adapters/python/common/pyproject.toml
@@ -9,7 +9,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "nemo-fabric-adapters-common"
-version = "0.3.0"
+version = "0.4.0"
 description = "Shared Python helpers for NeMo Fabric adapters"
 authors = [
   { name = "NVIDIA Corporation" },
@@ -25,7 +25,7 @@ license-files = ["LICENSE"]
 readme = "pypi.md"
 requires-python = ">=3.11"
 dependencies = [
-  "nemo-fabric-adapter-contract == 0.3.0",
+  "nemo-fabric-adapter-contract == 0.4.0",
 ]
 
 [project.urls]

--- a/adapters/python/common/uv.lock
+++ b/adapters/python/common/uv.lock
@@ -10,7 +10,7 @@ resolution-markers = [
 
 [[package]]
 name = "nemo-fabric-adapter-contract"
-version = "0.3.0"
+version = "0.4.0"
 source = { editable = "../../../adapter-contract/python" }
 
 [package.metadata]
@@ -19,7 +19,7 @@ provides-extras = ["pydantic"]
 
 [[package]]
 name = "nemo-fabric-adapters-common"
-version = "0.3.0"
+version = "0.4.0"
 source = { editable = "." }
 dependencies = [
     { name = "nemo-fabric-adapter-contract" },

--- a/adapters/python/deepagents/pyproject.toml
+++ b/adapters/python/deepagents/pyproject.toml
@@ -9,7 +9,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "nemo-fabric-adapters-deepagents"
-version = "0.3.0"
+version = "0.4.0"
 description = "LangChain Deep Agents adapter for NeMo Fabric"
 authors = [
   { name = "NVIDIA Corporation" },
@@ -25,8 +25,8 @@ license-files = ["LICENSE"]
 readme = "pypi.md"
 requires-python = ">=3.11"
 dependencies = [
-  "nemo-fabric-adapter-contract == 0.3.0",
-  "nemo-fabric-adapters-common == 0.3.0",
+  "nemo-fabric-adapter-contract == 0.4.0",
+  "nemo-fabric-adapters-common == 0.4.0",
   "langchain-mcp-adapters>=0.1,<0.3.0",
   "langchain-openai>=0.3",
   # Requires 3.x: the 2.x line is incompatible with the langgraph core deepagents

--- a/adapters/python/deepagents/uv.lock
+++ b/adapters/python/deepagents/uv.lock
@@ -836,7 +836,7 @@ wheels = [
 
 [[package]]
 name = "nemo-fabric-adapter-contract"
-version = "0.3.0"
+version = "0.4.0"
 source = { editable = "../../../adapter-contract/python" }
 
 [package.metadata]
@@ -845,7 +845,7 @@ provides-extras = ["pydantic"]
 
 [[package]]
 name = "nemo-fabric-adapters-common"
-version = "0.3.0"
+version = "0.4.0"
 source = { editable = "../common" }
 dependencies = [
     { name = "nemo-fabric-adapter-contract" },
@@ -856,7 +856,7 @@ requires-dist = [{ name = "nemo-fabric-adapter-contract", editable = "../../../a
 
 [[package]]
 name = "nemo-fabric-adapters-deepagents"
-version = "0.3.0"
+version = "0.4.0"
 source = { editable = "." }
 dependencies = [
     { name = "langchain-mcp-adapters" },

--- a/adapters/python/hermes/pyproject.toml
+++ b/adapters/python/hermes/pyproject.toml
@@ -9,7 +9,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "nemo-fabric-adapters-hermes"
-version = "0.3.0"
+version = "0.4.0"
 description = "Hermes Agent adapter for NeMo Fabric"
 authors = [
   { name = "NVIDIA Corporation" },
@@ -26,8 +26,8 @@ readme = "pypi.md"
 # Hermes Agent does not currently support Python 3.14 or later.
 requires-python = ">=3.11,<3.14"
 dependencies = [
-  "nemo-fabric-adapter-contract == 0.3.0",
-  "nemo-fabric-adapters-common == 0.3.0",
+  "nemo-fabric-adapter-contract == 0.4.0",
+  "nemo-fabric-adapters-common == 0.4.0",
 ]
 
 [project.optional-dependencies]

--- a/adapters/python/hermes/uv.lock
+++ b/adapters/python/hermes/uv.lock
@@ -4,7 +4,7 @@ requires-python = ">=3.11, <3.14"
 
 [[package]]
 name = "nemo-fabric-adapter-contract"
-version = "0.3.0"
+version = "0.4.0"
 source = { editable = "../../../adapter-contract/python" }
 
 [package.metadata]
@@ -13,7 +13,7 @@ provides-extras = ["pydantic"]
 
 [[package]]
 name = "nemo-fabric-adapters-common"
-version = "0.3.0"
+version = "0.4.0"
 source = { editable = "../common" }
 dependencies = [
     { name = "nemo-fabric-adapter-contract" },
@@ -24,7 +24,7 @@ requires-dist = [{ name = "nemo-fabric-adapter-contract", editable = "../../../a
 
 [[package]]
 name = "nemo-fabric-adapters-hermes"
-version = "0.3.0"
+version = "0.4.0"
 source = { editable = "." }
 dependencies = [
     { name = "nemo-fabric-adapter-contract" },

--- a/adapters/python/mini-swe-agent/pyproject.toml
+++ b/adapters/python/mini-swe-agent/pyproject.toml
@@ -9,7 +9,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "nemo-fabric-adapters-mini-swe-agent"
-version = "0.3.0"
+version = "0.4.0"
 description = "mini-SWE-agent adapter for NeMo Fabric"
 authors = [
   { name = "NVIDIA Corporation" },
@@ -25,8 +25,8 @@ license-files = ["LICENSE"]
 readme = "pypi.md"
 requires-python = ">=3.11"
 dependencies = [
-  "nemo-fabric-adapter-contract == 0.3.0",
-  "nemo-fabric-adapters-common == 0.3.0",
+  "nemo-fabric-adapter-contract == 0.4.0",
+  "nemo-fabric-adapters-common == 0.4.0",
 ]
 
 [project.optional-dependencies]

--- a/adapters/python/mini-swe-agent/uv.lock
+++ b/adapters/python/mini-swe-agent/uv.lock
@@ -1139,7 +1139,7 @@ wheels = [
 
 [[package]]
 name = "nemo-fabric-adapter-contract"
-version = "0.3.0"
+version = "0.4.0"
 source = { editable = "../../../adapter-contract/python" }
 
 [package.metadata]
@@ -1148,7 +1148,7 @@ provides-extras = ["pydantic"]
 
 [[package]]
 name = "nemo-fabric-adapters-common"
-version = "0.3.0"
+version = "0.4.0"
 source = { editable = "../common" }
 dependencies = [
     { name = "nemo-fabric-adapter-contract" },
@@ -1159,7 +1159,7 @@ requires-dist = [{ name = "nemo-fabric-adapter-contract", editable = "../../../a
 
 [[package]]
 name = "nemo-fabric-adapters-mini-swe-agent"
-version = "0.3.0"
+version = "0.4.0"
 source = { editable = "." }
 dependencies = [
     { name = "nemo-fabric-adapter-contract" },

--- a/adapters/python/nooa/pyproject.toml
+++ b/adapters/python/nooa/pyproject.toml
@@ -9,7 +9,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "nemo-fabric-adapters-nooa"
-version = "0.3.0"
+version = "0.4.0"
 description = "NOOA adapters for NeMo Fabric"
 authors = [
   { name = "NVIDIA Corporation" },
@@ -25,8 +25,8 @@ license-files = ["LICENSE"]
 readme = "pypi.md"
 requires-python = ">=3.12,<3.14"
 dependencies = [
-  "nemo-fabric-adapter-contract == 0.3.0",
-  "nemo-fabric-adapters-common == 0.3.0",
+  "nemo-fabric-adapter-contract == 0.4.0",
+  "nemo-fabric-adapters-common == 0.4.0",
 ]
 
 [project.optional-dependencies]

--- a/adapters/python/nooa/uv.lock
+++ b/adapters/python/nooa/uv.lock
@@ -653,7 +653,7 @@ wheels = [
 
 [[package]]
 name = "nemo-fabric-adapter-contract"
-version = "0.3.0"
+version = "0.4.0"
 source = { editable = "../../../adapter-contract/python" }
 
 [package.metadata]
@@ -662,7 +662,7 @@ provides-extras = ["pydantic"]
 
 [[package]]
 name = "nemo-fabric-adapters-common"
-version = "0.3.0"
+version = "0.4.0"
 source = { editable = "../common" }
 dependencies = [
     { name = "nemo-fabric-adapter-contract" },
@@ -673,7 +673,7 @@ requires-dist = [{ name = "nemo-fabric-adapter-contract", editable = "../../../a
 
 [[package]]
 name = "nemo-fabric-adapters-nooa"
-version = "0.3.0"
+version = "0.4.0"
 source = { editable = "." }
 dependencies = [
     { name = "nemo-fabric-adapter-contract" },

--- a/adapters/python/remote-agent/pyproject.toml
+++ b/adapters/python/remote-agent/pyproject.toml
@@ -9,7 +9,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "nemo-fabric-adapters-remote-agent"
-version = "0.3.0"
+version = "0.4.0"
 description = "Remote agent adapter for NeMo Fabric"
 authors = [
   { name = "NVIDIA Corporation" },
@@ -25,8 +25,8 @@ license-files = ["LICENSE"]
 readme = "pypi.md"
 requires-python = ">=3.11"
 dependencies = [
-  "nemo-fabric-adapter-contract == 0.3.0",
-  "nemo-fabric-adapters-common == 0.3.0",
+  "nemo-fabric-adapter-contract == 0.4.0",
+  "nemo-fabric-adapters-common == 0.4.0",
   "httpx[http2]~=0.28",
 ]
 

--- a/adapters/python/remote-agent/uv.lock
+++ b/adapters/python/remote-agent/uv.lock
@@ -108,7 +108,7 @@ wheels = [
 
 [[package]]
 name = "nemo-fabric-adapter-contract"
-version = "0.3.0"
+version = "0.4.0"
 source = { editable = "../../../adapter-contract/python" }
 
 [package.metadata]
@@ -117,7 +117,7 @@ provides-extras = ["pydantic"]
 
 [[package]]
 name = "nemo-fabric-adapters-common"
-version = "0.3.0"
+version = "0.4.0"
 source = { editable = "../common" }
 dependencies = [
     { name = "nemo-fabric-adapter-contract" },
@@ -128,7 +128,7 @@ requires-dist = [{ name = "nemo-fabric-adapter-contract", editable = "../../../a
 
 [[package]]
 name = "nemo-fabric-adapters-remote-agent"
-version = "0.3.0"
+version = "0.4.0"
 source = { editable = "." }
 dependencies = [
     { name = "httpx", extra = ["http2"] },

--- a/adapters/typescript/common/package.json
+++ b/adapters/typescript/common/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nemo-fabric-adapters-common",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "description": "Shared TypeScript lifecycle host for NVIDIA NeMo Fabric adapters.",
   "license": "Apache-2.0",
   "type": "module",
@@ -43,7 +43,7 @@
   },
   "dependencies": {
     "ajv": "8.20.0",
-    "nemo-fabric-adapter-contract": "0.3.0"
+    "nemo-fabric-adapter-contract": "0.4.0"
   },
   "devDependencies": {
     "@types/node": "22.19.19",

--- a/adapters/typescript/package-lock.json
+++ b/adapters/typescript/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "nemo-fabric-typescript-adapters",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "nemo-fabric-typescript-adapters",
-      "version": "0.3.0",
+      "version": "0.4.0",
       "license": "Apache-2.0",
       "workspaces": [
         "common",
@@ -21,7 +21,7 @@
     },
     "../../adapter-contract/typescript": {
       "name": "nemo-fabric-adapter-contract",
-      "version": "0.3.0",
+      "version": "0.4.0",
       "license": "Apache-2.0",
       "devDependencies": {
         "json-schema-to-typescript": "15.0.4",
@@ -33,11 +33,11 @@
     },
     "common": {
       "name": "nemo-fabric-adapters-common",
-      "version": "0.3.0",
+      "version": "0.4.0",
       "license": "Apache-2.0",
       "dependencies": {
         "ajv": "8.20.0",
-        "nemo-fabric-adapter-contract": "0.3.0"
+        "nemo-fabric-adapter-contract": "0.4.0"
       },
       "devDependencies": {
         "@types/node": "22.19.19",
@@ -3339,12 +3339,12 @@
     },
     "pi": {
       "name": "nemo-fabric-adapters-pi",
-      "version": "0.3.0",
+      "version": "0.4.0",
       "license": "Apache-2.0",
       "dependencies": {
         "jiti": "2.7.0",
-        "nemo-fabric-adapter-contract": "0.3.0",
-        "nemo-fabric-adapters-common": "0.3.0"
+        "nemo-fabric-adapter-contract": "0.4.0",
+        "nemo-fabric-adapters-common": "0.4.0"
       },
       "bin": {
         "nemo-fabric-adapters-pi": "dist/cli.js"

--- a/adapters/typescript/package.json
+++ b/adapters/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nemo-fabric-typescript-adapters",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "description": "TypeScript adapter workspace for NVIDIA NeMo Fabric.",
   "license": "Apache-2.0",
   "private": true,

--- a/adapters/typescript/pi/package.json
+++ b/adapters/typescript/pi/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nemo-fabric-adapters-pi",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "description": "Pi SDK harness adapter for NVIDIA NeMo Fabric.",
   "license": "Apache-2.0",
   "type": "module",
@@ -43,8 +43,8 @@
   },
   "dependencies": {
     "jiti": "2.7.0",
-    "nemo-fabric-adapter-contract": "0.3.0",
-    "nemo-fabric-adapters-common": "0.3.0"
+    "nemo-fabric-adapter-contract": "0.4.0",
+    "nemo-fabric-adapters-common": "0.4.0"
   },
   "peerDependencies": {
     "@earendil-works/pi-ai": "^0.84.2",

--- a/examples/harbor/README.md
+++ b/examples/harbor/README.md
@@ -68,16 +68,16 @@ not read task paths; adapter and asset resolution is deferred to
 
 Use the following package requirements for the two-environment model. Pin the
 host and task packages to the same NeMo Fabric release. These examples use
-version `0.3.0`.
+version `0.4.0`.
 
 | Environment | Required Dependencies | Purpose |
 | --- | --- | --- |
-| Harbor host | `nemo-fabric[harbor]==0.3.0` | Harbor CLI, `FabricAgent`, and typed `FabricConfig` construction |
-| Claude task without Relay | `nemo-fabric[claude]==0.3.0` | NeMo Fabric runner, Claude adapter, and supported Claude harness |
-| Claude task with Relay | `nemo-fabric[claude]==0.3.0` plus a NeMo Relay CLI in the `>=0.7.2,<0.8` range on `PATH` | NeMo Fabric runner, Claude adapter and harness, and the adapter-managed Relay gateway and hooks |
-| Hermes Agent task with Relay | Task image with Hermes Agent, `nemo-fabric==0.3.0`, `nemo-fabric-adapters-hermes==0.3.0`, and `nemo-relay>=0.7.2,<0.8` | NeMo Fabric runner, preinstalled Hermes Agent and adapter, and the NeMo Relay Python package |
-| NOOA BenchAgent task | `nemo-fabric==0.3.0` and `nemo-fabric-adapters-nooa[harness]==0.3.0` | NeMo Fabric runner, the packaged BenchAgent adapter and descriptors, and tested NOOA harness packages |
-| NOOA BenchAgent task with Relay | `nemo-fabric==0.3.0` and `nemo-fabric-adapters-nooa[full]==0.3.0` | Baseline dependencies plus compatible Relay telemetry support |
+| Harbor host | `nemo-fabric[harbor]==0.4.0` | Harbor CLI, `FabricAgent`, and typed `FabricConfig` construction |
+| Claude task without Relay | `nemo-fabric[claude]==0.4.0` | NeMo Fabric runner, Claude adapter, and supported Claude harness |
+| Claude task with Relay | `nemo-fabric[claude]==0.4.0` plus a NeMo Relay CLI in the `>=0.7.2,<0.8` range on `PATH` | NeMo Fabric runner, Claude adapter and harness, and the adapter-managed Relay gateway and hooks |
+| Hermes Agent task with Relay | Task image with Hermes Agent, `nemo-fabric==0.4.0`, `nemo-fabric-adapters-hermes==0.4.0`, and `nemo-relay>=0.7.2,<0.8` | NeMo Fabric runner, preinstalled Hermes Agent and adapter, and the NeMo Relay Python package |
+| NOOA BenchAgent task | `nemo-fabric==0.4.0` and `nemo-fabric-adapters-nooa[harness]==0.4.0` | NeMo Fabric runner, the packaged BenchAgent adapter and descriptors, and tested NOOA harness packages |
+| NOOA BenchAgent task with Relay | `nemo-fabric==0.4.0` and `nemo-fabric-adapters-nooa[full]==0.4.0` | Baseline dependencies plus compatible Relay telemetry support |
 
 The `nemo-fabric` package installs the runtime. The `relay` extra installs the
 NeMo Relay Python package, not the CLI required by Claude.

--- a/examples/harbor/swebench/README.md
+++ b/examples/harbor/swebench/README.md
@@ -27,7 +27,7 @@ cd "$(git rev-parse --show-toplevel)"
 
 export FABRIC_AGENT='nemo_fabric.integrations.harbor:FabricAgent'
 export FABRIC_BUNDLE="$PWD/examples/harbor/swebench"
-export FABRIC_PACKAGE='nemo-fabric[claude,hermes-agent,relay]==0.3.0'
+export FABRIC_PACKAGE='nemo-fabric[claude,hermes-agent,relay]==0.4.0'
 export RUNS_DIR="$PWD/.tmp/harbor/fabric-swebench"
 
 curl -fsSL https://raw.githubusercontent.com/NVIDIA/NeMo-Relay/main/install.sh |

--- a/examples/notebooks/01_quickstart.ipynb
+++ b/examples/notebooks/01_quickstart.ipynb
@@ -106,7 +106,7 @@
     "%%bash\n",
     "set -euo pipefail\n",
     "\n",
-    "NEMO_FABRIC_VERSION=\"0.3.0\"\n",
+    "NEMO_FABRIC_VERSION=\"0.4.0\"\n",
     "\n",
     "if [ \"$(\"$FABRIC_PYTHON\" -c 'from importlib.metadata import version; print(version(\"nemo-fabric\"))' 2>/dev/null || true)\" != \"$NEMO_FABRIC_VERSION\" ]; then\n",
     "    \"$FABRIC_PYTHON\" -m pip install \"nemo-fabric==$NEMO_FABRIC_VERSION\"\n",

--- a/examples/notebooks/02_variations.ipynb
+++ b/examples/notebooks/02_variations.ipynb
@@ -95,7 +95,7 @@
     "%%bash\n",
     "set -euo pipefail\n",
     "\n",
-    "NEMO_FABRIC_VERSION=\"0.3.0\"\n",
+    "NEMO_FABRIC_VERSION=\"0.4.0\"\n",
     "\"$FABRIC_PYTHON\" -m pip install \"nemo-fabric[claude,codex,deepagents,relay]==$NEMO_FABRIC_VERSION\"\n",
     "\n",
     "if [ \"$(\"$HERMES_PYTHON\" -c 'from importlib.metadata import version; print(version(\"nemo-fabric-adapters-hermes\"))' 2>/dev/null || true)\" != \"$NEMO_FABRIC_VERSION\" ]; then\n",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ description = "Development environment for NVIDIA NeMo Fabric"
 requires-python = ">=3.11"
 dependencies = [
   "nemo-fabric",
-  "nemo-fabric-runtime == 0.3.0",
+  "nemo-fabric-runtime == 0.4.0",
 ]
 
 [project.optional-dependencies]

--- a/scripts/ci/set_python_project_versions.py
+++ b/scripts/ci/set_python_project_versions.py
@@ -19,7 +19,7 @@ INTERNAL_PIN_PATTERN = re.compile(
 def set_python_project_versions(root: Path, version: str) -> None:
     project_paths = (
         root / "sdk" / "python" / "nemo-fabric" / "pyproject.toml",
-        root / "sdk" / "python" / "collector" / "pyproject.toml",
+        root / "sdk" / "python" / "nemo-fabric-collector" / "pyproject.toml",
         root / "adapter-contract" / "python" / "pyproject.toml",
         *sorted((root / "adapters" / "python").glob("*/pyproject.toml")),
     )

--- a/sdk/python/nemo-fabric-collector/pyproject.toml
+++ b/sdk/python/nemo-fabric-collector/pyproject.toml
@@ -7,7 +7,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "nemo-fabric-collector"
-version = "0.3.0"
+version = "0.4.0"
 description = "Standalone collector for NVIDIA NeMo Fabric"
 authors = [{ name = "NVIDIA Corporation" }]
 license = "Apache-2.0"

--- a/sdk/python/nemo-fabric-collector/uv.lock
+++ b/sdk/python/nemo-fabric-collector/uv.lock
@@ -44,7 +44,7 @@ wheels = [
 
 [[package]]
 name = "nemo-fabric-collector"
-version = "0.3.0"
+version = "0.4.0"
 source = { editable = "." }
 dependencies = [
     { name = "starlette" },

--- a/sdk/python/nemo-fabric-runtime/pyproject.toml
+++ b/sdk/python/nemo-fabric-runtime/pyproject.toml
@@ -30,7 +30,7 @@ dynamic = ["version"]
 
 [project.optional-dependencies]
 streaming = [
-  "nemo-fabric-collector == 0.3.0",
+  "nemo-fabric-collector == 0.4.0",
 ]
 
 [project.urls]

--- a/sdk/python/nemo-fabric-runtime/uv.lock
+++ b/sdk/python/nemo-fabric-runtime/uv.lock
@@ -90,7 +90,7 @@ wheels = [
 
 [[package]]
 name = "nemo-fabric-collector"
-version = "0.3.0"
+version = "0.4.0"
 source = { editable = "../nemo-fabric-collector" }
 dependencies = [
     { name = "starlette" },

--- a/sdk/python/nemo-fabric/pyproject.toml
+++ b/sdk/python/nemo-fabric/pyproject.toml
@@ -9,7 +9,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "nemo-fabric"
-version = "0.3.0"
+version = "0.4.0"
 description = "Python SDK distribution for NeMo Fabric"
 authors = [
   { name = "NVIDIA Corporation" },
@@ -25,7 +25,7 @@ license-files = ["LICENSE"]
 readme = "pypi.md"
 requires-python = ">=3.11"
 dependencies = [
-  "nemo-fabric-runtime == 0.3.0",
+  "nemo-fabric-runtime == 0.4.0",
 ]
 
 [project.urls]
@@ -53,31 +53,31 @@ nemo-fabric-adapters-remote-agent = { path = "../../../adapters/python/remote-ag
 [project.optional-dependencies]
 
 claude = [
-  "nemo-fabric-adapters-claude[harness] == 0.3.0",
+  "nemo-fabric-adapters-claude[harness] == 0.4.0",
 ]
 
 codex = [
-  "nemo-fabric-adapters-codex[harness] == 0.3.0",
+  "nemo-fabric-adapters-codex[harness] == 0.4.0",
 ]
 
 streaming = [
-  "nemo-fabric-runtime[streaming] == 0.3.0",
+  "nemo-fabric-runtime[streaming] == 0.4.0",
 ]
 
 deepagents = [
-  "nemo-fabric-adapters-deepagents[harness] == 0.3.0",
+  "nemo-fabric-adapters-deepagents[harness] == 0.4.0",
 ]
 
 mini-swe-agent = [
-  "nemo-fabric-adapters-mini-swe-agent[harness] == 0.3.0",
+  "nemo-fabric-adapters-mini-swe-agent[harness] == 0.4.0",
 ]
 
 nooa = [
-  "nemo-fabric-adapters-nooa[harness] == 0.3.0; python_version >= '3.12' and python_version < '3.14'",
+  "nemo-fabric-adapters-nooa[harness] == 0.4.0; python_version >= '3.12' and python_version < '3.14'",
 ]
 
 remote-agent = [
-  "nemo-fabric-adapters-remote-agent[harness] == 0.3.0",
+  "nemo-fabric-adapters-remote-agent[harness] == 0.4.0",
 ]
 
 harbor = [
@@ -86,7 +86,7 @@ harbor = [
 ]
 
 hermes-agent = [
-  "nemo-fabric-adapters-hermes == 0.3.0; python_version < '3.14'",
+  "nemo-fabric-adapters-hermes == 0.4.0; python_version < '3.14'",
 ]
 
 relay = [

--- a/sdk/python/nemo-fabric/uv.lock
+++ b/sdk/python/nemo-fabric/uv.lock
@@ -226,9 +226,9 @@ name = "boto3"
 version = "1.43.91"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "botocore" },
-    { name = "jmespath" },
-    { name = "s3transfer" },
+    { name = "botocore", marker = "python_full_version >= '3.12' and python_full_version < '3.14'" },
+    { name = "jmespath", marker = "python_full_version >= '3.12' and python_full_version < '3.14'" },
+    { name = "s3transfer", marker = "python_full_version >= '3.12' and python_full_version < '3.14'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/42/76/e5c5fb601b09273599bf9c1a678ea2bc645385e758fbc66a36c9614b6324/boto3-1.43.91.tar.gz", hash = "sha256:98643e500883bf6fcd13d04bb19da983bf97e5f1c600fc11470ce45437fa96b4", size = 112693, upload-time = "2026-09-09T19:24:38.927Z" }
 wheels = [
@@ -240,9 +240,9 @@ name = "botocore"
 version = "1.43.91"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "jmespath" },
-    { name = "python-dateutil" },
-    { name = "urllib3" },
+    { name = "jmespath", marker = "python_full_version >= '3.12' and python_full_version < '3.14'" },
+    { name = "python-dateutil", marker = "python_full_version >= '3.12' and python_full_version < '3.14'" },
+    { name = "urllib3", marker = "python_full_version >= '3.12' and python_full_version < '3.14'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/9a/1e/c6d26cb1124799e2bee54854813b02aa8a813c57335f97b0b8ed50f902ff/botocore-1.43.91.tar.gz", hash = "sha256:0f12bceb8c5d90a0c60f326e883bf674ded8c7d7c18ee0b559843b3a6c52f2ad", size = 16089153, upload-time = "2026-09-09T19:24:34.426Z" }
 wheels = [
@@ -659,7 +659,7 @@ name = "deprecation"
 version = "2.1.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "packaging" },
+    { name = "packaging", marker = "python_full_version >= '3.12'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/5a/d3/8ae2869247df154b64c1884d7346d412fed0c49df84db635aab2d1c40e62/deprecation-2.1.0.tar.gz", hash = "sha256:72b3bde64e5d778694b0cf68178aed03d15e15477116add3fb773e581f9518ff", size = 173788, upload-time = "2020-04-20T14:23:38.738Z" }
 wheels = [
@@ -680,7 +680,7 @@ name = "dirhash"
 version = "0.5.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "scantree" },
+    { name = "scantree", marker = "python_full_version >= '3.12'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/1d/70/49f93897f3a4f7ab5f20a854ebc91aad47854e9fb2cd169e3a4452fa3f5e/dirhash-0.5.0.tar.gz", hash = "sha256:e60760f0ab2e935d8cb088923ea2c6492398dca42cec785df778985fd4cd5386", size = 21377, upload-time = "2024-08-03T22:14:13.322Z" }
 wheels = [
@@ -710,11 +710,11 @@ name = "fastapi"
 version = "0.141.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "annotated-doc" },
-    { name = "pydantic" },
-    { name = "starlette" },
-    { name = "typing-extensions" },
-    { name = "typing-inspection" },
+    { name = "annotated-doc", marker = "python_full_version >= '3.12'" },
+    { name = "pydantic", marker = "python_full_version >= '3.12'" },
+    { name = "starlette", marker = "python_full_version >= '3.12'" },
+    { name = "typing-extensions", marker = "python_full_version >= '3.12'" },
+    { name = "typing-inspection", marker = "python_full_version >= '3.12'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/8a/02/91e3416a8fdd715abb903a952a6bec7cdd8d14eed55d415fc8595524c319/fastapi-0.141.1.tar.gz", hash = "sha256:e8822fc40db1e1858054d7a949a888695bc9bdce70139178e33bd2871a453ca1", size = 425799, upload-time = "2026-07-29T17:18:05.568Z" }
 wheels = [
@@ -976,28 +976,28 @@ name = "harbor"
 version = "0.18.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "dirhash" },
-    { name = "fastapi" },
-    { name = "filelock" },
-    { name = "httpx" },
-    { name = "jinja2" },
+    { name = "dirhash", marker = "python_full_version >= '3.12'" },
+    { name = "fastapi", marker = "python_full_version >= '3.12'" },
+    { name = "filelock", marker = "python_full_version >= '3.12'" },
+    { name = "httpx", marker = "python_full_version >= '3.12'" },
+    { name = "jinja2", marker = "python_full_version >= '3.12'" },
     { name = "litellm", version = "1.96.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.14'" },
-    { name = "litellm", version = "1.100.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.14'" },
-    { name = "packaging" },
-    { name = "pathspec" },
-    { name = "platformdirs" },
-    { name = "pydantic" },
-    { name = "pyjwt" },
-    { name = "python-dotenv" },
-    { name = "pyyaml" },
-    { name = "requests" },
-    { name = "rich" },
-    { name = "shortuuid" },
-    { name = "supabase" },
-    { name = "tenacity" },
-    { name = "toml" },
-    { name = "typer" },
-    { name = "uvicorn" },
+    { name = "litellm", version = "1.100.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12' and python_full_version < '3.14'" },
+    { name = "packaging", marker = "python_full_version >= '3.12'" },
+    { name = "pathspec", marker = "python_full_version >= '3.12'" },
+    { name = "platformdirs", marker = "python_full_version >= '3.12'" },
+    { name = "pydantic", marker = "python_full_version >= '3.12'" },
+    { name = "pyjwt", marker = "python_full_version >= '3.12'" },
+    { name = "python-dotenv", marker = "python_full_version >= '3.12'" },
+    { name = "pyyaml", marker = "python_full_version >= '3.12'" },
+    { name = "requests", marker = "python_full_version >= '3.12'" },
+    { name = "rich", marker = "python_full_version >= '3.12'" },
+    { name = "shortuuid", marker = "python_full_version >= '3.12'" },
+    { name = "supabase", marker = "python_full_version >= '3.12'" },
+    { name = "tenacity", marker = "python_full_version >= '3.12'" },
+    { name = "toml", marker = "python_full_version >= '3.12'" },
+    { name = "typer", marker = "python_full_version >= '3.12'" },
+    { name = "uvicorn", marker = "python_full_version >= '3.12'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/38/24/7222433d3b9f665db1759456c281a9c136b921300be5d7af269f183ee59e/harbor-0.18.0.tar.gz", hash = "sha256:9b918b99ec38b4e16db7e0b797dcebf92bfc8be9d9ba22a2d2ed6ebb8feb38df", size = 1535447, upload-time = "2026-07-07T20:29:46.878Z" }
 wheels = [
@@ -1511,19 +1511,19 @@ resolution-markers = [
     "python_full_version < '3.12' and sys_platform != 'emscripten' and sys_platform != 'win32'",
 ]
 dependencies = [
-    { name = "aiohttp" },
-    { name = "click" },
-    { name = "fastuuid" },
-    { name = "httpx" },
-    { name = "importlib-metadata" },
-    { name = "jinja2" },
-    { name = "jsonschema" },
-    { name = "openai" },
-    { name = "pydantic" },
-    { name = "pydantic-settings" },
-    { name = "python-dotenv" },
-    { name = "tiktoken" },
-    { name = "tokenizers" },
+    { name = "aiohttp", marker = "python_full_version < '3.12' or python_full_version >= '3.14'" },
+    { name = "click", marker = "python_full_version < '3.12' or python_full_version >= '3.14'" },
+    { name = "fastuuid", marker = "python_full_version < '3.12' or python_full_version >= '3.14'" },
+    { name = "httpx", marker = "python_full_version < '3.12' or python_full_version >= '3.14'" },
+    { name = "importlib-metadata", marker = "python_full_version < '3.12' or python_full_version >= '3.14'" },
+    { name = "jinja2", marker = "python_full_version < '3.12' or python_full_version >= '3.14'" },
+    { name = "jsonschema", marker = "python_full_version < '3.12' or python_full_version >= '3.14'" },
+    { name = "openai", marker = "python_full_version < '3.12' or python_full_version >= '3.14'" },
+    { name = "pydantic", marker = "python_full_version < '3.12' or python_full_version >= '3.14'" },
+    { name = "pydantic-settings", marker = "python_full_version < '3.12' or python_full_version >= '3.14'" },
+    { name = "python-dotenv", marker = "python_full_version < '3.12' or python_full_version >= '3.14'" },
+    { name = "tiktoken", marker = "python_full_version < '3.12' or python_full_version >= '3.14'" },
+    { name = "tokenizers", marker = "python_full_version < '3.12' or python_full_version >= '3.14'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/79/fe/d03be8a6be6914fabacef29457a2b3d02128c52c448cc6f3019b8e63488b/litellm-1.96.2.tar.gz", hash = "sha256:80d477ae092b05ce023b5084542cb3cb75999b52b1dd2e4d834fb348effc9399", size = 17682558, upload-time = "2026-08-11T21:12:24.117Z" }
 wheels = [
@@ -1546,20 +1546,20 @@ resolution-markers = [
     "python_full_version >= '3.12' and python_full_version < '3.14' and sys_platform != 'emscripten' and sys_platform != 'win32'",
 ]
 dependencies = [
-    { name = "aiohttp" },
-    { name = "boto3" },
-    { name = "click" },
-    { name = "fastuuid" },
-    { name = "httpx" },
-    { name = "importlib-metadata" },
-    { name = "jinja2" },
-    { name = "jsonschema" },
-    { name = "openai" },
-    { name = "pydantic" },
-    { name = "pydantic-settings" },
-    { name = "python-dotenv" },
-    { name = "tiktoken" },
-    { name = "tokenizers" },
+    { name = "aiohttp", marker = "python_full_version >= '3.12' and python_full_version < '3.14'" },
+    { name = "boto3", marker = "python_full_version >= '3.12' and python_full_version < '3.14'" },
+    { name = "click", marker = "python_full_version >= '3.12' and python_full_version < '3.14'" },
+    { name = "fastuuid", marker = "python_full_version >= '3.12' and python_full_version < '3.14'" },
+    { name = "httpx", marker = "python_full_version >= '3.12' and python_full_version < '3.14'" },
+    { name = "importlib-metadata", marker = "python_full_version >= '3.12' and python_full_version < '3.14'" },
+    { name = "jinja2", marker = "python_full_version >= '3.12' and python_full_version < '3.14'" },
+    { name = "jsonschema", marker = "python_full_version >= '3.12' and python_full_version < '3.14'" },
+    { name = "openai", marker = "python_full_version >= '3.12' and python_full_version < '3.14'" },
+    { name = "pydantic", marker = "python_full_version >= '3.12' and python_full_version < '3.14'" },
+    { name = "pydantic-settings", marker = "python_full_version >= '3.12' and python_full_version < '3.14'" },
+    { name = "python-dotenv", marker = "python_full_version >= '3.12' and python_full_version < '3.14'" },
+    { name = "tiktoken", marker = "python_full_version >= '3.12' and python_full_version < '3.14'" },
+    { name = "tokenizers", marker = "python_full_version >= '3.12' and python_full_version < '3.14'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/48/a5/f78d2fafa950040f833efd41dd5690598afeef0c9c4657171372573698aa/litellm-1.100.1.tar.gz", hash = "sha256:d24b5fbdeb1f0b5c0a6f7f0caf7b6aa79b69c704b90daca57e3ce7d50a9d6bf4", size = 17330008, upload-time = "2026-09-10T01:42:53.328Z" }
 wheels = [
@@ -1874,7 +1874,7 @@ wheels = [
 
 [[package]]
 name = "nemo-fabric"
-version = "0.3.0"
+version = "0.4.0"
 source = { editable = "." }
 dependencies = [
     { name = "nemo-fabric-runtime" },
@@ -1932,7 +1932,7 @@ provides-extras = ["claude", "codex", "streaming", "deepagents", "mini-swe-agent
 
 [[package]]
 name = "nemo-fabric-adapter-contract"
-version = "0.3.0"
+version = "0.4.0"
 source = { editable = "../../../adapter-contract/python" }
 
 [package.metadata]
@@ -1941,7 +1941,7 @@ provides-extras = ["pydantic"]
 
 [[package]]
 name = "nemo-fabric-adapters-claude"
-version = "0.3.0"
+version = "0.4.0"
 source = { editable = "../../../adapters/python/claude" }
 dependencies = [
     { name = "nemo-fabric-adapter-contract" },
@@ -1969,7 +1969,7 @@ provides-extras = ["harness", "full"]
 
 [[package]]
 name = "nemo-fabric-adapters-codex"
-version = "0.3.0"
+version = "0.4.0"
 source = { editable = "../../../adapters/python/codex" }
 dependencies = [
     { name = "nemo-fabric-adapter-contract" },
@@ -1997,7 +1997,7 @@ provides-extras = ["harness", "full"]
 
 [[package]]
 name = "nemo-fabric-adapters-common"
-version = "0.3.0"
+version = "0.4.0"
 source = { editable = "../../../adapters/python/common" }
 dependencies = [
     { name = "nemo-fabric-adapter-contract" },
@@ -2008,7 +2008,7 @@ requires-dist = [{ name = "nemo-fabric-adapter-contract", editable = "../../../a
 
 [[package]]
 name = "nemo-fabric-adapters-deepagents"
-version = "0.3.0"
+version = "0.4.0"
 source = { editable = "../../../adapters/python/deepagents" }
 dependencies = [
     { name = "langchain-mcp-adapters" },
@@ -2045,11 +2045,11 @@ provides-extras = ["harness", "relay", "full"]
 
 [[package]]
 name = "nemo-fabric-adapters-hermes"
-version = "0.3.0"
+version = "0.4.0"
 source = { editable = "../../../adapters/python/hermes" }
 dependencies = [
-    { name = "nemo-fabric-adapter-contract" },
-    { name = "nemo-fabric-adapters-common" },
+    { name = "nemo-fabric-adapter-contract", marker = "python_full_version < '3.14'" },
+    { name = "nemo-fabric-adapters-common", marker = "python_full_version < '3.14'" },
 ]
 
 [package.metadata]
@@ -2063,7 +2063,7 @@ provides-extras = ["relay", "full"]
 
 [[package]]
 name = "nemo-fabric-adapters-mini-swe-agent"
-version = "0.3.0"
+version = "0.4.0"
 source = { editable = "../../../adapters/python/mini-swe-agent" }
 dependencies = [
     { name = "nemo-fabric-adapter-contract" },
@@ -2088,18 +2088,18 @@ provides-extras = ["harness", "relay", "full"]
 
 [[package]]
 name = "nemo-fabric-adapters-nooa"
-version = "0.3.0"
+version = "0.4.0"
 source = { editable = "../../../adapters/python/nooa" }
 dependencies = [
-    { name = "nemo-fabric-adapter-contract" },
-    { name = "nemo-fabric-adapters-common" },
+    { name = "nemo-fabric-adapter-contract", marker = "python_full_version >= '3.12' and python_full_version < '3.14'" },
+    { name = "nemo-fabric-adapters-common", marker = "python_full_version >= '3.12' and python_full_version < '3.14'" },
 ]
 
 [package.optional-dependencies]
 harness = [
-    { name = "nooa" },
-    { name = "nooa-bench" },
-    { name = "nooa-cli" },
+    { name = "nooa", marker = "python_full_version >= '3.12' and python_full_version < '3.14'" },
+    { name = "nooa-bench", marker = "python_full_version >= '3.12' and python_full_version < '3.14'" },
+    { name = "nooa-cli", marker = "python_full_version >= '3.12' and python_full_version < '3.14'" },
 ]
 
 [package.metadata]
@@ -2119,7 +2119,7 @@ provides-extras = ["harness", "relay", "full"]
 
 [[package]]
 name = "nemo-fabric-adapters-remote-agent"
-version = "0.3.0"
+version = "0.4.0"
 source = { editable = "../../../adapters/python/remote-agent" }
 dependencies = [
     { name = "httpx", extra = ["http2"] },
@@ -2137,7 +2137,7 @@ provides-extras = ["harness", "full"]
 
 [[package]]
 name = "nemo-fabric-collector"
-version = "0.3.0"
+version = "0.4.0"
 source = { editable = "../nemo-fabric-collector" }
 dependencies = [
     { name = "starlette" },
@@ -2207,10 +2207,10 @@ name = "nooa"
 version = "0.0.10"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "httpx" },
-    { name = "litellm", version = "1.100.1", source = { registry = "https://pypi.org/simple" } },
-    { name = "openinference-instrumentation-litellm" },
-    { name = "pydantic" },
+    { name = "httpx", marker = "python_full_version >= '3.12' and python_full_version < '3.14'" },
+    { name = "litellm", version = "1.100.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12' and python_full_version < '3.14'" },
+    { name = "openinference-instrumentation-litellm", marker = "python_full_version >= '3.12' and python_full_version < '3.14'" },
+    { name = "pydantic", marker = "python_full_version >= '3.12' and python_full_version < '3.14'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/27/90/f07e44b57d10e3687caba9b18a1b2064e7c9602f85fdeb9c9b0a4843aeba/nooa-0.0.10.tar.gz", hash = "sha256:91d44a48610b116561d2ddc42ed80a7c4011c7324a67236300d2fe78182d3c78", size = 3504802, upload-time = "2026-09-04T06:04:36.719Z" }
 wheels = [
@@ -2222,9 +2222,9 @@ name = "nooa-bench"
 version = "0.0.10"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "click" },
-    { name = "nooa" },
-    { name = "nooa-cli" },
+    { name = "click", marker = "python_full_version >= '3.12' and python_full_version < '3.14'" },
+    { name = "nooa", marker = "python_full_version >= '3.12' and python_full_version < '3.14'" },
+    { name = "nooa-cli", marker = "python_full_version >= '3.12' and python_full_version < '3.14'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/c0/60/7a1fcf359ee503c1edfc66fd83f6e41f3444302d05aa4f870c74363117ff/nooa_bench-0.0.10.tar.gz", hash = "sha256:2838fc23172f12d4fb2069b5cee8e223e86429800db02f3132a2ea4383b829f0", size = 18489, upload-time = "2026-09-04T06:04:34.104Z" }
 wheels = [
@@ -2236,9 +2236,9 @@ name = "nooa-cli"
 version = "0.0.10"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "click" },
-    { name = "nooa" },
-    { name = "pyyaml" },
+    { name = "click", marker = "python_full_version >= '3.12' and python_full_version < '3.14'" },
+    { name = "nooa", marker = "python_full_version >= '3.12' and python_full_version < '3.14'" },
+    { name = "pyyaml", marker = "python_full_version >= '3.12' and python_full_version < '3.14'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/36/c6/d1e555b461b508cf43b9c8ba55f3359dc94fbcbda231013c101ef5543297/nooa_cli-0.0.10.tar.gz", hash = "sha256:845d029afaed26166ca16ed15bfa69308703aac7aefc6afece5cddfa47ecbf6e", size = 89911, upload-time = "2026-09-04T06:04:33.448Z" }
 wheels = [
@@ -2462,10 +2462,10 @@ name = "openinference-instrumentation"
 version = "0.1.62"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "openinference-semantic-conventions" },
-    { name = "opentelemetry-api" },
-    { name = "opentelemetry-sdk" },
-    { name = "wrapt" },
+    { name = "openinference-semantic-conventions", marker = "python_full_version >= '3.12' and python_full_version < '3.14'" },
+    { name = "opentelemetry-api", marker = "python_full_version >= '3.12' and python_full_version < '3.14'" },
+    { name = "opentelemetry-sdk", marker = "python_full_version >= '3.12' and python_full_version < '3.14'" },
+    { name = "wrapt", marker = "python_full_version >= '3.12' and python_full_version < '3.14'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/30/d1/8a50a7b7f40170e06121964dc5ec4122ddac6cbe7c3f11aff572dc74a711/openinference_instrumentation-0.1.62.tar.gz", hash = "sha256:37e3313c5927087c7cea3679cf2301846064ad3c5b4cdd74c13c51fc23c14210", size = 43525, upload-time = "2026-09-09T07:32:19.976Z" }
 wheels = [
@@ -2477,13 +2477,13 @@ name = "openinference-instrumentation-litellm"
 version = "0.1.42"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "openinference-instrumentation" },
-    { name = "openinference-semantic-conventions" },
-    { name = "opentelemetry-api" },
-    { name = "opentelemetry-instrumentation" },
-    { name = "opentelemetry-sdk" },
-    { name = "setuptools" },
-    { name = "wrapt" },
+    { name = "openinference-instrumentation", marker = "python_full_version >= '3.12' and python_full_version < '3.14'" },
+    { name = "openinference-semantic-conventions", marker = "python_full_version >= '3.12' and python_full_version < '3.14'" },
+    { name = "opentelemetry-api", marker = "python_full_version >= '3.12' and python_full_version < '3.14'" },
+    { name = "opentelemetry-instrumentation", marker = "python_full_version >= '3.12' and python_full_version < '3.14'" },
+    { name = "opentelemetry-sdk", marker = "python_full_version >= '3.12' and python_full_version < '3.14'" },
+    { name = "setuptools", marker = "python_full_version >= '3.12' and python_full_version < '3.14'" },
+    { name = "wrapt", marker = "python_full_version >= '3.12' and python_full_version < '3.14'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/59/6c/c39695ccf77091078133a4b43f638558a4fec0d069e77cc51cf269aa1d63/openinference_instrumentation_litellm-0.1.42.tar.gz", hash = "sha256:a16d56e30e741a0ac9bc3ca4ed97b0d6ccd8f6ecce202a9f0757e65f8aeae77e", size = 111019, upload-time = "2026-09-09T07:12:06.497Z" }
 wheels = [
@@ -2504,7 +2504,7 @@ name = "opentelemetry-api"
 version = "1.44.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "typing-extensions" },
+    { name = "typing-extensions", marker = "python_full_version >= '3.12' and python_full_version < '3.14'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/ee/8b/aa9e2d8b8dfa7c946f7dec5d1f8f6ba8eca062f43509a06bdb5ce93d26c0/opentelemetry_api-1.44.0.tar.gz", hash = "sha256:67647e5e9566edcf421166fdf022b3537f818635daa852b289e34604dc6fb33a", size = 72406, upload-time = "2026-07-16T15:25:32.678Z" }
 wheels = [
@@ -2516,10 +2516,10 @@ name = "opentelemetry-instrumentation"
 version = "0.65b0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "opentelemetry-api" },
-    { name = "opentelemetry-semantic-conventions" },
-    { name = "packaging" },
-    { name = "wrapt" },
+    { name = "opentelemetry-api", marker = "python_full_version >= '3.12' and python_full_version < '3.14'" },
+    { name = "opentelemetry-semantic-conventions", marker = "python_full_version >= '3.12' and python_full_version < '3.14'" },
+    { name = "packaging", marker = "python_full_version >= '3.12' and python_full_version < '3.14'" },
+    { name = "wrapt", marker = "python_full_version >= '3.12' and python_full_version < '3.14'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/13/91/3c58961cb0360cd60509064734f0be4275383c8681d73c580a40ca83ddce/opentelemetry_instrumentation-0.65b0.tar.gz", hash = "sha256:071d9d9eced9bd6460444ec3b0c77229870ed05a881c22c84fdede58e4eed09b", size = 42689, upload-time = "2026-07-16T15:25:50.275Z" }
 wheels = [
@@ -2531,9 +2531,9 @@ name = "opentelemetry-sdk"
 version = "1.44.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "opentelemetry-api" },
-    { name = "opentelemetry-semantic-conventions" },
-    { name = "typing-extensions" },
+    { name = "opentelemetry-api", marker = "python_full_version >= '3.12' and python_full_version < '3.14'" },
+    { name = "opentelemetry-semantic-conventions", marker = "python_full_version >= '3.12' and python_full_version < '3.14'" },
+    { name = "typing-extensions", marker = "python_full_version >= '3.12' and python_full_version < '3.14'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/5d/77/a6592cbc7c8d9bcc9d6757a9df45e04a7c585e3e6e7a13456da522b21109/opentelemetry_sdk-1.44.0.tar.gz", hash = "sha256:cebe7f65dc12f26ead75c6064de12fd2a9052e5060c0272d402cfa203aae123b", size = 208624, upload-time = "2026-07-16T15:25:46.078Z" }
 wheels = [
@@ -2545,8 +2545,8 @@ name = "opentelemetry-semantic-conventions"
 version = "0.65b0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "opentelemetry-api" },
-    { name = "typing-extensions" },
+    { name = "opentelemetry-api", marker = "python_full_version >= '3.12' and python_full_version < '3.14'" },
+    { name = "typing-extensions", marker = "python_full_version >= '3.12' and python_full_version < '3.14'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/8f/73/0cbdebcb4cf545fdd328da14f5137e37d0770c3f26185e478b0d15d94f50/opentelemetry_semantic_conventions-0.65b0.tar.gz", hash = "sha256:f9b2b81e9d5b64f11bc952075e7e9c7fb0aab075c7fd1c46d597f1b919852d60", size = 148774, upload-time = "2026-07-16T15:25:46.902Z" }
 wheels = [
@@ -2756,10 +2756,10 @@ name = "postgrest"
 version = "2.31.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "deprecation" },
-    { name = "httpx", extra = ["http2"] },
-    { name = "pydantic" },
-    { name = "yarl" },
+    { name = "deprecation", marker = "python_full_version >= '3.12'" },
+    { name = "httpx", extra = ["http2"], marker = "python_full_version >= '3.12'" },
+    { name = "pydantic", marker = "python_full_version >= '3.12'" },
+    { name = "yarl", marker = "python_full_version >= '3.12'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/e2/22/88c470d8838d2678a44e0172d061630b8837cba3fb7fb492e28f6578c309/postgrest-2.31.0.tar.gz", hash = "sha256:2f395d84b2ee34fc57622ff2f711df603e2ede625f98e5015240741888f7bd0c", size = 14419, upload-time = "2026-06-04T13:37:20.474Z" }
 wheels = [
@@ -3228,9 +3228,9 @@ name = "realtime"
 version = "2.31.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "pydantic" },
-    { name = "typing-extensions" },
-    { name = "websockets" },
+    { name = "pydantic", marker = "python_full_version >= '3.12'" },
+    { name = "typing-extensions", marker = "python_full_version >= '3.12'" },
+    { name = "websockets", marker = "python_full_version >= '3.12'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/df/34/54a1eaaefa24db5cb12596fd74792e08efa53ed30dc5bce2c0a68ded6146/realtime-2.31.0.tar.gz", hash = "sha256:9e641cb4d77ca0fe768515f8cf9f83550c79f49ce1550a95afc2dc0e252be8c9", size = 18716, upload-time = "2026-06-04T13:37:22.089Z" }
 wheels = [
@@ -3523,7 +3523,7 @@ name = "s3transfer"
 version = "0.19.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "botocore" },
+    { name = "botocore", marker = "python_full_version >= '3.12' and python_full_version < '3.14'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/76/43/35e4d8aa320bffe8287fe8f65f578fa2d2db0a64212f0e710dce58267854/s3transfer-0.19.2.tar.gz", hash = "sha256:ba0309fd86be3c27dbf78cdd813c13c5e1df16e5874b99d2535ebbdfb9892993", size = 165592, upload-time = "2026-07-22T19:30:44.432Z" }
 wheels = [
@@ -3535,8 +3535,8 @@ name = "scantree"
 version = "0.0.4"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "attrs" },
-    { name = "pathspec" },
+    { name = "attrs", marker = "python_full_version >= '3.12'" },
+    { name = "pathspec", marker = "python_full_version >= '3.12'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/b3/e4/40998faefc72ba1ddeb640a44fba92935353525dba110488806da8339c0b/scantree-0.0.4.tar.gz", hash = "sha256:15bd5cb24483b04db2c70653604e8ea3522e98087db7e38ab8482f053984c0ac", size = 24643, upload-time = "2024-08-03T20:08:59.413Z" }
 wheels = [
@@ -3631,10 +3631,10 @@ name = "storage3"
 version = "2.31.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "deprecation" },
-    { name = "httpx", extra = ["http2"] },
-    { name = "pydantic" },
-    { name = "yarl" },
+    { name = "deprecation", marker = "python_full_version >= '3.12'" },
+    { name = "httpx", extra = ["http2"], marker = "python_full_version >= '3.12'" },
+    { name = "pydantic", marker = "python_full_version >= '3.12'" },
+    { name = "yarl", marker = "python_full_version >= '3.12'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/13/30/fee43d523d3f680a833a4aae5bf8094de0b9031b0c2bddb3e0bc6e829e1b/storage3-2.31.0.tar.gz", hash = "sha256:d2161e2ea650dc115a1787c30e09b118365589ac772f4dd8643e3a503ecfc667", size = 20348, upload-time = "2026-06-04T13:37:23.703Z" }
 wheels = [
@@ -3655,13 +3655,13 @@ name = "supabase"
 version = "2.31.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "httpx" },
-    { name = "postgrest" },
-    { name = "realtime" },
-    { name = "storage3" },
-    { name = "supabase-auth" },
-    { name = "supabase-functions" },
-    { name = "yarl" },
+    { name = "httpx", marker = "python_full_version >= '3.12'" },
+    { name = "postgrest", marker = "python_full_version >= '3.12'" },
+    { name = "realtime", marker = "python_full_version >= '3.12'" },
+    { name = "storage3", marker = "python_full_version >= '3.12'" },
+    { name = "supabase-auth", marker = "python_full_version >= '3.12'" },
+    { name = "supabase-functions", marker = "python_full_version >= '3.12'" },
+    { name = "yarl", marker = "python_full_version >= '3.12'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/fe/8e/54a2f950629689b1613434a61fc3bff5f92f84ba6b20213f5b2add05c1bb/supabase-2.31.0.tar.gz", hash = "sha256:3467b09d00482b9a0138235bdbde7a350426f93cf2a1342372eaddfc669f1206", size = 9805, upload-time = "2026-06-04T13:37:25.22Z" }
 wheels = [
@@ -3673,9 +3673,9 @@ name = "supabase-auth"
 version = "2.31.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "httpx", extra = ["http2"] },
-    { name = "pydantic" },
-    { name = "pyjwt", extra = ["crypto"] },
+    { name = "httpx", extra = ["http2"], marker = "python_full_version >= '3.12'" },
+    { name = "pydantic", marker = "python_full_version >= '3.12'" },
+    { name = "pyjwt", extra = ["crypto"], marker = "python_full_version >= '3.12'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/61/8a/408689cf39820f0d46d2731d6747ff94dbefc87ae977b4b5c4066da5b070/supabase_auth-2.31.0.tar.gz", hash = "sha256:0945b33fa96239c76dc8eaf96d7d2c94991950d24b4cfe4a5c2da9aa5e909663", size = 39151, upload-time = "2026-06-04T13:37:27.375Z" }
 wheels = [
@@ -3687,9 +3687,9 @@ name = "supabase-functions"
 version = "2.31.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "httpx", extra = ["http2"] },
-    { name = "strenum" },
-    { name = "yarl" },
+    { name = "httpx", extra = ["http2"], marker = "python_full_version >= '3.12'" },
+    { name = "strenum", marker = "python_full_version >= '3.12'" },
+    { name = "yarl", marker = "python_full_version >= '3.12'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/84/5d/61c2446ed26a57fa5543f9c270a731320911569202340d15341f72cdba7c/supabase_functions-2.31.0.tar.gz", hash = "sha256:4ad027b3ae3bd28b31233339f4db1da6965affd3546f655b421baf40cee2690f", size = 4683, upload-time = "2026-06-04T13:37:28.878Z" }
 wheels = [

--- a/tests/scripts/test_set_python_project_versions.py
+++ b/tests/scripts/test_set_python_project_versions.py
@@ -20,7 +20,7 @@ def test_set_python_project_versions_updates_internal_pins_with_extras(
     (tmp_path / "adapters" / "python" / "claude").mkdir(parents=True)
     (tmp_path / "adapters" / "typescript" / "pi").mkdir(parents=True)
     (tmp_path / "adapter-contract" / "python").mkdir(parents=True)
-    (tmp_path / "sdk" / "python" / "collector").mkdir(parents=True)
+    (tmp_path / "sdk" / "python" / "nemo-fabric-collector").mkdir(parents=True)
     (tmp_path / "sdk" / "python" / "nemo-fabric").mkdir(parents=True)
     (tmp_path / "sdk" / "python" / "nemo-fabric-runtime").mkdir()
     coordinator_path = tmp_path / "pyproject.toml"
@@ -59,7 +59,9 @@ hermes-agent = [
 """,
         encoding="utf-8",
     )
-    collector_path = tmp_path / "sdk" / "python" / "collector" / "pyproject.toml"
+    collector_path = (
+        tmp_path / "sdk" / "python" / "nemo-fabric-collector" / "pyproject.toml"
+    )
     collector_path.write_text(
         """\
 [project]

--- a/uv.lock
+++ b/uv.lock
@@ -40,14 +40,14 @@ resolution-markers = [
     "python_full_version < '3.12' and sys_platform != 'emscripten' and sys_platform != 'linux' and sys_platform != 'win32'",
 ]
 dependencies = [
-    { name = "aiohappyeyeballs" },
-    { name = "aiosignal" },
-    { name = "attrs" },
-    { name = "frozenlist" },
-    { name = "multidict" },
-    { name = "propcache" },
-    { name = "typing-extensions", marker = "python_full_version < '3.14'" },
-    { name = "yarl" },
+    { name = "aiohappyeyeballs", marker = "python_full_version < '3.12' or python_full_version >= '3.14'" },
+    { name = "aiosignal", marker = "python_full_version < '3.12' or python_full_version >= '3.14'" },
+    { name = "attrs", marker = "python_full_version < '3.12' or python_full_version >= '3.14'" },
+    { name = "frozenlist", marker = "python_full_version < '3.12' or python_full_version >= '3.14'" },
+    { name = "multidict", marker = "python_full_version < '3.12' or python_full_version >= '3.14'" },
+    { name = "propcache", marker = "python_full_version < '3.12' or python_full_version >= '3.14'" },
+    { name = "typing-extensions", marker = "python_full_version < '3.12'" },
+    { name = "yarl", marker = "python_full_version < '3.12' or python_full_version >= '3.14'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/82/78/8ea7308cac6934de8c74a14f3d5f65d1c89287426688be79538d0e5c013d/aiohttp-3.14.1.tar.gz", hash = "sha256:307f2cff90a764d329e77040603fa032db89c5c24fdad50c4c15334cba744035", size = 7955794, upload-time = "2026-06-07T21:09:35.529Z" }
 wheels = [
@@ -164,14 +164,14 @@ resolution-markers = [
     "python_full_version >= '3.12' and python_full_version < '3.14' and sys_platform != 'emscripten' and sys_platform != 'linux' and sys_platform != 'win32'",
 ]
 dependencies = [
-    { name = "aiohappyeyeballs" },
-    { name = "aiosignal" },
-    { name = "attrs" },
-    { name = "frozenlist" },
-    { name = "multidict" },
-    { name = "propcache" },
-    { name = "typing-extensions", marker = "python_full_version != '3.13.*'" },
-    { name = "yarl" },
+    { name = "aiohappyeyeballs", marker = "python_full_version >= '3.12' and python_full_version < '3.14'" },
+    { name = "aiosignal", marker = "python_full_version >= '3.12' and python_full_version < '3.14'" },
+    { name = "attrs", marker = "python_full_version >= '3.12' and python_full_version < '3.14'" },
+    { name = "frozenlist", marker = "python_full_version >= '3.12' and python_full_version < '3.14'" },
+    { name = "multidict", marker = "python_full_version >= '3.12' and python_full_version < '3.14'" },
+    { name = "propcache", marker = "python_full_version >= '3.12' and python_full_version < '3.14'" },
+    { name = "typing-extensions", marker = "python_full_version == '3.12.*'" },
+    { name = "yarl", marker = "python_full_version >= '3.12' and python_full_version < '3.14'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/58/d9/22ce5786ac0c1653ae8b6c23bded02c1686d11f0dbb45b31ce128e0df985/aiohttp-3.14.3.tar.gz", hash = "sha256:9491196535a88924a60afd5b5f434b5b203b6cc616250878dbdb223a8f7844bc", size = 7971213, upload-time = "2026-07-23T01:57:27.037Z" }
 wheels = [
@@ -384,9 +384,9 @@ name = "boto3"
 version = "1.43.91"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "botocore" },
-    { name = "jmespath" },
-    { name = "s3transfer" },
+    { name = "botocore", marker = "python_full_version >= '3.12' and python_full_version < '3.14'" },
+    { name = "jmespath", marker = "python_full_version >= '3.12' and python_full_version < '3.14'" },
+    { name = "s3transfer", marker = "python_full_version >= '3.12' and python_full_version < '3.14'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/42/76/e5c5fb601b09273599bf9c1a678ea2bc645385e758fbc66a36c9614b6324/boto3-1.43.91.tar.gz", hash = "sha256:98643e500883bf6fcd13d04bb19da983bf97e5f1c600fc11470ce45437fa96b4", size = 112693, upload-time = "2026-09-09T19:24:38.927Z" }
 wheels = [
@@ -398,9 +398,9 @@ name = "botocore"
 version = "1.43.91"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "jmespath" },
-    { name = "python-dateutil" },
-    { name = "urllib3" },
+    { name = "jmespath", marker = "python_full_version >= '3.12' and python_full_version < '3.14'" },
+    { name = "python-dateutil", marker = "python_full_version >= '3.12' and python_full_version < '3.14'" },
+    { name = "urllib3", marker = "python_full_version >= '3.12' and python_full_version < '3.14'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/9a/1e/c6d26cb1124799e2bee54854813b02aa8a813c57335f97b0b8ed50f902ff/botocore-1.43.91.tar.gz", hash = "sha256:0f12bceb8c5d90a0c60f326e883bf674ded8c7d7c18ee0b559843b3a6c52f2ad", size = 16089153, upload-time = "2026-09-09T19:24:34.426Z" }
 wheels = [
@@ -637,7 +637,7 @@ name = "concurrent-log-handler"
 version = "0.9.29"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "portalocker" },
+    { name = "portalocker", marker = "python_full_version < '3.14' and sys_platform == 'win32'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/9c/2c/ba185acc438cff6b58cd8f8dec27e7f4fcabf6968a1facbb6d0cacbde7fe/concurrent_log_handler-0.9.29.tar.gz", hash = "sha256:bc37a76d3f384cbf4a98f693ebd770543edc0f4cd5c6ab6bc70e9e1d7d582265", size = 42114, upload-time = "2026-02-22T18:18:25.758Z" }
 wheels = [
@@ -738,8 +738,8 @@ name = "croniter"
 version = "6.0.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "python-dateutil" },
-    { name = "pytz" },
+    { name = "python-dateutil", marker = "python_full_version < '3.14'" },
+    { name = "pytz", marker = "python_full_version < '3.14'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/ad/2f/44d1ae153a0e27be56be43465e5cb39b9650c781e001e7864389deb25090/croniter-6.0.0.tar.gz", hash = "sha256:37c504b313956114a983ece2c2b07790b1f1094fe9d81cc94739214748255577", size = 64481, upload-time = "2024-12-17T17:17:47.32Z" }
 wheels = [
@@ -757,7 +757,7 @@ resolution-markers = [
     "python_full_version >= '3.14' and sys_platform != 'emscripten' and sys_platform != 'linux' and sys_platform != 'win32'",
 ]
 dependencies = [
-    { name = "cffi", marker = "platform_python_implementation != 'PyPy'" },
+    { name = "cffi", marker = "python_full_version >= '3.14' and platform_python_implementation != 'PyPy'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/1f/99/d1c90d6041656cc6ee229dc99cd67fd0cd5aec3c5f7d72fffc27cc750054/cryptography-49.0.0.tar.gz", hash = "sha256:f89660a348f4f78a92366240a61404e337586ef7f5909a2fef59ca88ef505493", size = 854345, upload-time = "2026-06-12T20:02:30.512Z" }
 wheels = [
@@ -823,7 +823,7 @@ resolution-markers = [
     "python_full_version < '3.12' and sys_platform != 'emscripten' and sys_platform != 'linux' and sys_platform != 'win32'",
 ]
 dependencies = [
-    { name = "cffi", marker = "platform_python_implementation != 'PyPy'" },
+    { name = "cffi", marker = "python_full_version < '3.14' and platform_python_implementation != 'PyPy'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/de/41/6cbdcf9142d00fe82836fbb51e503e58088575cf7a0fe1dbff6695bf0840/cryptography-50.0.0.tar.gz", hash = "sha256:eeac2acb5a20ed25e0ad6d1df9891a520b78b404266b6d11778f25d5d691a6c9", size = 880201, upload-time = "2026-07-31T14:25:10.11Z" }
 wheels = [
@@ -932,7 +932,7 @@ name = "deprecation"
 version = "2.1.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "packaging" },
+    { name = "packaging", marker = "python_full_version >= '3.12'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/5a/d3/8ae2869247df154b64c1884d7346d412fed0c49df84db635aab2d1c40e62/deprecation-2.1.0.tar.gz", hash = "sha256:72b3bde64e5d778694b0cf68178aed03d15e15477116add3fb773e581f9518ff", size = 173788, upload-time = "2020-04-20T14:23:38.738Z" }
 wheels = [
@@ -953,7 +953,7 @@ name = "dirhash"
 version = "0.5.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "scantree" },
+    { name = "scantree", marker = "python_full_version >= '3.12'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/1d/70/49f93897f3a4f7ab5f20a854ebc91aad47854e9fb2cd169e3a4452fa3f5e/dirhash-0.5.0.tar.gz", hash = "sha256:e60760f0ab2e935d8cb088923ea2c6492398dca42cec785df778985fd4cd5386", size = 21377, upload-time = "2024-08-03T22:14:13.322Z" }
 wheels = [
@@ -1088,7 +1088,7 @@ name = "fire"
 version = "0.7.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "termcolor" },
+    { name = "termcolor", marker = "python_full_version < '3.14'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/c0/00/f8d10588d2019d6d6452653def1ee807353b21983db48550318424b5ff18/fire-0.7.1.tar.gz", hash = "sha256:3b208f05c736de98fb343310d090dcc4d8c78b2a89ea4f32b837c586270a9cbf", size = 88720, upload-time = "2025-08-16T20:20:24.175Z" }
 wheels = [
@@ -1297,28 +1297,28 @@ name = "harbor"
 version = "0.18.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "dirhash" },
-    { name = "fastapi" },
-    { name = "filelock" },
-    { name = "httpx" },
-    { name = "jinja2" },
+    { name = "dirhash", marker = "python_full_version >= '3.12'" },
+    { name = "fastapi", marker = "python_full_version >= '3.12'" },
+    { name = "filelock", marker = "python_full_version >= '3.12'" },
+    { name = "httpx", marker = "python_full_version >= '3.12'" },
+    { name = "jinja2", marker = "python_full_version >= '3.12'" },
     { name = "litellm", version = "1.89.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.14'" },
-    { name = "litellm", version = "1.100.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.14'" },
-    { name = "packaging" },
-    { name = "pathspec" },
-    { name = "platformdirs" },
-    { name = "pydantic" },
-    { name = "pyjwt" },
-    { name = "python-dotenv" },
-    { name = "pyyaml" },
-    { name = "requests" },
-    { name = "rich" },
-    { name = "shortuuid" },
-    { name = "supabase" },
-    { name = "tenacity" },
-    { name = "toml" },
-    { name = "typer" },
-    { name = "uvicorn" },
+    { name = "litellm", version = "1.100.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12' and python_full_version < '3.14'" },
+    { name = "packaging", marker = "python_full_version >= '3.12'" },
+    { name = "pathspec", marker = "python_full_version >= '3.12'" },
+    { name = "platformdirs", marker = "python_full_version >= '3.12'" },
+    { name = "pydantic", marker = "python_full_version >= '3.12'" },
+    { name = "pyjwt", marker = "python_full_version >= '3.12'" },
+    { name = "python-dotenv", marker = "python_full_version >= '3.12'" },
+    { name = "pyyaml", marker = "python_full_version >= '3.12'" },
+    { name = "requests", marker = "python_full_version >= '3.12'" },
+    { name = "rich", marker = "python_full_version >= '3.12'" },
+    { name = "shortuuid", marker = "python_full_version >= '3.12'" },
+    { name = "supabase", marker = "python_full_version >= '3.12'" },
+    { name = "tenacity", marker = "python_full_version >= '3.12'" },
+    { name = "toml", marker = "python_full_version >= '3.12'" },
+    { name = "typer", marker = "python_full_version >= '3.12'" },
+    { name = "uvicorn", marker = "python_full_version >= '3.12'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/38/24/7222433d3b9f665db1759456c281a9c136b921300be5d7af269f183ee59e/harbor-0.18.0.tar.gz", hash = "sha256:9b918b99ec38b4e16db7e0b797dcebf92bfc8be9d9ba22a2d2ed6ebb8feb38df", size = 1535447, upload-time = "2026-07-07T20:29:46.878Z" }
 wheels = [
@@ -1330,40 +1330,40 @@ name = "hermes-agent"
 version = "0.21.0"
 source = { editable = "external/hermes-agent" }
 dependencies = [
-    { name = "certifi" },
-    { name = "concurrent-log-handler", marker = "sys_platform == 'win32'" },
-    { name = "croniter" },
-    { name = "cryptography", version = "50.0.0", source = { registry = "https://pypi.org/simple" } },
-    { name = "fastapi" },
-    { name = "fire" },
-    { name = "firecrawl-anydoc" },
-    { name = "httpx", extra = ["socks"] },
-    { name = "jinja2" },
-    { name = "markdown" },
-    { name = "nemo-relay", marker = "(platform_machine == 'aarch64' and 'android' not in platform_release and sys_platform == 'linux') or (platform_machine == 'x86_64' and 'android' not in platform_release and sys_platform == 'linux') or (platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'AMD64' and sys_platform == 'win32') or (platform_machine == 'ARM64' and sys_platform == 'win32')" },
-    { name = "openai" },
-    { name = "packaging" },
-    { name = "pathspec" },
-    { name = "pillow" },
-    { name = "prompt-toolkit" },
-    { name = "psutil" },
-    { name = "ptyprocess", marker = "sys_platform != 'win32'" },
-    { name = "pydantic" },
-    { name = "pyjwt", extra = ["crypto"] },
-    { name = "python-dotenv" },
-    { name = "python-multipart" },
-    { name = "pywin32", version = "311", source = { registry = "https://pypi.org/simple" }, marker = "sys_platform == 'win32'" },
-    { name = "pywinpty", marker = "sys_platform == 'win32'" },
-    { name = "pyyaml" },
-    { name = "requests" },
-    { name = "rich" },
-    { name = "ruamel-yaml" },
-    { name = "snowballstemmer" },
-    { name = "tenacity" },
-    { name = "tzdata", marker = "sys_platform == 'win32'" },
-    { name = "urllib3" },
-    { name = "uvicorn", extra = ["standard"] },
-    { name = "websockets" },
+    { name = "certifi", marker = "python_full_version < '3.14'" },
+    { name = "concurrent-log-handler", marker = "python_full_version < '3.14' and sys_platform == 'win32'" },
+    { name = "croniter", marker = "python_full_version < '3.14'" },
+    { name = "cryptography", version = "50.0.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.14'" },
+    { name = "fastapi", marker = "python_full_version < '3.14'" },
+    { name = "fire", marker = "python_full_version < '3.14'" },
+    { name = "firecrawl-anydoc", marker = "python_full_version < '3.14'" },
+    { name = "httpx", extra = ["socks"], marker = "python_full_version < '3.14'" },
+    { name = "jinja2", marker = "python_full_version < '3.14'" },
+    { name = "markdown", marker = "python_full_version < '3.14'" },
+    { name = "nemo-relay", marker = "(python_full_version < '3.14' and platform_machine == 'aarch64' and 'android' not in platform_release and sys_platform == 'linux') or (python_full_version < '3.14' and platform_machine == 'x86_64' and 'android' not in platform_release and sys_platform == 'linux') or (python_full_version < '3.14' and platform_machine == 'arm64' and sys_platform == 'darwin') or (python_full_version < '3.14' and platform_machine == 'AMD64' and sys_platform == 'win32') or (python_full_version < '3.14' and platform_machine == 'ARM64' and sys_platform == 'win32')" },
+    { name = "openai", marker = "python_full_version < '3.14'" },
+    { name = "packaging", marker = "python_full_version < '3.14'" },
+    { name = "pathspec", marker = "python_full_version < '3.14'" },
+    { name = "pillow", marker = "python_full_version < '3.14'" },
+    { name = "prompt-toolkit", marker = "python_full_version < '3.14'" },
+    { name = "psutil", marker = "python_full_version < '3.14'" },
+    { name = "ptyprocess", marker = "python_full_version < '3.14' and sys_platform != 'win32'" },
+    { name = "pydantic", marker = "python_full_version < '3.14'" },
+    { name = "pyjwt", extra = ["crypto"], marker = "python_full_version < '3.14'" },
+    { name = "python-dotenv", marker = "python_full_version < '3.14'" },
+    { name = "python-multipart", marker = "python_full_version < '3.14'" },
+    { name = "pywin32", version = "311", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.14' and sys_platform == 'win32'" },
+    { name = "pywinpty", marker = "python_full_version < '3.14' and sys_platform == 'win32'" },
+    { name = "pyyaml", marker = "python_full_version < '3.14'" },
+    { name = "requests", marker = "python_full_version < '3.14'" },
+    { name = "rich", marker = "python_full_version < '3.14'" },
+    { name = "ruamel-yaml", marker = "python_full_version < '3.14'" },
+    { name = "snowballstemmer", marker = "python_full_version < '3.14'" },
+    { name = "tenacity", marker = "python_full_version < '3.14'" },
+    { name = "tzdata", marker = "python_full_version < '3.14' and sys_platform == 'win32'" },
+    { name = "urllib3", marker = "python_full_version < '3.14'" },
+    { name = "uvicorn", extra = ["standard"], marker = "python_full_version < '3.14'" },
+    { name = "websockets", marker = "python_full_version < '3.14'" },
 ]
 
 [package.metadata]
@@ -1567,8 +1567,8 @@ name = "httpcore2"
 version = "2.12.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "h11" },
-    { name = "truststore" },
+    { name = "h11", marker = "sys_platform != 'emscripten'" },
+    { name = "truststore", marker = "sys_platform != 'emscripten'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/be/ad/f4f0e57345f1870f3e8cb624e058d7eca6e5a27d33bcc3311d9b618734cd/httpcore2-2.12.0.tar.gz", hash = "sha256:9293522bba0aa7c4c8e9e3f040c16575bd8868e155a77fa30c7a9085a5eae648", size = 67548, upload-time = "2026-08-18T13:22:08.211Z" }
 wheels = [
@@ -1638,7 +1638,7 @@ http2 = [
     { name = "h2" },
 ]
 socks = [
-    { name = "socksio" },
+    { name = "socksio", marker = "python_full_version < '3.14'" },
 ]
 
 [[package]]
@@ -2178,18 +2178,18 @@ resolution-markers = [
     "python_full_version < '3.12' and sys_platform != 'emscripten' and sys_platform != 'linux' and sys_platform != 'win32'",
 ]
 dependencies = [
-    { name = "aiohttp", version = "3.14.1", source = { registry = "https://pypi.org/simple" } },
-    { name = "click" },
-    { name = "fastuuid" },
-    { name = "httpx" },
-    { name = "importlib-metadata" },
-    { name = "jinja2" },
-    { name = "jsonschema" },
-    { name = "openai" },
-    { name = "pydantic" },
-    { name = "python-dotenv" },
-    { name = "tiktoken" },
-    { name = "tokenizers" },
+    { name = "aiohttp", version = "3.14.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.12' or python_full_version >= '3.14'" },
+    { name = "click", marker = "python_full_version < '3.12' or python_full_version >= '3.14'" },
+    { name = "fastuuid", marker = "python_full_version < '3.12' or python_full_version >= '3.14'" },
+    { name = "httpx", marker = "python_full_version < '3.12' or python_full_version >= '3.14'" },
+    { name = "importlib-metadata", marker = "python_full_version < '3.12' or python_full_version >= '3.14'" },
+    { name = "jinja2", marker = "python_full_version < '3.12' or python_full_version >= '3.14'" },
+    { name = "jsonschema", marker = "python_full_version < '3.12' or python_full_version >= '3.14'" },
+    { name = "openai", marker = "python_full_version < '3.12' or python_full_version >= '3.14'" },
+    { name = "pydantic", marker = "python_full_version < '3.12' or python_full_version >= '3.14'" },
+    { name = "python-dotenv", marker = "python_full_version < '3.12' or python_full_version >= '3.14'" },
+    { name = "tiktoken", marker = "python_full_version < '3.12' or python_full_version >= '3.14'" },
+    { name = "tokenizers", marker = "python_full_version < '3.12' or python_full_version >= '3.14'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/56/f1/f7cfead063f2ab1877c8fb465d0d7fe300b75f081bcb73525f6d550aeb1c/litellm-1.89.3.tar.gz", hash = "sha256:8fcdb2b7a0ef3381d41adf164443842e31ef9f0cd5bcda6fc3c0bd8bc2959510", size = 14080611, upload-time = "2026-06-20T22:42:26.997Z" }
 wheels = [
@@ -2207,20 +2207,20 @@ resolution-markers = [
     "python_full_version >= '3.12' and python_full_version < '3.14' and sys_platform != 'emscripten' and sys_platform != 'linux' and sys_platform != 'win32'",
 ]
 dependencies = [
-    { name = "aiohttp", version = "3.14.3", source = { registry = "https://pypi.org/simple" } },
-    { name = "boto3" },
-    { name = "click" },
-    { name = "fastuuid" },
-    { name = "httpx" },
-    { name = "importlib-metadata" },
-    { name = "jinja2" },
-    { name = "jsonschema" },
-    { name = "openai" },
-    { name = "pydantic" },
-    { name = "pydantic-settings" },
-    { name = "python-dotenv" },
-    { name = "tiktoken" },
-    { name = "tokenizers" },
+    { name = "aiohttp", version = "3.14.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12' and python_full_version < '3.14'" },
+    { name = "boto3", marker = "python_full_version >= '3.12' and python_full_version < '3.14'" },
+    { name = "click", marker = "python_full_version >= '3.12' and python_full_version < '3.14'" },
+    { name = "fastuuid", marker = "python_full_version >= '3.12' and python_full_version < '3.14'" },
+    { name = "httpx", marker = "python_full_version >= '3.12' and python_full_version < '3.14'" },
+    { name = "importlib-metadata", marker = "python_full_version >= '3.12' and python_full_version < '3.14'" },
+    { name = "jinja2", marker = "python_full_version >= '3.12' and python_full_version < '3.14'" },
+    { name = "jsonschema", marker = "python_full_version >= '3.12' and python_full_version < '3.14'" },
+    { name = "openai", marker = "python_full_version >= '3.12' and python_full_version < '3.14'" },
+    { name = "pydantic", marker = "python_full_version >= '3.12' and python_full_version < '3.14'" },
+    { name = "pydantic-settings", marker = "python_full_version >= '3.12' and python_full_version < '3.14'" },
+    { name = "python-dotenv", marker = "python_full_version >= '3.12' and python_full_version < '3.14'" },
+    { name = "tiktoken", marker = "python_full_version >= '3.12' and python_full_version < '3.14'" },
+    { name = "tokenizers", marker = "python_full_version >= '3.12' and python_full_version < '3.14'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/48/a5/f78d2fafa950040f833efd41dd5690598afeef0c9c4657171372573698aa/litellm-1.100.1.tar.gz", hash = "sha256:d24b5fbdeb1f0b5c0a6f7f0caf7b6aa79b69c704b90daca57e3ce7d50a9d6bf4", size = 17330008, upload-time = "2026-09-10T01:42:53.328Z" }
 wheels = [
@@ -2368,7 +2368,7 @@ wheels = [
 
 [package.optional-dependencies]
 zig = [
-    { name = "ziglang" },
+    { name = "ziglang", marker = "sys_platform == 'linux'" },
 ]
 
 [[package]]
@@ -2599,7 +2599,7 @@ wheels = [
 
 [[package]]
 name = "nemo-fabric"
-version = "0.3.0"
+version = "0.4.0"
 source = { editable = "sdk/python/nemo-fabric" }
 dependencies = [
     { name = "nemo-fabric-runtime" },
@@ -2620,7 +2620,7 @@ harbor = [
     { name = "pyyaml" },
 ]
 hermes-agent = [
-    { name = "nemo-fabric-adapters-hermes" },
+    { name = "nemo-fabric-adapters-hermes", marker = "python_full_version < '3.14'" },
 ]
 mini-swe-agent = [
     { name = "nemo-fabric-adapters-mini-swe-agent", extra = ["harness"] },
@@ -2657,7 +2657,7 @@ provides-extras = ["claude", "codex", "streaming", "deepagents", "mini-swe-agent
 
 [[package]]
 name = "nemo-fabric-adapter-contract"
-version = "0.3.0"
+version = "0.4.0"
 source = { editable = "adapter-contract/python" }
 
 [package.metadata]
@@ -2666,7 +2666,7 @@ provides-extras = ["pydantic"]
 
 [[package]]
 name = "nemo-fabric-adapters-claude"
-version = "0.3.0"
+version = "0.4.0"
 source = { editable = "adapters/python/claude" }
 dependencies = [
     { name = "nemo-fabric-adapter-contract" },
@@ -2694,7 +2694,7 @@ provides-extras = ["harness", "full"]
 
 [[package]]
 name = "nemo-fabric-adapters-codex"
-version = "0.3.0"
+version = "0.4.0"
 source = { editable = "adapters/python/codex" }
 dependencies = [
     { name = "nemo-fabric-adapter-contract" },
@@ -2722,7 +2722,7 @@ provides-extras = ["harness", "full"]
 
 [[package]]
 name = "nemo-fabric-adapters-common"
-version = "0.3.0"
+version = "0.4.0"
 source = { editable = "adapters/python/common" }
 dependencies = [
     { name = "nemo-fabric-adapter-contract" },
@@ -2733,7 +2733,7 @@ requires-dist = [{ name = "nemo-fabric-adapter-contract", editable = "adapter-co
 
 [[package]]
 name = "nemo-fabric-adapters-deepagents"
-version = "0.3.0"
+version = "0.4.0"
 source = { editable = "adapters/python/deepagents" }
 dependencies = [
     { name = "langchain-mcp-adapters" },
@@ -2773,16 +2773,16 @@ provides-extras = ["harness", "relay", "full"]
 
 [[package]]
 name = "nemo-fabric-adapters-hermes"
-version = "0.3.0"
+version = "0.4.0"
 source = { editable = "adapters/python/hermes" }
 dependencies = [
-    { name = "nemo-fabric-adapter-contract" },
-    { name = "nemo-fabric-adapters-common" },
+    { name = "nemo-fabric-adapter-contract", marker = "python_full_version < '3.14'" },
+    { name = "nemo-fabric-adapters-common", marker = "python_full_version < '3.14'" },
 ]
 
 [package.optional-dependencies]
 full = [
-    { name = "nemo-relay" },
+    { name = "nemo-relay", marker = "python_full_version < '3.14'" },
 ]
 
 [package.metadata]
@@ -2796,7 +2796,7 @@ provides-extras = ["relay", "full"]
 
 [[package]]
 name = "nemo-fabric-adapters-mini-swe-agent"
-version = "0.3.0"
+version = "0.4.0"
 source = { editable = "adapters/python/mini-swe-agent" }
 dependencies = [
     { name = "nemo-fabric-adapter-contract" },
@@ -2824,24 +2824,24 @@ provides-extras = ["harness", "relay", "full"]
 
 [[package]]
 name = "nemo-fabric-adapters-nooa"
-version = "0.3.0"
+version = "0.4.0"
 source = { editable = "adapters/python/nooa" }
 dependencies = [
-    { name = "nemo-fabric-adapter-contract" },
-    { name = "nemo-fabric-adapters-common" },
+    { name = "nemo-fabric-adapter-contract", marker = "python_full_version >= '3.12' and python_full_version < '3.14'" },
+    { name = "nemo-fabric-adapters-common", marker = "python_full_version >= '3.12' and python_full_version < '3.14'" },
 ]
 
 [package.optional-dependencies]
 full = [
-    { name = "nemo-relay" },
-    { name = "nooa" },
-    { name = "nooa-bench" },
-    { name = "nooa-cli" },
+    { name = "nemo-relay", marker = "python_full_version >= '3.12' and python_full_version < '3.14'" },
+    { name = "nooa", marker = "python_full_version >= '3.12' and python_full_version < '3.14'" },
+    { name = "nooa-bench", marker = "python_full_version >= '3.12' and python_full_version < '3.14'" },
+    { name = "nooa-cli", marker = "python_full_version >= '3.12' and python_full_version < '3.14'" },
 ]
 harness = [
-    { name = "nooa" },
-    { name = "nooa-bench" },
-    { name = "nooa-cli" },
+    { name = "nooa", marker = "python_full_version >= '3.12' and python_full_version < '3.14'" },
+    { name = "nooa-bench", marker = "python_full_version >= '3.12' and python_full_version < '3.14'" },
+    { name = "nooa-cli", marker = "python_full_version >= '3.12' and python_full_version < '3.14'" },
 ]
 
 [package.metadata]
@@ -2861,7 +2861,7 @@ provides-extras = ["harness", "relay", "full"]
 
 [[package]]
 name = "nemo-fabric-adapters-remote-agent"
-version = "0.3.0"
+version = "0.4.0"
 source = { editable = "adapters/python/remote-agent" }
 dependencies = [
     { name = "httpx", extra = ["http2"] },
@@ -2879,7 +2879,7 @@ provides-extras = ["harness", "full"]
 
 [[package]]
 name = "nemo-fabric-collector"
-version = "0.3.0"
+version = "0.4.0"
 source = { editable = "sdk/python/nemo-fabric-collector" }
 dependencies = [
     { name = "starlette", version = "1.0.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.14'" },
@@ -3142,10 +3142,10 @@ name = "nooa"
 version = "0.0.10"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "httpx" },
-    { name = "litellm", version = "1.100.1", source = { registry = "https://pypi.org/simple" } },
-    { name = "openinference-instrumentation-litellm" },
-    { name = "pydantic" },
+    { name = "httpx", marker = "python_full_version >= '3.12' and python_full_version < '3.14'" },
+    { name = "litellm", version = "1.100.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12' and python_full_version < '3.14'" },
+    { name = "openinference-instrumentation-litellm", marker = "python_full_version >= '3.12' and python_full_version < '3.14'" },
+    { name = "pydantic", marker = "python_full_version >= '3.12' and python_full_version < '3.14'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/27/90/f07e44b57d10e3687caba9b18a1b2064e7c9602f85fdeb9c9b0a4843aeba/nooa-0.0.10.tar.gz", hash = "sha256:91d44a48610b116561d2ddc42ed80a7c4011c7324a67236300d2fe78182d3c78", size = 3504802, upload-time = "2026-09-04T06:04:36.719Z" }
 wheels = [
@@ -3157,9 +3157,9 @@ name = "nooa-bench"
 version = "0.0.10"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "click" },
-    { name = "nooa" },
-    { name = "nooa-cli" },
+    { name = "click", marker = "python_full_version >= '3.12' and python_full_version < '3.14'" },
+    { name = "nooa", marker = "python_full_version >= '3.12' and python_full_version < '3.14'" },
+    { name = "nooa-cli", marker = "python_full_version >= '3.12' and python_full_version < '3.14'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/c0/60/7a1fcf359ee503c1edfc66fd83f6e41f3444302d05aa4f870c74363117ff/nooa_bench-0.0.10.tar.gz", hash = "sha256:2838fc23172f12d4fb2069b5cee8e223e86429800db02f3132a2ea4383b829f0", size = 18489, upload-time = "2026-09-04T06:04:34.104Z" }
 wheels = [
@@ -3171,9 +3171,9 @@ name = "nooa-cli"
 version = "0.0.10"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "click" },
-    { name = "nooa" },
-    { name = "pyyaml" },
+    { name = "click", marker = "python_full_version >= '3.12' and python_full_version < '3.14'" },
+    { name = "nooa", marker = "python_full_version >= '3.12' and python_full_version < '3.14'" },
+    { name = "pyyaml", marker = "python_full_version >= '3.12' and python_full_version < '3.14'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/36/c6/d1e555b461b508cf43b9c8ba55f3359dc94fbcbda231013c101ef5543297/nooa_cli-0.0.10.tar.gz", hash = "sha256:845d029afaed26166ca16ed15bfa69308703aac7aefc6afece5cddfa47ecbf6e", size = 89911, upload-time = "2026-09-04T06:04:33.448Z" }
 wheels = [
@@ -3400,10 +3400,10 @@ name = "openinference-instrumentation"
 version = "0.1.62"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "openinference-semantic-conventions" },
-    { name = "opentelemetry-api" },
-    { name = "opentelemetry-sdk" },
-    { name = "wrapt" },
+    { name = "openinference-semantic-conventions", marker = "python_full_version >= '3.12' and python_full_version < '3.14'" },
+    { name = "opentelemetry-api", marker = "python_full_version >= '3.12' and python_full_version < '3.14'" },
+    { name = "opentelemetry-sdk", marker = "python_full_version >= '3.12' and python_full_version < '3.14'" },
+    { name = "wrapt", marker = "python_full_version >= '3.12' and python_full_version < '3.14'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/30/d1/8a50a7b7f40170e06121964dc5ec4122ddac6cbe7c3f11aff572dc74a711/openinference_instrumentation-0.1.62.tar.gz", hash = "sha256:37e3313c5927087c7cea3679cf2301846064ad3c5b4cdd74c13c51fc23c14210", size = 43525, upload-time = "2026-09-09T07:32:19.976Z" }
 wheels = [
@@ -3415,13 +3415,13 @@ name = "openinference-instrumentation-litellm"
 version = "0.1.42"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "openinference-instrumentation" },
-    { name = "openinference-semantic-conventions" },
-    { name = "opentelemetry-api" },
-    { name = "opentelemetry-instrumentation" },
-    { name = "opentelemetry-sdk" },
-    { name = "setuptools" },
-    { name = "wrapt" },
+    { name = "openinference-instrumentation", marker = "python_full_version >= '3.12' and python_full_version < '3.14'" },
+    { name = "openinference-semantic-conventions", marker = "python_full_version >= '3.12' and python_full_version < '3.14'" },
+    { name = "opentelemetry-api", marker = "python_full_version >= '3.12' and python_full_version < '3.14'" },
+    { name = "opentelemetry-instrumentation", marker = "python_full_version >= '3.12' and python_full_version < '3.14'" },
+    { name = "opentelemetry-sdk", marker = "python_full_version >= '3.12' and python_full_version < '3.14'" },
+    { name = "setuptools", marker = "python_full_version >= '3.12' and python_full_version < '3.14'" },
+    { name = "wrapt", marker = "python_full_version >= '3.12' and python_full_version < '3.14'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/59/6c/c39695ccf77091078133a4b43f638558a4fec0d069e77cc51cf269aa1d63/openinference_instrumentation_litellm-0.1.42.tar.gz", hash = "sha256:a16d56e30e741a0ac9bc3ca4ed97b0d6ccd8f6ecce202a9f0757e65f8aeae77e", size = 111019, upload-time = "2026-09-09T07:12:06.497Z" }
 wheels = [
@@ -3442,7 +3442,7 @@ name = "opentelemetry-api"
 version = "1.44.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "typing-extensions" },
+    { name = "typing-extensions", marker = "python_full_version >= '3.12' and python_full_version < '3.14'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/ee/8b/aa9e2d8b8dfa7c946f7dec5d1f8f6ba8eca062f43509a06bdb5ce93d26c0/opentelemetry_api-1.44.0.tar.gz", hash = "sha256:67647e5e9566edcf421166fdf022b3537f818635daa852b289e34604dc6fb33a", size = 72406, upload-time = "2026-07-16T15:25:32.678Z" }
 wheels = [
@@ -3454,10 +3454,10 @@ name = "opentelemetry-instrumentation"
 version = "0.65b0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "opentelemetry-api" },
-    { name = "opentelemetry-semantic-conventions" },
-    { name = "packaging" },
-    { name = "wrapt" },
+    { name = "opentelemetry-api", marker = "python_full_version >= '3.12' and python_full_version < '3.14'" },
+    { name = "opentelemetry-semantic-conventions", marker = "python_full_version >= '3.12' and python_full_version < '3.14'" },
+    { name = "packaging", marker = "python_full_version >= '3.12' and python_full_version < '3.14'" },
+    { name = "wrapt", marker = "python_full_version >= '3.12' and python_full_version < '3.14'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/13/91/3c58961cb0360cd60509064734f0be4275383c8681d73c580a40ca83ddce/opentelemetry_instrumentation-0.65b0.tar.gz", hash = "sha256:071d9d9eced9bd6460444ec3b0c77229870ed05a881c22c84fdede58e4eed09b", size = 42689, upload-time = "2026-07-16T15:25:50.275Z" }
 wheels = [
@@ -3469,9 +3469,9 @@ name = "opentelemetry-sdk"
 version = "1.44.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "opentelemetry-api" },
-    { name = "opentelemetry-semantic-conventions" },
-    { name = "typing-extensions" },
+    { name = "opentelemetry-api", marker = "python_full_version >= '3.12' and python_full_version < '3.14'" },
+    { name = "opentelemetry-semantic-conventions", marker = "python_full_version >= '3.12' and python_full_version < '3.14'" },
+    { name = "typing-extensions", marker = "python_full_version >= '3.12' and python_full_version < '3.14'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/5d/77/a6592cbc7c8d9bcc9d6757a9df45e04a7c585e3e6e7a13456da522b21109/opentelemetry_sdk-1.44.0.tar.gz", hash = "sha256:cebe7f65dc12f26ead75c6064de12fd2a9052e5060c0272d402cfa203aae123b", size = 208624, upload-time = "2026-07-16T15:25:46.078Z" }
 wheels = [
@@ -3483,8 +3483,8 @@ name = "opentelemetry-semantic-conventions"
 version = "0.65b0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "opentelemetry-api" },
-    { name = "typing-extensions" },
+    { name = "opentelemetry-api", marker = "python_full_version >= '3.12' and python_full_version < '3.14'" },
+    { name = "typing-extensions", marker = "python_full_version >= '3.12' and python_full_version < '3.14'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/8f/73/0cbdebcb4cf545fdd328da14f5137e37d0770c3f26185e478b0d15d94f50/opentelemetry_semantic_conventions-0.65b0.tar.gz", hash = "sha256:f9b2b81e9d5b64f11bc952075e7e9c7fb0aab075c7fd1c46d597f1b919852d60", size = 148774, upload-time = "2026-07-16T15:25:46.902Z" }
 wheels = [
@@ -3694,7 +3694,7 @@ name = "pexpect"
 version = "4.9.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "ptyprocess" },
+    { name = "ptyprocess", marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/42/92/cc564bf6381ff43ce1f4d06852fc19a2f11d180f23dc32d9588bee2f149d/pexpect-4.9.0.tar.gz", hash = "sha256:ee7d41123f3c9911050ea2c2dac107568dc43b2d3b0c7557a33212c398ead30f", size = 166450, upload-time = "2023-11-25T09:07:26.339Z" }
 wheels = [
@@ -3839,10 +3839,10 @@ name = "postgrest"
 version = "2.31.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "deprecation" },
-    { name = "httpx", extra = ["http2"] },
-    { name = "pydantic" },
-    { name = "yarl" },
+    { name = "deprecation", marker = "python_full_version >= '3.12'" },
+    { name = "httpx", extra = ["http2"], marker = "python_full_version >= '3.12'" },
+    { name = "pydantic", marker = "python_full_version >= '3.12'" },
+    { name = "yarl", marker = "python_full_version >= '3.12'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/e2/22/88c470d8838d2678a44e0172d061630b8837cba3fb7fb492e28f6578c309/postgrest-2.31.0.tar.gz", hash = "sha256:2f395d84b2ee34fc57622ff2f711df603e2ede625f98e5015240741888f7bd0c", size = 14419, upload-time = "2026-06-04T13:37:20.474Z" }
 wheels = [
@@ -4489,9 +4489,9 @@ name = "realtime"
 version = "2.31.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "pydantic" },
-    { name = "typing-extensions" },
-    { name = "websockets" },
+    { name = "pydantic", marker = "python_full_version >= '3.12'" },
+    { name = "typing-extensions", marker = "python_full_version >= '3.12'" },
+    { name = "websockets", marker = "python_full_version >= '3.12'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/df/34/54a1eaaefa24db5cb12596fd74792e08efa53ed30dc5bce2c0a68ded6146/realtime-2.31.0.tar.gz", hash = "sha256:9e641cb4d77ca0fe768515f8cf9f83550c79f49ce1550a95afc2dc0e252be8c9", size = 18716, upload-time = "2026-06-04T13:37:22.089Z" }
 wheels = [
@@ -4798,7 +4798,7 @@ name = "ruamel-yaml"
 version = "0.18.17"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "ruamel-yaml-clib", marker = "platform_python_implementation == 'CPython'" },
+    { name = "ruamel-yaml-clib", marker = "python_full_version < '3.14' and platform_python_implementation == 'CPython'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/3a/2b/7a1f1ebcd6b3f14febdc003e658778d81e76b40df2267904ee6b13f0c5c6/ruamel_yaml-0.18.17.tar.gz", hash = "sha256:9091cd6e2d93a3a4b157ddb8fabf348c3de7f1fb1381346d985b6b247dcd8d3c", size = 149602, upload-time = "2025-12-17T20:02:55.757Z" }
 wheels = [
@@ -4858,7 +4858,7 @@ name = "s3transfer"
 version = "0.19.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "botocore" },
+    { name = "botocore", marker = "python_full_version >= '3.12' and python_full_version < '3.14'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/76/43/35e4d8aa320bffe8287fe8f65f578fa2d2db0a64212f0e710dce58267854/s3transfer-0.19.2.tar.gz", hash = "sha256:ba0309fd86be3c27dbf78cdd813c13c5e1df16e5874b99d2535ebbdfb9892993", size = 165592, upload-time = "2026-07-22T19:30:44.432Z" }
 wheels = [
@@ -4870,8 +4870,8 @@ name = "scantree"
 version = "0.0.4"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "attrs" },
-    { name = "pathspec" },
+    { name = "attrs", marker = "python_full_version >= '3.12'" },
+    { name = "pathspec", marker = "python_full_version >= '3.12'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/b3/e4/40998faefc72ba1ddeb640a44fba92935353525dba110488806da8339c0b/scantree-0.0.4.tar.gz", hash = "sha256:15bd5cb24483b04db2c70653604e8ea3522e98087db7e38ab8482f053984c0ac", size = 24643, upload-time = "2024-08-03T20:08:59.413Z" }
 wheels = [
@@ -5005,8 +5005,8 @@ resolution-markers = [
     "python_full_version < '3.12' and sys_platform != 'emscripten' and sys_platform != 'linux' and sys_platform != 'win32'",
 ]
 dependencies = [
-    { name = "anyio" },
-    { name = "typing-extensions", marker = "python_full_version != '3.13.*'" },
+    { name = "anyio", marker = "python_full_version < '3.14'" },
+    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/08/a3/84e821cc54b4ab50ae6dbc6ac3800a651b65ec35f045cc73785380654057/starlette-1.0.1.tar.gz", hash = "sha256:512399c5f1de7fac99c88572212ded9ddeddef2fb32afa82d724000e88b38f4f", size = 2659596, upload-time = "2026-05-21T21:58:58.433Z" }
 wheels = [
@@ -5024,7 +5024,7 @@ resolution-markers = [
     "python_full_version >= '3.14' and sys_platform != 'emscripten' and sys_platform != 'linux' and sys_platform != 'win32'",
 ]
 dependencies = [
-    { name = "anyio" },
+    { name = "anyio", marker = "python_full_version >= '3.14'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/eb/e3/7c1dc7381d9f8ab7d854328ebfa884e62cb3f3d8549ddfd37c7814f42afa/starlette-1.3.1.tar.gz", hash = "sha256:05d0213193f2fbaae60e2ecb593b4add4262ad4e46536b54abe36f11a71724e0", size = 2703240, upload-time = "2026-06-12T09:23:11.602Z" }
 wheels = [
@@ -5036,10 +5036,10 @@ name = "storage3"
 version = "2.31.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "deprecation" },
-    { name = "httpx", extra = ["http2"] },
-    { name = "pydantic" },
-    { name = "yarl" },
+    { name = "deprecation", marker = "python_full_version >= '3.12'" },
+    { name = "httpx", extra = ["http2"], marker = "python_full_version >= '3.12'" },
+    { name = "pydantic", marker = "python_full_version >= '3.12'" },
+    { name = "yarl", marker = "python_full_version >= '3.12'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/13/30/fee43d523d3f680a833a4aae5bf8094de0b9031b0c2bddb3e0bc6e829e1b/storage3-2.31.0.tar.gz", hash = "sha256:d2161e2ea650dc115a1787c30e09b118365589ac772f4dd8643e3a503ecfc667", size = 20348, upload-time = "2026-06-04T13:37:23.703Z" }
 wheels = [
@@ -5060,13 +5060,13 @@ name = "supabase"
 version = "2.31.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "httpx" },
-    { name = "postgrest" },
-    { name = "realtime" },
-    { name = "storage3" },
-    { name = "supabase-auth" },
-    { name = "supabase-functions" },
-    { name = "yarl" },
+    { name = "httpx", marker = "python_full_version >= '3.12'" },
+    { name = "postgrest", marker = "python_full_version >= '3.12'" },
+    { name = "realtime", marker = "python_full_version >= '3.12'" },
+    { name = "storage3", marker = "python_full_version >= '3.12'" },
+    { name = "supabase-auth", marker = "python_full_version >= '3.12'" },
+    { name = "supabase-functions", marker = "python_full_version >= '3.12'" },
+    { name = "yarl", marker = "python_full_version >= '3.12'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/fe/8e/54a2f950629689b1613434a61fc3bff5f92f84ba6b20213f5b2add05c1bb/supabase-2.31.0.tar.gz", hash = "sha256:3467b09d00482b9a0138235bdbde7a350426f93cf2a1342372eaddfc669f1206", size = 9805, upload-time = "2026-06-04T13:37:25.22Z" }
 wheels = [
@@ -5078,9 +5078,9 @@ name = "supabase-auth"
 version = "2.31.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "httpx", extra = ["http2"] },
-    { name = "pydantic" },
-    { name = "pyjwt", extra = ["crypto"] },
+    { name = "httpx", extra = ["http2"], marker = "python_full_version >= '3.12'" },
+    { name = "pydantic", marker = "python_full_version >= '3.12'" },
+    { name = "pyjwt", extra = ["crypto"], marker = "python_full_version >= '3.12'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/61/8a/408689cf39820f0d46d2731d6747ff94dbefc87ae977b4b5c4066da5b070/supabase_auth-2.31.0.tar.gz", hash = "sha256:0945b33fa96239c76dc8eaf96d7d2c94991950d24b4cfe4a5c2da9aa5e909663", size = 39151, upload-time = "2026-06-04T13:37:27.375Z" }
 wheels = [
@@ -5092,9 +5092,9 @@ name = "supabase-functions"
 version = "2.31.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "httpx", extra = ["http2"] },
-    { name = "strenum" },
-    { name = "yarl" },
+    { name = "httpx", extra = ["http2"], marker = "python_full_version >= '3.12'" },
+    { name = "strenum", marker = "python_full_version >= '3.12'" },
+    { name = "yarl", marker = "python_full_version >= '3.12'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/84/5d/61c2446ed26a57fa5543f9c270a731320911569202340d15341f72cdba7c/supabase_functions-2.31.0.tar.gz", hash = "sha256:4ad027b3ae3bd28b31233339f4db1da6965affd3546f655b421baf40cee2690f", size = 4683, upload-time = "2026-06-04T13:37:28.878Z" }
 wheels = [
@@ -5497,13 +5497,13 @@ wheels = [
 
 [package.optional-dependencies]
 standard = [
-    { name = "colorama", marker = "sys_platform == 'win32'" },
-    { name = "httptools" },
-    { name = "python-dotenv" },
-    { name = "pyyaml" },
-    { name = "uvloop", marker = "platform_python_implementation != 'PyPy' and sys_platform != 'cygwin' and sys_platform != 'win32'" },
-    { name = "watchfiles" },
-    { name = "websockets" },
+    { name = "colorama", marker = "python_full_version < '3.14' and sys_platform == 'win32'" },
+    { name = "httptools", marker = "python_full_version < '3.14'" },
+    { name = "python-dotenv", marker = "python_full_version < '3.14'" },
+    { name = "pyyaml", marker = "python_full_version < '3.14'" },
+    { name = "uvloop", marker = "python_full_version < '3.14' and platform_python_implementation != 'PyPy' and sys_platform != 'cygwin' and sys_platform != 'win32'" },
+    { name = "watchfiles", marker = "python_full_version < '3.14'" },
+    { name = "websockets", marker = "python_full_version < '3.14'" },
 ]
 
 [[package]]
@@ -5564,7 +5564,7 @@ name = "watchfiles"
 version = "1.2.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "anyio" },
+    { name = "anyio", marker = "python_full_version < '3.14'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/cd/41/5e1a4bb12aac5f1493fa1bdc11154eca3b258ca4eba65d39c473fe19d8e9/watchfiles-1.2.0.tar.gz", hash = "sha256:c995fba777f1ea992f090f9236e9284cf7a5d1a0130dd5a3d82c598cacd76838", size = 108252, upload-time = "2026-05-18T04:32:04.251Z" }
 wheels = [


### PR DESCRIPTION
#### Overview

Prepare the `0.3` release line and advance `main` to `0.4.0`.

#### Details

- Created `release/0.3` from `0.3.0` on `upstream/main`.
- Confirmed the nightly alpha workflow remains on `main`; no frozen-line nightly configuration update is required.
- Updated release-versioned package metadata, internal dependency pins, lockfiles, and release-facing examples to `0.4.0`.
- Corrected the versioning helper's collector package path and updated its focused regression test.
- Release-bound PRs should now target `release/*`; later-release work should continue to target `main`.

#### Validation

- `uv run pytest tests/scripts/test_set_python_project_versions.py`
- `just set-version 0.4.0`
- `cargo check --workspace --locked`
- `just build-all`
- `just wheels`
- `just --fmt --check`
- `uv run pre-commit run --all-files attributions-rust`
- `uv run pre-commit run --all-files attributions-python`
- `uv run pre-commit run --all-files attributions-node`
- `git diff --check`

#### Where should the reviewer start?

Review `Cargo.toml` and `scripts/ci/set_python_project_versions.py` for the version handoff and the collector path correction.

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- Relates to: none

- [x] I confirm this contribution is my own work, or I have the right to submit it under this project's license.
- [x] I searched existing issues and open pull requests, and this does not duplicate existing work.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Release**
  * Updated NeMo Fabric and its adapters, runtimes, SDKs, and contracts to version 0.4.0.
  * Aligned package dependencies and optional integrations with the 0.4.0 release.

* **Documentation**
  * Updated Harbor, SWE-Bench, and notebook setup instructions and examples to use version 0.4.0.

* **Maintenance**
  * Updated version synchronization tooling and validation coverage for the renamed collector package.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->