### PR TITLE
ci: Perform npm publishing and npm verification in two separate steps.

### DIFF
--- a/.github/workflows/publish_typescript.yml
+++ b/.github/workflows/publish_typescript.yml
@@ -7,11 +7,7 @@ on:
   push:
     tags:
       - 'v*'
-      - 'npm/nemo-fabric-adapters-common/v*'
-      - 'npm/nemo-fabric-adapters-pi/v*'
       - '!v*-alpha*'
-      - '!npm/nemo-fabric-adapters-common/v*-alpha*'
-      - '!npm/nemo-fabric-adapters-pi/v*-alpha*'
 
 concurrency:
   group: publish-typescript
@@ -103,25 +99,10 @@ jobs:
 
           case "$RELEASE_TAG" in
             v*)
-              package_name="nemo-fabric-adapter-contract"
-              package_directory="adapter-contract/typescript"
-              test_recipe="test-typescript"
               version_tag="$RELEASE_TAG"
               ;;
-            npm/nemo-fabric-adapters-common/v*)
-              package_name="nemo-fabric-adapters-common"
-              package_directory="adapters/typescript/common"
-              test_recipe="test-typescript-adapters"
-              version_tag="${RELEASE_TAG##*/}"
-              ;;
-            npm/nemo-fabric-adapters-pi/v*)
-              package_name="nemo-fabric-adapters-pi"
-              package_directory="adapters/typescript/pi"
-              test_recipe="test-typescript-adapters"
-              version_tag="${RELEASE_TAG##*/}"
-              ;;
             *)
-              echo "Unsupported TypeScript package tag: $RELEASE_TAG" >&2
+              echo "Unsupported TypeScript release tag: $RELEASE_TAG" >&2
               exit 1
               ;;
           esac
@@ -143,40 +124,47 @@ jobs:
 
           python3 scripts/ci/set_typescript_project_version.py "$version"
           {
-            echo "package_name=$package_name"
-            echo "package_directory=$package_directory"
-            echo "test_recipe=$test_recipe"
             echo "version=$version"
             echo "dist_tag=$dist_tag"
           } >> "$GITHUB_OUTPUT"
 
-      - name: Test package
-        env:
-          RELEASE_TEST_RECIPE: ${{ steps.release.outputs.test_recipe }}
-        run: just "$RELEASE_TEST_RECIPE"
-
-      - name: Verify published dependencies
-        if: steps.release.outputs.package_name != 'nemo-fabric-adapter-contract'
-        env:
-          NPM_CONFIG_REGISTRY: https://registry.npmjs.org
-          PACKAGE_NAME: ${{ steps.release.outputs.package_name }}
-          RELEASE_VERSION: ${{ steps.release.outputs.version }}
+      - name: Test packages
         run: |
-          set -euo pipefail
-          npm view "nemo-fabric-adapter-contract@${RELEASE_VERSION}" version
-          if [[ "$PACKAGE_NAME" == "nemo-fabric-adapters-pi" ]]; then
-            npm view "nemo-fabric-adapters-common@${RELEASE_VERSION}" version
-          fi
+          just test-typescript
+          just test-typescript-adapters
 
-      - name: Publish package
+      - name: Publish packages
         env:
           NPM_CONFIG_REGISTRY: https://registry.npmjs.org
-          PACKAGE_DIRECTORY: ${{ steps.release.outputs.package_directory }}
           RELEASE_VERSION: ${{ steps.release.outputs.version }}
           RELEASE_DIST_TAG: ${{ steps.release.outputs.dist_tag }}
         run: |
           set -euo pipefail
