### PR TITLE
fix(pi): recover custom proxy context overflows

### DIFF
--- a/adapters/typescript/pi/README.md
+++ b/adapters/typescript/pi/README.md
@@ -27,7 +27,10 @@ The adapter supports:
 
 Ambient Pi settings, context files, packages, extensions, skills, prompts,
 themes, model files, credentials, and session files are disabled. Explicitly
-configured extensions are trusted code.
+configured extensions are trusted code. The adapter keeps enough context space
+for the selected model's maximum output. For custom model proxies, it also
+recognizes an exact bodyless server error as a recoverable overflow signal so
+Pi can make one bounded compact-and-retry attempt.
 
 ## Install the Adapter
 

--- a/adapters/typescript/pi/src/pi-sdk.ts
+++ b/adapters/typescript/pi/src/pi-sdk.ts
@@ -14,6 +14,7 @@ import type {
   ExtensionCommandContextActions,
   ToolDefinition,
 } from "@earendil-works/pi-coding-agent";
+import type { AssistantMessageEvent, Context, Model, SimpleStreamOptions } from "@earendil-works/pi-ai";
 import { createJiti } from "jiti/static";
 import type { AgentConfig, AgentModelConfig, AgentToolDefinition, JsonObject } from "nemo-fabric-adapter-contract";
 import { LifecycleError, type AdapterStartInput } from "nemo-fabric-adapters-common";
@@ -30,6 +31,44 @@ interface PiToolFactoryContext {
   workspace: string;
 }
 
+export function withCustomBaseUrl<T extends { api: string; baseUrl: string; compat?: object }>(
+  catalogModel: T,
+  baseUrl: string | null | undefined,
+): T {
+  if (!baseUrl) {
+    return catalogModel;
+  }
+  if (catalogModel.api !== "openai-completions") {
+    return { ...catalogModel, baseUrl };
+  }
+  return {
+    ...catalogModel,
+    baseUrl,
+    // Generic OpenAI-compatible proxies may reject provider-specific
+    // reasoning_content fields when Pi replays an assistant tool call.
+    compat: { ...catalogModel.compat, requiresThinkingAsText: true },
+  };
+}
+
+export function modelAwareCompactionReserveTokens(
+  configuredReserveTokens: number,
+  maxOutputTokens: number,
+): number {
+  return Math.max(configuredReserveTokens, maxOutputTokens);
+}
+
+const OPAQUE_PROXY_SERVER_ERROR = /^500 status code \(no body\)$/iu;
+
+export function classifyOpaqueProxyContextOverflow(
+  errorMessage: string | undefined,
+  contextWindow: number,
+): string | undefined {
+  if (errorMessage === undefined || contextWindow <= 0 || !OPAQUE_PROXY_SERVER_ERROR.test(errorMessage)) {
+    return errorMessage;
+  }
+  return `maximum context length is ${contextWindow} tokens (${errorMessage} from the configured model proxy)`;
+}
+
 type PiToolFactory = (context: PiToolFactoryContext) => ToolDefinition | Promise<ToolDefinition>;
 
 const PI_BUILTIN_TOOL_NAMES = new Set(["read", "bash", "edit", "write", "grep", "find", "ls"]);
