### PR TITLE
docs: address NOOA documentation style issues

### DIFF
--- a/adapters/python/nooa/pypi.md
+++ b/adapters/python/nooa/pypi.md
@@ -24,5 +24,5 @@ SPDX-License-Identifier: Apache-2.0
 | `pip install "nemo-fabric-adapters-nooa[full]"` | No | Yes | Yes | Yes |
 | `pip install nemo-fabric-adapters-nooa` | No | Yes | No | No |
 
-For configuration, supported targets, and behavior, see the
+For configuration, supported targets, and behavior, refer to the
 [NOOA adapter README](https://github.com/NVIDIA/NeMo-Fabric/tree/main/adapters/python/nooa/README.md).

--- a/examples/harbor/nooa_bench/README.md
+++ b/examples/harbor/nooa_bench/README.md
@@ -36,7 +36,7 @@ manylinux runtime wheel, into the ignored Docker build context:
 ./examples/harbor/nooa_bench/prepare.sh
 ```
 
-The task image installs `nemo-fabric-adapters-nooa[full]` from the built wheel;
+The task image installs `nemo-fabric-adapters-nooa[full]` from the built wheel, while
 its package metadata installs the tested `nooa`, `nooa-cli`, `nooa-bench`, and
 Relay versions from PyPI. `prepare.sh` builds the required NeMo Fabric wheels in
 a fresh temporary directory and uses Maturin with Zig for manylinux 2.17


### PR DESCRIPTION
#### Overview

Fix documentation style issues

#### Where should the reviewer start?

<!-- Point to the most important file, test, or design decision. -->

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- Closes FABRIC-240

- [ ] I confirm this contribution is my own work, or I have the right to submit it under this project's license.
- [ ] I searched existing issues and open pull requests, and this does not duplicate existing work.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated the Python adapter installation guidance to reference the NOOA adapter README for configuration, supported targets, and behavior.
  - Clarified task-image setup instructions in the NOOA benchmark example.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->