-          python3 scripts/ci/publish_typescript_package.py \
-            --package-directory "$PACKAGE_DIRECTORY" \
-            --version "$RELEASE_VERSION" \
-            --dist-tag "$RELEASE_DIST_TAG"
+          for package_directory in \
+            adapter-contract/typescript \
+            adapters/typescript/common \
+            adapters/typescript/pi; do
+            python3 scripts/ci/publish_typescript_package.py \
+              --action publish \
+              --package-directory "$package_directory" \
+              --version "$RELEASE_VERSION" \
+              --dist-tag "$RELEASE_DIST_TAG"
+          done
+
+      - name: Verify packages
+        env:
+          NPM_CONFIG_REGISTRY: https://registry.npmjs.org
+          RELEASE_VERSION: ${{ steps.release.outputs.version }}
+          RELEASE_DIST_TAG: ${{ steps.release.outputs.dist_tag }}
+        run: |
+          set -euo pipefail
+          for package_directory in \
+            adapter-contract/typescript \
+            adapters/typescript/common \
+            adapters/typescript/pi; do
+            python3 scripts/ci/publish_typescript_package.py \
+              --action verify \
+              --package-directory "$package_directory" \
+              --version "$RELEASE_VERSION" \
+              --dist-tag "$RELEASE_DIST_TAG"
+          done

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -241,8 +241,7 @@ Before the first supported TypeScript package release:
    account-level two-factor authentication.
 2. Create and protect the GitHub `npmjs` environment. Require the release
    approvers who should authorize registry publication, and restrict deployment
-   tags to canonical release tags matching `v*` and adapter publication tags
-   matching `npm/nemo-fabric-adapters-*/v*`.
+   tags to canonical release tags matching `v*`.
 3. Configure each package's single trusted publisher in npm with the common
    values below and the package-specific workflow filename shown in the table.
    The values are case-sensitive.
@@ -258,11 +257,9 @@ Before the first supported TypeScript package release:
    | `nemo-fabric-adapters-common` | `publish_typescript.yml` |
    | `nemo-fabric-adapters-pi` | `publish_typescript.yml` |
 
-4. Cut the canonical release tag first. After the contract version is visible
-   on npm, create the Common adapter tag at the same commit. After Common is
-   visible, create the Pi adapter tag at that commit. Release coordination is
-   responsible for keeping these tags aligned; the publishing workflow does not
-   compare adapter tags with the canonical tag.
+4. Cut the canonical release tag. The publishing workflow uses that tag to
+   publish the contract, Common adapter, and Pi adapter packages in dependency
+   order, then verifies them in that order.
 5. Approve the `npmjs` environment when prompted. The workflows test, pack, and
    publish through OIDC; do not manually pre-publish a supported version. On a
    retry, a workflow exits without republishing only when its repack has
@@ -413,44 +410,23 @@ git push upstream "refs/tags/${RELEASE_TAG}"
 
 ## Publish the TypeScript Adapter Packages
 
-After the canonical beta, RC, or stable tag publishes the contract package,
-publish the bundled adapter packages in dependency order. Every package tag
-must use the canonical release version and point to the canonical tag's commit.
-
-```bash
-export NPM_CONFIG_REGISTRY=https://registry.npmjs.org
-RELEASE_SHA="$(git rev-parse "${RELEASE_TAG}^{commit}")"
-
-npm view "nemo-fabric-adapter-contract@${RELEASE_VERSION}" version
-
-for package in nemo-fabric-adapters-common nemo-fabric-adapters-pi; do
-  package_tag="npm/${package}/v${RELEASE_VERSION}"
-  git tag -s -a \
-    -m "${package} ${RELEASE_VERSION}" \
-    "$package_tag" \
-    "$RELEASE_SHA"
-  test "$(git rev-parse "${package_tag}^{commit}")" = "$RELEASE_SHA"
-  git push upstream "refs/tags/${package_tag}"
-
-  # Wait for this publication to finish before advancing to its dependent.
-  npm view "${package}@${RELEASE_VERSION}" version
-done
-```
-
-Do not create npm package tags for alpha versions. The nightly workflow runs
-the TypeScript tests against the alpha tag without publishing to npm.
+Pushing the canonical beta, RC, or stable tag publishes the contract, Common
+adapter, and Pi adapter packages in dependency order. The workflow submits all
+three packages before it starts deployment verification, then verifies them in
+the same order. Do not create package-specific npm tags. The nightly workflow
+runs the TypeScript tests against alpha tags without publishing to npm.
 
 
-## What CI Does on a Tag Push
+## What CI Does on a Canonical Tag Push
 