@@ -39,6 +78,7 @@ const PI_HARNESS_INSTALL_COMMAND =
 
 interface PiSdkModules {
   InMemoryCredentialStore: typeof import("@earendil-works/pi-ai").InMemoryCredentialStore;
+  createAssistantMessageEventStream: typeof import("@earendil-works/pi-ai").createAssistantMessageEventStream;
   createAgentSession: typeof import("@earendil-works/pi-coding-agent").createAgentSession;
   DefaultResourceLoader: typeof import("@earendil-works/pi-coding-agent").DefaultResourceLoader;
   ModelRuntime: typeof import("@earendil-works/pi-coding-agent").ModelRuntime;
@@ -75,6 +115,7 @@ async function loadPiSdk(): Promise<PiSdkModules> {
 
   if (
     typeof ai.InMemoryCredentialStore !== "function" ||
+    typeof ai.createAssistantMessageEventStream !== "function" ||
     typeof codingAgent.createAgentSession !== "function" ||
     typeof codingAgent.DefaultResourceLoader !== "function" ||
     typeof codingAgent.ModelRuntime !== "function" ||
@@ -89,11 +130,70 @@ async function loadPiSdk(): Promise<PiSdkModules> {
 
   return {
     InMemoryCredentialStore: ai.InMemoryCredentialStore,
+    createAssistantMessageEventStream: ai.createAssistantMessageEventStream,
     createAgentSession: codingAgent.createAgentSession,
     DefaultResourceLoader: codingAgent.DefaultResourceLoader,
     ModelRuntime: codingAgent.ModelRuntime,
     SessionManager: codingAgent.SessionManager,
     SettingsManager: codingAgent.SettingsManager,
+  };
+}
+
+function streamFailure(model: Model<any>, error: unknown): AssistantMessageEvent {
+  const errorMessage = error instanceof Error ? error.message : String(error);
+  return {
+    type: "error",
+    reason: "error",
+    error: {
+      role: "assistant",
+      content: [],
+      api: model.api,
+      provider: model.provider,
+      model: model.id,
+      usage: {
+        input: 0,
+        output: 0,
+        cacheRead: 0,
+        cacheWrite: 0,
+        totalTokens: 0,
+        cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+      },
+      stopReason: "error",
+      errorMessage,
+      timestamp: Date.now(),
+    },
+  };
+}
+
+function installOpaqueProxyOverflowRecovery(session: AgentSession, pi: PiSdkModules): void {
+  const originalStream = session.agent.streamFunction.bind(session.agent);
+  session.agent.streamFunction = async (
+    model: Model<any>,
+    context: Context,
+    options?: SimpleStreamOptions,
+  ) => {
+    const source = await originalStream(model, context, options);
+    const target = pi.createAssistantMessageEventStream();
+    void (async () => {
+      try {
+        for await (const event of source) {
+          if (event.type !== "error") {
+            target.push(event);
+            continue;
+          }
+          const errorMessage = classifyOpaqueProxyContextOverflow(
+            event.error.errorMessage,
+            model.contextWindow,
+          );
+          target.push({ ...event, error: { ...event.error, errorMessage } });
+        }
+        target.end();
+      } catch (error) {
+        target.push(streamFailure(model, error));
+        target.end();
+      }
+    })();
+    return target;
   };
 }
 
@@ -491,7 +591,15 @@ export class PiSdkSessionFactory implements PiSessionFactory {
     if (catalogModel === undefined) {
       throw new LifecycleError("pi_model_unknown", "The selected provider and model are not present in Pi's catalog");
     }
-    const model = selected.base_url ? { ...catalogModel, baseUrl: selected.base_url } : catalogModel;
+    const model = withCustomBaseUrl(catalogModel, selected.base_url);
+    settings.applyOverrides({
+      compaction: {
+        reserveTokens: modelAwareCompactionReserveTokens(
+          settings.getCompactionReserveTokens(),
+          model.maxTokens,
+        ),
+      },
+    });
     const enabled = input.config.tools?.enabled;
     const blocked = input.config.tools?.blocked ?? [];
     const state = { shutdownRequested: false };
@@ -507,6 +615,9 @@ export class PiSdkSessionFactory implements PiSessionFactory {
       tools: enabled === null ? undefined : enabled,
       excludeTools: blocked,
     });
+    if (selected.base_url !== undefined && selected.base_url !== null) {
+      installOpaqueProxyOverflowRecovery(session, pi);
+    }
     const handle = new PiSdkSessionHandle(session, state);
     try {
       const blockedNames = new Set(blocked);

--- a/adapters/typescript/pi/test/pi-sdk.test.mjs
+++ b/adapters/typescript/pi/test/pi-sdk.test.mjs
@@ -7,7 +7,45 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import test from "node:test";
 
-import { PiSdkSessionFactory, resolveCustomTools } from "../dist/pi-sdk.js";
+import {
+  classifyOpaqueProxyContextOverflow,
+  modelAwareCompactionReserveTokens,
+  PiSdkSessionFactory,
+  resolveCustomTools,
+  withCustomBaseUrl,
+} from "../dist/pi-sdk.js";
+
+test("uses standard content when replaying reasoning through a custom model proxy", () => {
+  const catalogModel = {
+    api: "openai-completions",
+    baseUrl: "https://integrate.api.nvidia.com/v1",
+    compat: { supportsStore: false },
+  };
+
+  assert.deepEqual(withCustomBaseUrl(catalogModel, "http://model-proxy:10240"), {
+    api: "openai-completions",
+    baseUrl: "http://model-proxy:10240",
+    compat: { supportsStore: false, requiresThinkingAsText: true },
+  });
+  assert.strictEqual(withCustomBaseUrl(catalogModel, undefined), catalogModel);
+});
+
+test("reserves enough context for the selected model's maximum output", () => {
+  assert.equal(modelAwareCompactionReserveTokens(16_384, 65_536), 65_536);
+  assert.equal(modelAwareCompactionReserveTokens(65_536, 32_768), 65_536);
+});
+
+test("classifies only an exact opaque custom-proxy error as context overflow", () => {
+  assert.match(
+    classifyOpaqueProxyContextOverflow("500 status code (no body)", 262_144),
+    /maximum context length is 262144 tokens/u,
+  );
+  assert.equal(
+    classifyOpaqueProxyContextOverflow("503 status code (no body)", 262_144),
+    "503 status code (no body)",
+  );
+  assert.equal(classifyOpaqueProxyContextOverflow("500 status code (no body)", 0), "500 status code (no body)");
+});
 
 test("rejects append system instructions before loading the Pi harness", async () => {
   const factory = new PiSdkSessionFactory();


### PR DESCRIPTION
#### Overview

Improve the Pi adapter's behavior with custom OpenAI-compatible model proxies. The adapter now replays reasoning as standard text, reserves enough context for the selected model's maximum output, and translates the exact bodyless `500 status code (no body)` proxy response into Pi's context-overflow signal so Pi can perform one bounded compact-and-retry attempt.

No dependencies or public configuration fields change. This is a draft so downstream Gym evaluation work can pin and test the proposed fix before review is finalized.

#### Details

- Apply Pi's `requiresThinkingAsText` compatibility flag when a custom OpenAI-compatible base URL is configured.
- Make the compaction reserve at least the selected model's maximum output size.
- Limit opaque proxy recovery to custom base URLs and the exact bodyless HTTP 500 signature.
- Preserve all other stream events and error messages unchanged.
- Add focused regression tests and document the behavior.

#### Validation

- `just test-typescript`
- `git diff --check`

The TypeScript suite passed, including 23 Pi tests, package-content/install checks, dependency-tree checks, and npm audits. No Rust, Python, manifest, lockfile, or schema files changed.

#### Where should the reviewer start?

Start with `installOpaqueProxyOverflowRecovery` in `adapters/typescript/pi/src/pi-sdk.ts`, then review the three focused regression tests in `adapters/typescript/pi/test/pi-sdk.test.mjs`.

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- Relates to: none

- [x] I confirm this contribution is my own work, or I have the right to submit it under this project's license.
- [x] I searched existing issues and open pull requests, and this does not duplicate existing work.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Improved support for custom model proxies, including clearer handling of context-limit errors and one bounded compact-and-retry recovery attempt.
  - Custom model base URLs now support models that require assistant reasoning to be represented as text.
  - Context management now reserves space for the selected model’s maximum output.

- **Documentation**
  - Clarified that configured extensions run as trusted code.
  - Documented context reservation and custom proxy overflow recovery behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->