-Pushing a valid canonical or npm package tag triggers:
+Pushing a valid canonical tag triggers:
 
 | Workflow | Trigger |
 |---|---|
 | [`.github/workflows/ci_python.yml`](.github/workflows/ci_python.yml) | For all tags including alpha |
 | [`.github/workflows/publish_rust.yml`](.github/workflows/publish_rust.yml) | For RC, beta and release tags |
 | [`.github/workflows/ci_typescript.yml`](.github/workflows/ci_typescript.yml) | For nightly alpha tags and normal pull request/main validation |
-| [`.github/workflows/publish_typescript.yml`](.github/workflows/publish_typescript.yml) | For contract, Common, and Pi beta, RC, and stable tags |
+| [`.github/workflows/publish_typescript.yml`](.github/workflows/publish_typescript.yml) | Publishes and verifies the contract, Common, and Pi packages for beta, RC, and stable tags |
 | [`.github/workflows/fern-docs.yml`](.github/workflows/fern-docs.yml) | For RC, beta and release tags |
 
 The release pipeline then:
@@ -463,10 +439,10 @@ The release pipeline then:
 3. Publishes `nemo-fabric-core` and `nemo-fabric-cli` to crates.io through
    trusted publishing for stable, beta, and RC tags. Alpha tags are not
    published to crates.io.
-4. Publishes `nemo-fabric-adapter-contract` to npm from the canonical tag, then
-   publishes Common and Pi when their package tags are pushed in dependency
-   order. Stable releases use the `latest` dist-tag and beta and RC releases use
-   `next`. Alpha tags validate the packages without publishing them.
+4. Publishes the contract, Common, and Pi packages to npm from the canonical
+   tag in dependency order, then verifies the deployment in that order. Stable
+   releases use the `latest` dist-tag and beta and RC releases use `next`.
+   Alpha tags validate the packages without publishing them.
 5. Publishes Fern documentation versions for stable, beta, and RC tags. Alpha
    tags do not publish a separate documentation version.
 

--- a/scripts/ci/publish_typescript_package.py
+++ b/scripts/ci/publish_typescript_package.py
@@ -19,10 +19,6 @@ VERSION_PATTERN = re.compile(
     r"(?:-(?P<label>alpha|beta|rc)(?:\.(?P<number>\d+))?)?"
     r"(?:\+[0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*)?$"
 )
-EXACT_DEPENDENCY_VERSION_PATTERN = re.compile(
-    r"^\d+\.\d+\.\d+(?:-[0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*)?"
-    r"(?:\+[0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*)?$"
-)
 PRERELEASE_ORDER = {"alpha": 0, "beta": 1, "rc": 2}
 NPM_NOT_FOUND_MARKERS = ("E404", "404 Not Found")
 
@@ -167,47 +163,6 @@ def _view(
     )
 
 
-def _preflight_runtime_dependencies(
-    package_directory: Path,
-    run_npm: RunNpm,
-) -> None:
-    """Require every exact production dependency to exist in the npm registry."""
-    try:
-        manifest = json.loads(
-            (package_directory / "package.json").read_text(encoding="utf-8")
-        )
-    except (OSError, UnicodeError, json.JSONDecodeError) as error:
-        raise PublicationError("Package package.json could not be read") from error
-    if not isinstance(manifest, dict):
-        raise PublicationError("Package package.json must contain an object")
-    dependencies = manifest.get("dependencies", {})
-    if not isinstance(dependencies, dict):
-        raise PublicationError("Package dependencies must be an object")
-
-    for name, version in sorted(dependencies.items()):
-        if not isinstance(name, str) or not isinstance(version, str):
-            raise PublicationError("Package dependencies must map names to versions")
-        if EXACT_DEPENDENCY_VERSION_PATTERN.fullmatch(version) is None:
-            raise PublicationError(
-                f"Runtime dependency {name} must use an exact npm version, got {version}"
-            )
-        published_version = _view(
-            package_directory,
-            run_npm,
-            f"{name}@{version}",
-            "version",
-        )
-        if published_version is None:
-            raise PublicationError(
-                f"Required runtime dependency {name}@{version} is not published"
-            )
-        if published_version != version:
-            raise PublicationError(
-                f"Required runtime dependency {name}@{version} resolved as "
-                f"{published_version}"
-            )
-
-
 def _published_state(
     package_directory: Path,
     artifact: PackageArtifact,
@@ -281,16 +236,11 @@ def publish_package(
     dist_tag: str,
     *,
     run_npm: RunNpm = _run_npm,
-    sleep: Sleep = time.sleep,
-    verification_attempts: int = 6,
 ) -> None:
     if dist_tag not in {"alpha", "latest", "next"}:
         raise PublicationError(f"Unsupported npm dist-tag: {dist_tag}")
-    if verification_attempts < 1:
-        raise PublicationError("At least one registry verification attempt is required")
 
     artifact = _pack_package(package_directory, version, run_npm)
-    _preflight_runtime_dependencies(package_directory, run_npm)
     state = _published_state(package_directory, artifact, dist_tag, run_npm)
     if state is not None:
         if _state_matches(state, artifact):
@@ -331,6 +281,28 @@ def publish_package(
     if publish_result.stderr:
         print(publish_result.stderr.rstrip(), file=sys.stderr)
 
+    if publish_result.returncode != 0:
+        publish_detail = _command_error(publish_result)
+        raise PublicationError(
+            f"npm publish failed{f': {publish_detail}' if publish_detail else ''}"
+        )
+
+
+def verify_package(
+    package_directory: Path,
+    version: str,
+    dist_tag: str,
+    *,
+    run_npm: RunNpm = _run_npm,
+    sleep: Sleep = time.sleep,
+    verification_attempts: int = 6,
+) -> None:
+    if dist_tag not in {"alpha", "latest", "next"}:
+        raise PublicationError(f"Unsupported npm dist-tag: {dist_tag}")
+    if verification_attempts < 1:
+        raise PublicationError("At least one registry verification attempt is required")
+
+    artifact = _pack_package(package_directory, version, run_npm)
     last_error = PublicationError("The package version is not visible in npm")
     for attempt in range(verification_attempts):
         state = _published_state(package_directory, artifact, dist_tag, run_npm)
@@ -345,15 +317,7 @@ def publish_package(
         if attempt + 1 < verification_attempts:
             sleep(5 * (2**attempt))
 
-    publish_detail = _command_error(publish_result)
-    if publish_result.returncode != 0:
-        raise PublicationError(
-            f"npm publish failed{f': {publish_detail}' if publish_detail else ''}; "
-            f"registry verification also failed: {last_error}"
-        )
-    raise PublicationError(
-        f"npm publish completed, but verification failed: {last_error}"
-    )
+    raise PublicationError(f"Verification failed: {last_error}")
 
 
 def _parse_args() -> argparse.Namespace:
@@ -362,6 +326,11 @@ def _parse_args() -> argparse.Namespace:
     )
     parser.add_argument("--package-directory", type=Path, required=True)
     parser.add_argument("--version", required=True)
+    parser.add_argument(
+        "--action",
+        choices=("publish", "verify"),
+        required=True,
+    )
     parser.add_argument(
         "--dist-tag",
         choices=("alpha", "latest", "next"),
@@ -372,11 +341,18 @@ def _parse_args() -> argparse.Namespace:
 
 def main() -> None:
     arguments = _parse_args()
-    publish_package(
-        arguments.package_directory,
-        arguments.version,
-        arguments.dist_tag,
-    )
+    if arguments.action == "publish":
+        publish_package(
+            arguments.package_directory,
+            arguments.version,
+            arguments.dist_tag,
+        )
+    else:
+        verify_package(
+            arguments.package_directory,
+            arguments.version,
+            arguments.dist_tag,
+        )
 
 
 if __name__ == "__main__":

--- a/scripts/ci/publish_typescript_package.py
+++ b/scripts/ci/publish_typescript_package.py
@@ -313,7 +313,9 @@ def verify_package(
                     f"{dist_tag} dist-tag"
                 )
                 return
-            raise PublicationError(_describe_conflict(state, artifact, dist_tag))
+            if state.integrity and state.integrity != artifact.integrity:
+                raise PublicationError(_describe_conflict(state, artifact, dist_tag))
+            last_error = PublicationError(_describe_conflict(state, artifact, dist_tag))
         if attempt + 1 < verification_attempts:
             sleep(5 * (2**attempt))
 

--- a/tests/scripts/test_publish_typescript_package.py
+++ b/tests/scripts/test_publish_typescript_package.py
@@ -163,9 +163,7 @@ def test_existing_exact_package_without_registry_readme_is_idempotent_success(
         (dist_tag, integrity, dist_tag_version, error)
         for dist_tag in ("alpha", "latest", "next")
         for integrity, dist_tag_version, error in (
-            ("", VERSION, "Published integrity is missing"),
             ("sha512-wrong", VERSION, "Expected integrity"),
-            (INTEGRITY, "0.1.0", f"Published {dist_tag} dist-tag"),
         )
     ],
 )
@@ -475,6 +473,32 @@ def test_visible_verification_conflict_fails_without_retry(package_directory: Pa
         )
 
     assert delays == []
+    runner.assert_finished()
+
+
+def test_verification_retries_until_registry_metadata_converges(
+    package_directory: Path,
+):
+    runner = NpmRunner(
+        [
+            (["pack", "--json", "--ignore-scripts"], _pack_result()),
+            (["view", f"{PACKAGE}@{VERSION}", "version"], _result(VERSION)),
+            (["view", f"{PACKAGE}@{VERSION}", "dist.integrity"], _result()),
+            (["view", PACKAGE, "dist-tags.latest"], _result("0.1.0")),
+            *_exact_view_responses(),
+        ]
+    )
+    delays: list[float] = []
+
+    publish_typescript_package.verify_package(
+        package_directory,
+        VERSION,
+        "latest",
+        run_npm=runner,
+        sleep=delays.append,
+    )
+
+    assert delays == [5]
     runner.assert_finished()
 
 

--- a/tests/scripts/test_publish_typescript_package.py
+++ b/tests/scripts/test_publish_typescript_package.py
@@ -101,103 +101,6 @@ def package_directory_fixture(tmp_path: Path) -> Path:
     return package_directory
 
 
-def test_runtime_dependencies_are_preflighted_against_npm(
-    package_directory: Path,
-):
-    dependency = "nemo-fabric-adapters-common"
-    dependency_version = "0.3.0"
-    manifest = json.loads(
-        (package_directory / "package.json").read_text(encoding="utf-8")
-    )
-    manifest["dependencies"] = {dependency: dependency_version}
-    (package_directory / "package.json").write_text(
-        json.dumps(manifest), encoding="utf-8"
-    )
-    runner = NpmRunner(
-        [
-            (["pack", "--json", "--ignore-scripts"], _pack_result()),
-            (
-                ["view", f"{dependency}@{dependency_version}", "version"],
-                _result(dependency_version),
-            ),
-            *_exact_view_responses(),
-        ]
-    )
-
-    publish_typescript_package.publish_package(
-        package_directory,
-        VERSION,
-        "latest",
-        run_npm=runner,
-        sleep=lambda _: None,
-    )
-
-    runner.assert_finished()
-
-
-def test_unpublished_runtime_dependency_blocks_publication(
-    package_directory: Path,
-):
-    dependency = "nemo-fabric-adapters-common"
-    dependency_version = "0.3.0"
-    manifest = json.loads(
-        (package_directory / "package.json").read_text(encoding="utf-8")
-    )
-    manifest["dependencies"] = {dependency: dependency_version}
-    (package_directory / "package.json").write_text(
-        json.dumps(manifest), encoding="utf-8"
-    )
-    missing = _result(returncode=1, stderr="npm error code E404")
-    runner = NpmRunner(
-        [
-            (["pack", "--json", "--ignore-scripts"], _pack_result()),
-            (["view", f"{dependency}@{dependency_version}", "version"], missing),
-        ]
-    )
-
-    with pytest.raises(
-        publish_typescript_package.PublicationError,
-        match=(
-            "Required runtime dependency "
-            f"{dependency}@{dependency_version} is not published"
-        ),
-    ):
-        publish_typescript_package.publish_package(
-            package_directory,
-            VERSION,
-            "latest",
-            run_npm=runner,
-            sleep=lambda _: None,
-        )
-
-    runner.assert_finished()
-
-
-def test_runtime_dependency_versions_must_be_exact(package_directory: Path):
-    manifest = json.loads(
-        (package_directory / "package.json").read_text(encoding="utf-8")
-    )
-    manifest["dependencies"] = {"nemo-fabric-adapters-common": "^0.3.0"}
-    (package_directory / "package.json").write_text(
-        json.dumps(manifest), encoding="utf-8"
-    )
-    runner = NpmRunner([(["pack", "--json", "--ignore-scripts"], _pack_result())])
-
-    with pytest.raises(
-        publish_typescript_package.PublicationError,
-        match=r"must use an exact npm version, got \^0\.3\.0",
-    ):
-        publish_typescript_package.publish_package(
-            package_directory,
-            VERSION,
-            "latest",
-            run_npm=runner,
-            sleep=lambda _: None,
-        )
-
-    runner.assert_finished()
-
-
 def _exact_view_responses(
     *,
     integrity: str = INTEGRITY,
@@ -220,7 +123,7 @@ def test_invalid_readme_encoding_fails_closed(package_directory: Path):
         publish_typescript_package.PublicationError,
         match=r"Package README\.md could not be read",
     ):
-        publish_typescript_package.publish_package(
+        publish_typescript_package.verify_package(
             package_directory,
             VERSION,
             "latest",
@@ -243,7 +146,7 @@ def test_existing_exact_package_without_registry_readme_is_idempotent_success(
         ]
     )
 
-    publish_typescript_package.publish_package(
+    publish_typescript_package.verify_package(
         package_directory,
         VERSION,
         dist_tag,
@@ -288,7 +191,7 @@ def test_existing_conflicting_package_fails(
         publish_typescript_package.PublicationError,
         match=error,
     ):
-        publish_typescript_package.publish_package(
+        publish_typescript_package.verify_package(
             package_directory,
             VERSION,
             dist_tag,
@@ -313,7 +216,7 @@ def test_packed_artifact_must_include_readme(package_directory: Path):
         publish_typescript_package.PublicationError,
         match=r"Packed artifact is missing README\.md",
     ):
-        publish_typescript_package.publish_package(
+        publish_typescript_package.verify_package(
             package_directory,
             VERSION,
             "latest",
@@ -325,7 +228,7 @@ def test_packed_artifact_must_include_readme(package_directory: Path):
 
 
 @pytest.mark.parametrize("dist_tag", ["alpha", "latest", "next"])
-def test_absent_package_publishes_directory_and_verifies(
+def test_absent_package_publishes_directory(
     package_directory: Path,
     dist_tag: str,
 ):
@@ -347,7 +250,6 @@ def test_absent_package_publishes_directory_and_verifies(
                 ],
                 _result("published"),
             ),
-            *_exact_view_responses(dist_tag=dist_tag),
         ]
     )
 
@@ -356,7 +258,6 @@ def test_absent_package_publishes_directory_and_verifies(
         VERSION,
         dist_tag,
         run_npm=runner,
-        sleep=lambda _: None,
     )
 
     runner.assert_finished()
@@ -377,12 +278,11 @@ def test_non_404_lookup_failure_fails_closed(package_directory: Path):
         publish_typescript_package.PublicationError,
         match="E503",
     ):
-        publish_typescript_package.publish_package(
+        publish_typescript_package.verify_package(
             package_directory,
             VERSION,
             "latest",
             run_npm=runner,
-            sleep=lambda _: None,
         )
 
     runner.assert_finished()
@@ -411,13 +311,12 @@ def test_dist_tag_cannot_move_backward(
             VERSION,
             dist_tag,
             run_npm=runner,
-            sleep=lambda _: None,
         )
 
     runner.assert_finished()
 
 
-def test_ambiguous_publish_failure_reconciles_registry_state(package_directory: Path):
+def test_publish_failure_is_reported(package_directory: Path):
     missing = _result(returncode=1, stderr="npm error code E404")
     runner = NpmRunner(
         [
@@ -436,17 +335,19 @@ def test_ambiguous_publish_failure_reconciles_registry_state(package_directory: 
                 ],
                 _result(returncode=1, stderr="network connection closed"),
             ),
-            *_exact_view_responses(),
         ]
     )
 
-    publish_typescript_package.publish_package(
-        package_directory,
-        VERSION,
-        "latest",
-        run_npm=runner,
-        sleep=lambda _: None,
-    )
+    with pytest.raises(
+        publish_typescript_package.PublicationError,
+        match="npm publish failed: network connection closed",
+    ):
+        publish_typescript_package.publish_package(
+            package_directory,
+            VERSION,
+            "latest",
+            run_npm=runner,
+        )
 
     runner.assert_finished()
 
@@ -458,7 +359,7 @@ def test_invalid_dist_tag_fails_before_packing(package_directory: Path):
         publish_typescript_package.PublicationError,
         match="Unsupported npm dist-tag: beta",
     ):
-        publish_typescript_package.publish_package(
+        publish_typescript_package.verify_package(
             package_directory,
             VERSION,
             "beta",
@@ -479,7 +380,7 @@ def test_invalid_verification_attempts_fail_before_packing(
         publish_typescript_package.PublicationError,
         match="At least one registry verification attempt is required",
     ):
-        publish_typescript_package.publish_package(
+        publish_typescript_package.verify_package(
             package_directory,
             VERSION,
             "latest",
@@ -552,25 +453,10 @@ def test_packed_tarball_must_exist(package_directory: Path):
     runner.assert_finished()
 
 
-def test_visible_post_publish_conflict_fails_without_retry(package_directory: Path):
-    missing = _result(returncode=1, stderr="npm error code E404")
+def test_visible_verification_conflict_fails_without_retry(package_directory: Path):
     runner = NpmRunner(
         [
             (["pack", "--json", "--ignore-scripts"], _pack_result()),
-            (["view", f"{PACKAGE}@{VERSION}", "version"], missing),
-            (["view", PACKAGE, "dist-tags.latest"], _result("0.1.0")),
-            (
-                [
-                    "publish",
-                    ".",
-                    "--ignore-scripts",
-                    "--access",
-                    "public",
-                    "--tag",
-                    "latest",
-                ],
-                _result(returncode=1, stderr="network connection closed"),
-            ),
             *_exact_view_responses(integrity="sha512-conflict"),
         ]
     )
@@ -580,7 +466,7 @@ def test_visible_post_publish_conflict_fails_without_retry(package_directory: Pa
         publish_typescript_package.PublicationError,
         match="Expected integrity",
     ):
-        publish_typescript_package.publish_package(
+        publish_typescript_package.verify_package(
             package_directory,
             VERSION,
             "latest",
@@ -592,25 +478,11 @@ def test_visible_post_publish_conflict_fails_without_retry(package_directory: Pa
     runner.assert_finished()
 
 
-def test_failed_publish_exhaustion_reports_both_failures(package_directory: Path):
+def test_verification_exhaustion_reports_failure(package_directory: Path):
     missing = _result(returncode=1, stderr="npm error code E404")
     runner = NpmRunner(
         [
             (["pack", "--json", "--ignore-scripts"], _pack_result()),
-            (["view", f"{PACKAGE}@{VERSION}", "version"], missing),
-            (["view", PACKAGE, "dist-tags.latest"], _result("0.1.0")),
-            (
-                [
-                    "publish",
-                    ".",
-                    "--ignore-scripts",
-                    "--access",
-                    "public",
-                    "--tag",
-                    "latest",
-                ],
-                _result(returncode=1, stderr="network connection closed"),
-            ),
             (["view", f"{PACKAGE}@{VERSION}", "version"], missing),
             (["view", f"{PACKAGE}@{VERSION}", "version"], missing),
             (["view", f"{PACKAGE}@{VERSION}", "version"], missing),
@@ -621,7 +493,7 @@ def test_failed_publish_exhaustion_reports_both_failures(package_directory: Path
     with pytest.raises(
         publish_typescript_package.PublicationError,
     ) as error:
-        publish_typescript_package.publish_package(
+        publish_typescript_package.verify_package(
             package_directory,
             VERSION,
             "latest",
@@ -631,9 +503,7 @@ def test_failed_publish_exhaustion_reports_both_failures(package_directory: Path
         )
 
     message = str(error.value)
-    assert "npm publish failed: network connection closed" in message
-    assert "registry verification also failed" in message
-    assert "package version is not visible in npm" in message
+    assert "Verification failed: The package version is not visible in npm" in message
     assert delays == [5, 10]
     runner.assert_finished()
 

--- a/tests/scripts/test_publish_typescript_workflow.py
+++ b/tests/scripts/test_publish_typescript_workflow.py
@@ -46,10 +46,9 @@ def test_publisher_only_triggers_for_public_release_channels():
     assert not _tag_triggers_workflow("v0.3.0-alpha.20260817", tag_patterns)
     for package in ("nemo-fabric-adapters-common", "nemo-fabric-adapters-pi"):
         for version in ("0.3.0", "0.3.0-beta.1", "0.3.0-rc.1"):
-            assert _tag_triggers_workflow(f"npm/{package}/v{version}", tag_patterns)
-        assert not _tag_triggers_workflow(
-            f"npm/{package}/v0.3.0-alpha.20260817", tag_patterns
-        )
+            assert not _tag_triggers_workflow(
+                f"npm/{package}/v{version}", tag_patterns
+            )
 
     steps = {
         step["name"]: step
@@ -62,30 +61,35 @@ def test_publisher_only_triggers_for_public_release_channels():
     assert '*) dist_tag="latest"' in release_metadata
 
 
-def test_publisher_routes_packages_and_checks_adapter_dependencies():
+def test_publisher_publishes_then_verifies_packages_in_dependency_order():
     workflow = _load_workflow(PUBLISH_WORKFLOW)
     steps = {
         step["name"]: step
         for step in workflow["jobs"]["publish-typescript"]["steps"]
     }
     release = steps["Resolve package release"]["run"]
-    assert 'package_name="nemo-fabric-adapter-contract"' in release
-    assert 'package_directory="adapter-contract/typescript"' in release
-    assert 'package_name="nemo-fabric-adapters-common"' in release
-    assert 'package_directory="adapters/typescript/common"' in release
-    assert 'package_name="nemo-fabric-adapters-pi"' in release
-    assert 'package_directory="adapters/typescript/pi"' in release
-    assert 'test_recipe="test-typescript"' in release
-    assert 'test_recipe="test-typescript-adapters"' in release
+    assert 'case "$RELEASE_TAG" in' in release
+    assert "npm/nemo-fabric-adapters" not in release
     assert "set_typescript_project_version.py" in release
     assert "set_typescript_adapter_version.py" not in release
-    assert steps["Test package"]["run"] == 'just "$RELEASE_TEST_RECIPE"'
-    dependency_check = steps["Verify published dependencies"]["run"]
-    assert "nemo-fabric-adapter-contract@${RELEASE_VERSION}" in dependency_check
-    assert "nemo-fabric-adapters-common@${RELEASE_VERSION}" in dependency_check
-    assert steps["Publish package"]["env"]["PACKAGE_DIRECTORY"] == (
-        "${{ steps.release.outputs.package_directory }}"
+    assert steps["Test packages"]["run"] == (
+        "just test-typescript\njust test-typescript-adapters\n"
     )
+    assert "Verify published dependencies" not in steps
+
+    package_directories = (
+        "adapter-contract/typescript",
+        "adapters/typescript/common",
+        "adapters/typescript/pi",
+    )
+    for step_name, action in (
+        ("Publish packages", "publish"),
+        ("Verify packages", "verify"),
+    ):
+        run = steps[step_name]["run"]
+        positions = [run.index(directory) for directory in package_directories]
+        assert positions == sorted(positions)
+        assert f"--action {action}" in run
 
 
 def test_nightly_alpha_runs_typescript_ci_without_npm_permissions():


### PR DESCRIPTION
#### Overview

* Doesn't block publishing other packages for verification
* Adds time between the publish of the first package and verification
* Remove older one-off tagging logic
* `.github/workflows/publish_typescript.yml`

- [x] I confirm this contribution is my own work, or I have the right to submit it under this project's license.
- [x] I searched existing issues and open pull requests, and this does not duplicate existing work.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Release Process**
  - TypeScript packages are now published and verified together using one canonical beta, release-candidate, or stable `v*` tag.
  - Alpha tags continue to validate packages without publishing them.
  - Package-specific npm tags are no longer created.
  - Publishing and verification cover all TypeScript packages in dependency order.
  - Release verification confirms package availability after publishing.
  - npm-prefixed release tags no longer trigger publishing.

- **Documentation**
  - Updated release guidance to describe canonical version tags and the TypeScript publishing workflow.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->